### PR TITLE
Add Linux (AppImage) packaging target

### DIFF
--- a/apps/shell/electron-builder.cjs
+++ b/apps/shell/electron-builder.cjs
@@ -82,36 +82,45 @@ const config = {
       to: 'gsk/node_modules/ws',
     },
   ],
+  // `mimeType` is read only by the Linux target, where it becomes the
+  // desktop entry's MimeType= list; associations without it are dropped
+  // there. macOS and Windows ignore the field and key off `ext`.
   fileAssociations: [
     {
       ext: 'docx',
       name: 'Word Document',
       role: 'Editor',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     },
     {
       ext: 'xlsx',
       name: 'Excel Workbook',
       role: 'Editor',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     },
     {
       ext: 'pptx',
       name: 'PowerPoint Presentation',
       role: 'Editor',
+      mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     },
     {
       ext: 'xls',
       name: 'Excel 97-2003 Workbook',
       role: 'Editor',
+      mimeType: 'application/vnd.ms-excel',
     },
     {
       ext: 'csv',
       name: 'CSV Document',
       role: 'Editor',
+      mimeType: 'text/csv',
     },
     {
       ext: 'pdf',
       name: 'PDF Document',
       role: 'Editor',
+      mimeType: 'application/pdf',
     },
   ],
   npmRebuild: false,
@@ -141,6 +150,39 @@ const config = {
       {
         from: '../sheets/native/xlsx-engine/target/x86_64-pc-windows-gnu/release/xlsx-sidecar.exe',
         to: 'native/xlsx-sidecar.exe',
+      },
+    ],
+  },
+  // Unlike win (which cross-compiles the sidecar to an explicit target
+  // triple), linux takes it from cargo's host-native target/release/ — the
+  // same source mac uses. So no `arch` is pinned here: electron-builder
+  // defaults to the build host's architecture, which is the only one the
+  // sidecar was actually built for. Packaging arm64 on an x64 host, or the
+  // reverse, needs a matching `cargo build --target` first.
+  linux: {
+    // AppImage only: it needs no packaging identity, whereas deb/rpm would
+    // require a Debian maintainer and homepage in the repo metadata.
+    target: ['AppImage'],
+    category: 'Office',
+    icon: 'build/icon.png',
+    // mac and win name the binary from productName; linux instead derives it
+    // from package.json "name", and "@genoffice/shell" sanitizes to the
+    // invalid "@genofficeshell". Setting it explicitly also makes the
+    // generated genoffice.desktop match the WM_CLASS Electron reports (it
+    // takes that from the executable basename), so the running window links
+    // back to its launcher entry.
+    executableName: 'genoffice',
+    // Electron takes its X11 app_id from package.json "desktopName"
+    // (genoffice.desktop); syncDesktopName makes electron-builder name the
+    // .desktop file and its StartupWMClass from the same value. Without it
+    // StartupWMClass falls back to productName ("GenOffice"), which does not
+    // match the "genoffice" WM_CLASS the window actually reports — and X11
+    // compares case-sensitively, so the taskbar shows an unlinked window.
+    syncDesktopName: true,
+    extraResources: [
+      {
+        from: '../sheets/native/xlsx-engine/target/release/xlsx-sidecar',
+        to: 'native/xlsx-sidecar',
       },
     ],
   },

--- a/apps/shell/package.json
+++ b/apps/shell/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "description": "Unified GenOffice shell: one app hosting the docs and sheets modules behind a home/launcher window",
   "main": "out/main/index.js",
+  "desktopName": "genoffice.desktop",
   "scripts": {
     "dev": "electron-vite dev --watch",
     "build": "electron-vite build",
@@ -13,7 +14,8 @@
     "typecheck": "tsc --noEmit",
     "start": "electron-vite build && electron .",
     "dist:mac": "electron-vite build && electron-builder --mac",
-    "dist:win": "electron-vite build && electron-builder --win"
+    "dist:win": "electron-vite build && electron-builder --win",
+    "dist:linux": "electron-vite build && electron-builder --linux"
   },
   "devDependencies": {
     "@genoffice/agent-core": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "notices": "node tools/gen-third-party-notices.mjs",
     "licenses": "node tools/check-licenses.mjs",
     "dist:mac": "npm run notices && npm run build:all && npm run dist:mac -w @genoffice/shell",
-    "dist:win": "npm run notices && npm run build:all && npm run dist:win -w @genoffice/shell"
+    "dist:win": "npm run notices && npm run build:all && npm run dist:win -w @genoffice/shell",
+    "dist:linux": "npm run notices && npm run build:all && npm run dist:linux -w @genoffice/shell"
   },
   "dependencies": {
     "ws": "^8.21.1"


### PR DESCRIPTION
The shell packaged only for mac and win, so there was no way to produce a Linux artifact even though the tree already builds and runs there: npm install resolves linux-arm64 for every native optional dep, the xlsx sidecar compiles natively via cargo, and the full unit suite passes.

Adds a linux target alongside the existing two. Four Linux-only details the mac/win config never had to handle:

- executableName: linux derives the binary name from package.json "name", and "@genoffice/shell" sanitizes to the invalid "@genofficeshell", which fails the AppImage build outright. mac/win use productName.
- desktopName + syncDesktopName: otherwise StartupWMClass falls back to productName ("GenOffice") while the window reports WM_CLASS "genoffice", and X11 compares case-sensitively, so the taskbar shows the window unlinked from its launcher entry.
- fileAssociations mimeType: the Linux desktop entry builds its MimeType list from this field and drops associations without it. mac and win ignore the field and key off ext, so the existing targets are unaffected.
- The sidecar is taken from cargo's host-native target/release/, the same source mac uses, so no arch is pinned; electron-builder defaults to the build host's.

AppImage only. deb/rpm additionally require a Debian maintainer identity and homepage in the repo metadata.

Verified on arm64: builds, and the packaged AppImage launches with the aarch64 sidecar bundled at resources/native/xlsx-sidecar.

## Summary

- What changed?
- Why is this change needed?

## Related issue

Closes #

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why:

## Screenshots or recordings

Include before/after evidence for visible changes, or write "Not applicable."

## Contributor checklist

- [ ] The change is focused and does not include unrelated reformatting or refactoring.
- [ ] User-facing strings use the existing i18n resources.
- [ ] File open/save changes include an appropriate round-trip or fidelity test.
