### PR TITLE
fix(shell): relayout active tab after X11 maximize bounds settle

### DIFF
--- a/apps/shell/src/main/tab-manager.ts
+++ b/apps/shell/src/main/tab-manager.ts
@@ -63,7 +63,15 @@ export class TabManager {
     /** localized placeholder title for a tab that has no file yet */
     private readonly untitledTitleFor?: (kind: TabKind) => string,
   ) {
-    shellWindow.on('resize', () => this.layout())
+    // Layout once synchronously for macOS/Windows (bounds are already correct),
+    // then once more on the next tick. On Linux/X11, `resize` fires before the
+    // window manager applies the new size, so getContentBounds() is still the
+    // pre-maximize size inside the handler and a follow-up layout is required.
+    // See https://github.com/genspark-ai/genoffice/issues/15
+    shellWindow.on('resize', () => {
+      this.layout()
+      setImmediate(() => this.layout())
+    })
   }
 
   private untitled(kind: TabKind, fallback: string): string {
@@ -96,6 +104,8 @@ export class TabManager {
 
   /** re-fit the active tab's view after a window resize */
   layout(): void {
+    // Deferred resize layouts can land after the shell window was closed.
+    if (this.shellWindow.isDestroyed()) return
     const active = this.tabs.find((t) => t.id === this.activeId)
     if (active?.view) active.view.setBounds(this.contentBounds())
   }

--- a/apps/shell/tests/tab-manager.test.ts
+++ b/apps/shell/tests/tab-manager.test.ts
@@ -100,6 +100,7 @@ const WINDOW_HEIGHT = 600
 
 interface FakeShellWindow {
   on: ReturnType<typeof vi.fn>
+  isDestroyed: ReturnType<typeof vi.fn>
   getContentBounds: () => { x: number; y: number; width: number; height: number }
   contentView: {
     addChildView: ReturnType<typeof vi.fn>
@@ -110,6 +111,7 @@ interface FakeShellWindow {
 function makeShellWindow(): FakeShellWindow {
   return {
     on: vi.fn(),
+    isDestroyed: vi.fn(() => false),
     getContentBounds: () => ({ x: 0, y: 0, width: WINDOW_WIDTH, height: WINDOW_HEIGHT }),
     contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
   }
@@ -257,6 +259,61 @@ describe('activation', () => {
       width: WINDOW_WIDTH,
       height: WINDOW_HEIGHT - TAB_STRIP_HEIGHT,
     })
+  })
+})
+
+describe('window resize layout', () => {
+  function resizeHandler(): () => void {
+    const call = shellWindow.on.mock.calls.find((c) => c[0] === 'resize')
+    expect(call).toBeDefined()
+    return call![1] as () => void
+  }
+
+  it('re-lays out after resize bounds settle (Linux/X11 stale getContentBounds)', async () => {
+    // On X11, `resize` fires before the WM applies maximize bounds, so the first
+    // layout still sees the pre-maximize size. The deferred layout must pick up
+    // the real size on the next turn (see issue #15).
+    manager.openSheetsTab()
+    const view = lastCreatedView(createSheetsView)
+    view.setBounds.mockClear()
+
+    let width = WINDOW_WIDTH
+    let height = WINDOW_HEIGHT
+    shellWindow.getContentBounds = () => ({ x: 0, y: 0, width, height })
+
+    resizeHandler()()
+    expect(view.setBounds).toHaveBeenLastCalledWith({
+      x: 0,
+      y: TAB_STRIP_HEIGHT,
+      width: WINDOW_WIDTH,
+      height: WINDOW_HEIGHT - TAB_STRIP_HEIGHT,
+    })
+
+    // Bounds update after the synchronous layout, as on X11 maximize.
+    width = 1920
+    height = 1080
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(view.setBounds).toHaveBeenLastCalledWith({
+      x: 0,
+      y: TAB_STRIP_HEIGHT,
+      width: 1920,
+      height: 1080 - TAB_STRIP_HEIGHT,
+    })
+    expect(view.setBounds).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips deferred layout after the shell window is destroyed', async () => {
+    manager.openSheetsTab()
+    const view = lastCreatedView(createSheetsView)
+    view.setBounds.mockClear()
+
+    resizeHandler()()
+    expect(view.setBounds).toHaveBeenCalledTimes(1)
+
+    shellWindow.isDestroyed.mockReturnValue(true)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(view.setBounds).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary

- Fixes the Linux/X11 maximize bug where `TabManager` re-fits the active `WebContentsView` only on `resize`, but X11 fires that event before the window manager applies the new size — so `getContentBounds()` is still the pre-maximize size and a blank strip remains along the right/bottom.
- Layouts once synchronously (unchanged behavior on macOS/Windows) and once more via `setImmediate` after bounds settle; guards deferred `layout()` when the shell window is already destroyed.
- Adds regression tests that fail without the deferred re-layout and cover the destroyed-window guard.

Closes #15

Credit: root cause, repro, and fix shape reported on #15 by @skaka.

## Related issue

#15

## Validation

- [x] `npm run format:check`
- [x] `npm test -w @genoffice/shell` — 116 passed (was 114 + 2 new)
- [ ] `npm run lint` (not re-run full monorepo; change is shell-only)
- [ ] `npm run typecheck` (shell-only change; no new types)

## Screenshots or recordings

Not re-verified on a Linux X11 host in this environment (macOS). Behavior matches the isolated Electron repro and unit regression in #15.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (N/A — no UI strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A — shell layout only.)


Made with [Cursor](https://cursor.com)