### PR TITLE
fix(ai): keep multi-turn history valid after empty post-tool turns

### DIFF
--- a/apps/sheets/src/renderer/App.tsx
+++ b/apps/sheets/src/renderer/App.tsx
@@ -98,7 +98,12 @@ import '@univerjs/preset-sheets-table/lib/index.css'
 import { greenTheme } from '@univerjs/themes'
 import { createUniver } from './create-univer'
 
-import { AgentLoop, composeSkills, type AgentImage } from '@genoffice/agent-core'
+import {
+  AgentLoop,
+  COMPLETED_VIA_TOOLS_TEXT,
+  composeSkills,
+  type AgentImage,
+} from '@genoffice/agent-core'
 import type { AiSettings } from '@genoffice/ai-provider'
 import { type WorkbookOperation } from '../domain/workbook-dsl'
 import { columnIndex, columnLabel, parseAddress, parseRange } from '../domain/cell-address'
@@ -820,15 +825,34 @@ export function App(): React.JSX.Element {
           })
         },
         onDone: ({ text, cancelled, turnLimit }) => {
+          // Prefer tool summaries when the model finished via tools with no prose
+          // (agent-core fills history with COMPLETED_VIA_TOOLS_TEXT so follow-ups
+          // stay provider-safe; the UI can show the real work that ran).
+          const toolSummaries = (() => {
+            const lines: string[] = []
+            const seen = new Set<string>()
+            for (const tool of runToolsRef.current) {
+              if (!tool.summary || tool.isError || seen.has(tool.summary)) continue
+              seen.add(tool.summary)
+              lines.push(tool.summary)
+              if (lines.length >= 8) break
+            }
+            return lines.join('\n')
+          })()
+          const prose =
+            text && text !== COMPLETED_VIA_TOOLS_TEXT
+              ? text
+              : runLastTextRef.current || toolSummaries || text
           // A final empty turn must not claim completion: reuse the model's last
           // streamed text; with none, only a mutating run gets the "done" phrasing.
           const fallback = cancelled
             ? t('appAiStopped')
             : runLastTextRef.current ||
+              toolSummaries ||
               (runMutatedRef.current ? t('appAiNoSummary') : t('appAiNoAction'))
           const finalText = turnLimit
-            ? [text, t('appAiTurnLimit')].filter(Boolean).join('\n\n')
-            : text || fallback
+            ? [prose, t('appAiTurnLimit')].filter(Boolean).join('\n\n')
+            : prose || fallback
           setMessage(finalText)
           patchLastAssistant((entry) => ({
             ...entry,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -13,7 +13,7 @@ export type {
 } from './types'
 export { composeSkills } from './skill'
 export type { AgentSkill } from './skill'
-export { AgentLoop } from './loop'
+export { AgentLoop, COMPLETED_VIA_TOOLS_TEXT } from './loop'
 export type {
   AgentLoopEvents,
   AgentLoopOptions,

--- a/packages/agent-core/src/loop.ts
+++ b/packages/agent-core/src/loop.ts
@@ -85,6 +85,15 @@ const TURN_LIMIT_NOTE =
   '[System] The tool-call turn limit for this request has been reached; no more tools may be called this turn. ' +
   'Answer directly from the information already gathered; if the task is unfinished, briefly state what is done and what remains.'
 
+/**
+ * Terminal assistant text when tools mutated the artifact (or an edits-only
+ * turn was restored) and the model returned no prose. Must be non-empty so
+ * provider message converters never emit empty assistant content, which breaks
+ * multi-turn follow-ups (see finishTurn / restore).
+ * Exported so apps can substitute a localized / tool-derived summary in the UI.
+ */
+export const COMPLETED_VIA_TOOLS_TEXT = '(completed tool actions; no text reply)'
+
 const SUMMARIZE_SYSTEM =
   'You are a conversation compressor. Compress this editing session between the user and the AI assistant into a concise summary so later turns can continue with context. ' +
   "Keep: the user's goals and key instructions, completed changes (which files/pages/elements were modified), important facts and data, and outstanding items. " +
@@ -194,9 +203,7 @@ export class AgentLoop<TSnapshot = unknown> {
     // Edits-only runs persist an assistant message with no text; give it a placeholder
     // so the turn stays paired and providers never see an empty assistant content block
     const normalized = messages.map((m) =>
-      m.role === 'assistant' && !m.text
-        ? { ...m, text: '(completed tool actions; no text reply)' }
-        : m,
+      m.role === 'assistant' && !m.text ? { ...m, text: COMPLETED_VIA_TOOLS_TEXT } : m,
     )
     // Unanswered user messages (a failed or interrupted run persisted them without a
     // reply) must not re-enter the model context: trailing ones would pair with the
@@ -497,11 +504,20 @@ export class AgentLoop<TSnapshot = unknown> {
     // no-tools finalizing turn after hitting the limit
     // (a cancelled turn drops its tool calls — no results would follow)
     if (toolCalls.length === 0 || this.cancelled || this.finalizing) {
-      this.history.push({ role: 'assistant', text: this.turnText })
+      // Models often end a tool-using run with an empty text turn ("I'm done").
+      // Leaving assistant text empty in history then poisons the next user
+      // prompt: Anthropic rejects empty content arrays, Gemini rejects empty
+      // parts, and OpenAI-compatible routes send content:null with no tool_calls —
+      // all of which make follow-up turns fail or return empty again (see
+      // genoffice#12 / #22: first prompt works, second shows "no summary").
+      const text =
+        this.turnText ||
+        (!this.cancelled && this.mutationSeen ? COMPLETED_VIA_TOOLS_TEXT : this.turnText)
+      this.history.push({ role: 'assistant', text })
       this.running = false
       this.runUserMsg = null
       events?.onDone?.({
-        text: this.turnText,
+        text,
         cancelled: this.cancelled,
         turnLimit: this.finalizing,
         // set only when true so exact-shape consumers/tests stay unaffected

--- a/packages/agent-core/tests/loop.test.ts
+++ b/packages/agent-core/tests/loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   AgentLoop,
+  COMPLETED_VIA_TOOLS_TEXT,
   composeSkills,
   type AgentMessage,
   type AgentSkill,
@@ -508,6 +509,53 @@ describe('AgentLoop', () => {
     const placeholder = loop.messages[1] as { role: string; text: string }
     expect(placeholder.role).toBe('assistant')
     expect(placeholder.text).not.toBe('') // providers reject empty assistant content blocks
+  })
+
+  it('after tools mutate, an empty final model turn still stores non-empty history for follow-ups', async () => {
+    // Regression for genoffice#12 / #22: first AI prompt mutates via tools with no
+    // prose, second prompt must not inherit an empty assistant content block.
+    const transport = scriptedTransport([
+      (cb) => {
+        cb.onToolCall({ id: 't1', name: 'do_thing', input: { a: 1 } })
+        cb.onDone()
+      },
+      (cb) => cb.onDone(), // model returns no text after tools
+      (cb) => {
+        cb.onDelta('second prompt ok')
+        cb.onDone()
+      },
+    ])
+    const onDone = vi.fn()
+    const loop = new AgentLoop({
+      transport,
+      skill: makeSkill(),
+      events: { onDone },
+    })
+    loop.run('first change')
+    await flush()
+    await flush()
+
+    expect(onDone).toHaveBeenCalledWith({
+      text: COMPLETED_VIA_TOOLS_TEXT,
+      cancelled: false,
+      turnLimit: false,
+    })
+    const afterFirst = loop.messages
+    expect(afterFirst.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant'])
+    const finalAssistant = afterFirst[3] as Extract<AgentMessage, { role: 'assistant' }>
+    expect(finalAssistant.text).toBe(COMPLETED_VIA_TOOLS_TEXT)
+    expect(finalAssistant.text.length).toBeGreaterThan(0)
+
+    onDone.mockClear()
+    loop.run('follow-up')
+    await flush()
+    expect(onDone).toHaveBeenCalledWith({
+      text: 'second prompt ok',
+      cancelled: false,
+      turnLimit: false,
+    })
+    // Follow-up request carries the prior (now non-empty) terminal assistant
+    expect(transport.requests[2]!.messageCount).toBeGreaterThanOrEqual(5)
   })
 
   it('restore trims oversized history at a user boundary', () => {

--- a/packages/ai-provider/src/stream.ts
+++ b/packages/ai-provider/src/stream.ts
@@ -183,6 +183,9 @@ function anthropicMessages(messages: AgentMessage[]): unknown[] {
       for (const call of m.toolCalls ?? []) {
         content.push({ type: 'tool_use', id: call.id, name: call.name, input: call.input })
       }
+      // Anthropic rejects empty content arrays; a prior empty terminal turn
+      // (tool work with no prose) would otherwise poison every follow-up.
+      if (content.length === 0) content.push({ type: 'text', text: '(no content)' })
       return { role: 'assistant', content }
     }
     // tool results travel back as a user message of tool_result blocks
@@ -386,6 +389,8 @@ function geminiContents(messages: AgentMessage[]): unknown[] {
       for (const call of m.toolCalls ?? []) {
         parts.push({ functionCall: { name: call.name, args: call.input } })
       }
+      // Gemini rejects model turns with empty parts lists.
+      if (parts.length === 0) parts.push({ text: '(no content)' })
       return { role: 'model', parts }
     }
     return {
@@ -597,12 +602,15 @@ function openAiMessages(system: string, messages: AgentMessage[]): unknown[] {
         })
       }
     } else if (m.role === 'assistant') {
+      const hasTools = !!(m.toolCalls && m.toolCalls.length > 0)
+      // content:null with no tool_calls is an empty assistant turn; some OpenAI-
+      // compatible proxies drop or reject the follow-up conversation after that.
       out.push({
         role: 'assistant',
-        content: m.text || null,
-        ...(m.toolCalls && m.toolCalls.length > 0
+        content: m.text || (hasTools ? null : '(no content)'),
+        ...(hasTools
           ? {
-              tool_calls: m.toolCalls.map((call) => ({
+              tool_calls: m.toolCalls!.map((call) => ({
                 id: call.id,
                 type: 'function',
                 function: { name: call.name, arguments: JSON.stringify(call.input) },

--- a/packages/ai-provider/tests/stream.test.ts
+++ b/packages/ai-provider/tests/stream.test.ts
@@ -229,6 +229,44 @@ describe('streamForProvider: anthropic', () => {
     ).rejects.toThrow(/Claude returned no content/)
   })
 
+  it('never sends an empty assistant content array when history has edits-only replies', async () => {
+    // Prior empty terminal turns would map to content:[] and break follow-ups
+    // on Anthropic (genoffice#12 / #22 class of multi-turn failures).
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        okResponse(
+          sseStream([
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}',
+            'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+          ]),
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    const { cb } = collector()
+    await streamForProvider(
+      'anthropic',
+      { apiKey: 'k', model: 'm' },
+      'sys',
+      [
+        { role: 'user', text: 'first' },
+        { role: 'assistant', text: '' },
+        { role: 'user', text: 'second' },
+      ],
+      [],
+      100,
+      cb,
+    )
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string) as {
+      messages: Array<{ role: string; content: unknown }>
+    }
+    for (const msg of body.messages) {
+      if (msg.role !== 'assistant') continue
+      expect(Array.isArray(msg.content)).toBe(true)
+      expect((msg.content as unknown[]).length).toBeGreaterThan(0)
+    }
+  })
+
   it('replaces an HTML error body (e.g. a gateway block page) with a readable note', async () => {
     const html =
       '<!doctype html>\n<html>\n<head><title>Genspark</title></head><body>app shell</body></html>'
@@ -478,6 +516,43 @@ describe('streamForProvider: openai-compatible', () => {
     await expect(
       streamForProvider('openai', { apiKey: 'k', model: 'm' }, 'sys', [], [], 100, cb),
     ).rejects.toThrow(/The model returned no content/)
+  })
+
+  it('never sends content:null for an assistant turn with neither text nor tools', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        okResponse(
+          sseStream([
+            'data: {"choices":[{"delta":{"content":"ok"}}]}',
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+            'data: [DONE]',
+          ]),
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    const { cb } = collector()
+    await streamForProvider(
+      'openai',
+      { apiKey: 'k', model: 'm' },
+      'sys',
+      [
+        { role: 'user', text: 'first' },
+        { role: 'assistant', text: '' },
+        { role: 'user', text: 'second' },
+      ],
+      [],
+      100,
+      cb,
+    )
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string) as {
+      messages: Array<{ role: string; content: unknown; tool_calls?: unknown }>
+    }
+    for (const msg of body.messages) {
+      if (msg.role !== 'assistant') continue
+      expect(msg.content === null && !msg.tool_calls).toBe(false)
+      if (msg.content !== null) expect(String(msg.content).length).toBeGreaterThan(0)
+    }
   })
 
   it('routes deepseek and openai to their fixed base URLs', async () => {


### PR DESCRIPTION
## Summary

Fixes the widely reported second-prompt AI failure (**"AI finished with no summary."** on follow-up turns after the first prompt succeeded).

**What changed?**
- `AgentLoop` now stores the same non-empty terminal placeholder already used by `restore()` when tools mutated the document and the model returned no prose — live runs and reopened chats stay consistent.
- Provider message mappers (Anthropic / Gemini / OpenAI-compatible) never emit empty assistant content arrays / `content:null` without tools, which some gateways reject or treat as poisoned history.
- Sheets replaces the opaque placeholder in the UI with actual tool summaries when available.

**Why is this needed?**
Models often finish a tool-using run with an empty text turn. That left `{ role: 'assistant', text: '' }` in history. On the next user prompt:

- Anthropic: empty `content: []` is invalid
- Gemini: empty `parts` is invalid  
- OpenAI-compatible routes: `content: null` with no `tool_calls` breaks multi-turn continuity

Users saw the first prompt work (mutation + empty terminal), then every follow-up degrade into the generic "AI finished with no summary." path while tools may still fire — reported for Docs (#12) and Sheets (#22).

The restore path already knew empty assistants poison providers (`(completed tool actions; no text reply)`); live `finishTurn` did not apply the same guard until this PR.

## Related issue

Closes #12  
Closes #22

## Validation

- [x] `npm run format:check`
- [x] `npm test -w @genoffice/agent-core` — 45 passed (includes multi-turn regression)
- [x] `npm test -w @genoffice/ai-provider` — 78 passed (includes empty-assistant message guards)
- [x] `tsc --noEmit` for `agent-core` and `ai-provider`
- [ ] Full monorepo `npm test` / `npm run lint` (scoped change; suite not re-run end-to-end)

## Screenshots or recordings

Not applicable — agent/history behaviour. Before: empty second-prompt terminal / poisoned follow-up. After: non-empty history terminal + Sheets shows tool summaries when the model leaves no prose.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Placeholder is model/history-facing; Sheets tool summaries stay locale/skill-derived. Fallback `appAiNoSummary` kept for genuine empty+no-tools cases.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A — agent loop / provider mapping only.)


Made with [Cursor](https://cursor.com)