### PR TITLE
Fail the build when a module tree is missing from extraResources

### DIFF
--- a/apps/shell/electron-builder.cjs
+++ b/apps/shell/electron-builder.cjs
@@ -35,6 +35,19 @@ for (const rel of [
   }
 }
 
+// The module trees are electron-vite outputs produced by build:all; a missing
+// one means that module's build did not run or failed. electron-builder only
+// logs "file source doesn't exist" for an absent extraResources source and
+// still exits 0, so without this the installer launches normally and is simply
+// missing that editor — it surfaces only when a user opens the tab.
+for (const rel of ['../docs/out', '../sheets/out', '../slides/out', '../pdf/out']) {
+  if (!existsSync(join(__dirname, rel))) {
+    throw new Error(
+      `electron-builder extraResources source missing: ${rel} (run npm run build:all first)`,
+    )
+  }
+}
+
 /** @type {import('electron-builder').Configuration} */
 const config = {
   appId: 'com.genoffice.app',


### PR DESCRIPTION
## Summary

**What changed?** `apps/shell/electron-builder.cjs` now throws if any of the four module build outputs (`../docs/out`, `../sheets/out`, `../slides/out`, `../pdf/out`) is absent, mirroring the existing guard for the gsk CLI tree just above it.

**Why is this change needed?** electron-builder does not treat a missing `extraResources` source as an error. In `app-builder-lib`, `copyFiles` (`out/fileMatcher.js`) does:

```js
const fromStat = await statOrNull(matcher.from)
if (fromStat == null) {
  log.warn({ from: matcher.from }, `file source doesn't exist`)
  return
}
```

It warns and returns — the target still builds and the process still exits 0.

So a `dist:*` run against a partial `build:all` (one module's build failed, or never ran) produces an installer that packages cleanly, passes CI, and launches normally, but is silently missing that editor module. The failure only surfaces when a user opens the affected tab.

I hit this in practice: a first packaging run against a broken sheets build produced a working-looking artifact that was missing three of the four modules, with nothing in the build output to indicate it.

The config already fails fast for the gsk CLI tree on exactly this reasoning ("instead of shipping an installer with a broken gsk runtime"). This extends the same guard to the module trees.

**Deliberately not covered:** the native xlsx sidecar. Its `extraResources` entry is per-platform, and the win path is a cross-compiled target triple that legitimately does not exist during a mac or linux build, so checking it correctly needs platform awareness that this two-loop style does not have. Happy to add it if you'd prefer the broader guard — a missing sidecar is arguably the worse silent failure, since it makes every workbook open fail at runtime.

## Related issue

None.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

All run on this branch (Linux arm64, Node 22). `lint` reports 0 errors and 9 pre-existing `react-hooks/exhaustive-deps` warnings in `apps/slides`, untouched by this change.

Behavioural check, packaging via `electron-builder --linux`:

- with `apps/slides/out` removed — exits 1 with `electron-builder extraResources source missing: ../slides/out (run npm run build:all first)`
- with a complete tree — exits 0 and produces the same artifact as before

## Screenshots or recordings

Not applicable — build-time behaviour only.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (N/A — build-time error, never shown in the UI.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A — no open/save code touched.)