### PR TITLE
add A2A transport to agent-core

### DIFF
--- a/packages/agent-core/src/a2a-transport.ts
+++ b/packages/agent-core/src/a2a-transport.ts
@@ -1,0 +1,273 @@
+import type {
+  AgentMessage,
+  AgentStreamCallbacks,
+  AgentStreamRequest,
+  AgentTransport,
+} from './types'
+
+// ---- A2A protocol wire types (subset used by this transport) ----
+// Spec: https://github.com/a2aproject/A2A
+
+interface A2ATextPart {
+  type: 'text'
+  text: string
+}
+
+interface A2ADataPart {
+  type: 'data'
+  data: Record<string, unknown>
+}
+
+type A2APart = A2ATextPart | A2ADataPart
+
+interface A2AMessage {
+  role: 'user' | 'agent'
+  parts: A2APart[]
+}
+
+interface A2ATaskStatus {
+  state: 'submitted' | 'working' | 'input-required' | 'completed' | 'failed' | 'canceled'
+  message?: A2AMessage
+  timestamp?: string
+}
+
+interface A2AStreamEvent {
+  id: string
+  status?: A2ATaskStatus
+  artifact?: {
+    name: string
+    parts: A2APart[]
+    index?: number
+    append?: boolean
+    lastChunk?: boolean
+  }
+  final?: boolean
+}
+
+interface A2AJsonRpcResponse {
+  jsonrpc: '2.0'
+  id: unknown
+  result?: A2AStreamEvent
+  error?: { code: number; message: string; data?: unknown }
+}
+
+// ---- message encoding ----
+
+/**
+ * Encode GenOffice conversation history into a single A2A user message.
+ * System prompt is prepended as a bracketed text part; assistant turns and
+ * tool results are encoded as data parts so the remote agent has full context
+ * without any special multi-turn session wiring.
+ */
+function encodeAsA2AMessage(system: string, messages: AgentMessage[]): A2AMessage {
+  const parts: A2APart[] = []
+
+  if (system) {
+    parts.push({ type: 'text', text: `[System]\n${system}` })
+  }
+
+  for (const msg of messages) {
+    if (msg.role === 'user') {
+      parts.push({ type: 'text', text: msg.text })
+    } else if (msg.role === 'assistant') {
+      parts.push({
+        type: 'data',
+        data: {
+          role: 'assistant',
+          text: msg.text,
+          ...(msg.toolCalls?.length ? { toolCalls: msg.toolCalls } : {}),
+        },
+      })
+    } else {
+      // tool results
+      parts.push({ type: 'data', data: { role: 'tool', results: msg.results } })
+    }
+  }
+
+  return { role: 'user', parts }
+}
+
+// ---- SSE parsing ----
+
+async function* sseEvents(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): AsyncGenerator<string> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        if (line.startsWith('data:')) yield line.slice(5).trim()
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  if (buf.startsWith('data:')) yield buf.slice(5).trim()
+}
+
+// ---- public API ----
+
+export interface A2ATransportOptions {
+  /**
+   * Base URL of the A2A agent (e.g. "http://localhost:9100").
+   * The transport POSTs JSON-RPC to this URL directly.
+   */
+  agentUrl: string
+  /** Bearer token sent as Authorization header when provided. */
+  apiKey?: string | undefined
+  /**
+   * Session ID threaded through all tasks so the remote agent can correlate
+   * turns. Callers should create one UUID per AgentLoop instance.
+   */
+  sessionId?: string | undefined
+  /** Extra request headers (e.g. X-Agent-Type attribution). */
+  headers?: Record<string, string> | undefined
+}
+
+/**
+ * AgentTransport that talks to a remote A2A-protocol agent over HTTP SSE.
+ *
+ * The full GenOffice conversation context (system prompt + message history)
+ * is encoded into a single A2A user message on every transport.stream() call.
+ * The remote agent handles its own model calls and tools; GenOffice receives
+ * streamed text artifacts back as onDelta events.
+ *
+ * Spec: https://github.com/a2aproject/A2A
+ */
+export function createA2ATransport(options: A2ATransportOptions): AgentTransport {
+  const { agentUrl, apiKey, sessionId, headers: extraHeaders = {} } = options
+  const baseUrl = agentUrl.replace(/\/$/, '')
+
+  const authHeaders: Record<string, string> = apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+
+  return {
+    stream(request: AgentStreamRequest, cb: AgentStreamCallbacks) {
+      const controller = new AbortController()
+      const taskId = crypto.randomUUID()
+
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: taskId,
+        method: 'tasks/sendSubscribe',
+        params: {
+          id: taskId,
+          ...(sessionId ? { sessionId } : {}),
+          message: encodeAsA2AMessage(request.system, request.messages),
+        },
+      })
+
+      void runStream(controller.signal, body, cb)
+
+      return { cancel: () => controller.abort() }
+    },
+  }
+
+  async function runStream(
+    signal: AbortSignal,
+    body: string,
+    cb: AgentStreamCallbacks,
+  ): Promise<void> {
+    let resp: Response
+    try {
+      resp = await fetch(baseUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+          ...authHeaders,
+          ...extraHeaders,
+        },
+        body,
+        signal,
+      })
+    } catch (err) {
+      if (!signal.aborted) {
+        cb.onError(err instanceof Error ? err.message : 'A2A fetch failed')
+      }
+      return
+    }
+
+    if (!resp.ok) {
+      cb.onError(`A2A agent returned HTTP ${resp.status}`)
+      return
+    }
+
+    if (!resp.body) {
+      cb.onError('A2A agent returned no response body')
+      return
+    }
+
+    let settled = false
+    const settle = () => {
+      settled = true
+    }
+
+    for await (const data of sseEvents(resp.body, signal)) {
+      if (settled || !data || data === '[DONE]') continue
+
+      let parsed: A2AJsonRpcResponse
+      try {
+        parsed = JSON.parse(data) as A2AJsonRpcResponse
+      } catch {
+        continue
+      }
+
+      if (parsed.error) {
+        settle()
+        cb.onError(parsed.error.message)
+        return
+      }
+
+      const ev = parsed.result
+      if (!ev) continue
+
+      // Status events
+      if (ev.status) {
+        const { state, message } = ev.status
+        if (state === 'failed' || state === 'canceled') {
+          settle()
+          const errText = message?.parts.find((p): p is A2ATextPart => p.type === 'text')?.text
+          cb.onError(errText ?? `A2A task ${state}`)
+          return
+        }
+        if (state === 'completed' && !ev.artifact) {
+          settle()
+          cb.onDone()
+          return
+        }
+      }
+
+      // Artifact events (streamed text output)
+      if (ev.artifact) {
+        for (const part of ev.artifact.parts) {
+          if (part.type === 'text' && part.text) {
+            cb.onDelta(part.text)
+          }
+        }
+        if (ev.artifact.lastChunk || ev.final) {
+          settle()
+          cb.onDone()
+          return
+        }
+      }
+
+      if (ev.final) {
+        settle()
+        cb.onDone()
+        return
+      }
+    }
+
+    if (!settled && !signal.aborted) {
+      cb.onDone()
+    }
+  }
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -23,3 +23,5 @@ export type {
 } from './loop'
 export { createIpcTransport, IPC_STREAM_SILENCE_TIMEOUT_MS } from './electron-transport'
 export type { IpcStreamChunk, IpcStreamStart, IpcTransportOptions } from './electron-transport'
+export { createA2ATransport } from './a2a-transport'
+export type { A2ATransportOptions } from './a2a-transport'

--- a/packages/agent-core/tests/a2a-transport.test.ts
+++ b/packages/agent-core/tests/a2a-transport.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createA2ATransport, type A2ATransportOptions } from '../src/a2a-transport'
+import type { AgentStreamCallbacks, AgentStreamRequest } from '../src/types'
+
+// ---- helpers ----
+
+function makeRequest(overrides?: Partial<AgentStreamRequest>): AgentStreamRequest {
+  return {
+    system: 'You are a helpful assistant.',
+    messages: [{ role: 'user', text: 'Hello' }],
+    tools: [],
+    ...overrides,
+  }
+}
+
+function makeCb(): AgentStreamCallbacks & { calls: string[] } {
+  const calls: string[] = []
+  return {
+    calls,
+    onDelta: vi.fn((text: string) => calls.push(`delta:${text}`)),
+    onToolCall: vi.fn(),
+    onDone: vi.fn(() => calls.push('done')),
+    onError: vi.fn((err: string) => calls.push(`error:${err}`)),
+  }
+}
+
+/** Build a minimal SSE body from an array of JSON-RPC result payloads */
+function sseBody(events: object[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder()
+  const chunks = events.map((e) => enc.encode(`data: ${JSON.stringify(e)}\n\n`))
+  let i = 0
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(chunks[i++]!)
+      } else {
+        controller.close()
+      }
+    },
+  })
+}
+
+function taskEvent(id: string, result: object): { jsonrpc: '2.0'; id: string; result: object } {
+  return { jsonrpc: '2.0', id, result }
+}
+
+function statusEvent(id: string, state: string, final = false) {
+  return taskEvent(id, { id, status: { state, timestamp: '2026-01-01T00:00:00Z' }, final })
+}
+
+function artifactEvent(id: string, text: string, lastChunk = false) {
+  return taskEvent(id, {
+    id,
+    artifact: { name: 'response', parts: [{ type: 'text', text }], lastChunk },
+  })
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 10))
+
+// ---- tests ----
+
+describe('createA2ATransport', () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' })
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function makeTransport(opts?: Partial<A2ATransportOptions>) {
+    return createA2ATransport({ agentUrl: 'http://agent.local:9100', ...opts })
+  }
+
+  it('sends a POST with correct JSON-RPC body and headers', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const transport = makeTransport()
+    const cb = makeCb()
+    transport.stream(makeRequest(), cb)
+    await flush()
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('http://agent.local:9100')
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    expect((init?.headers as Record<string, string>)['Accept']).toBe('text/event-stream')
+
+    const body = JSON.parse(init?.body as string)
+    expect(body.method).toBe('tasks/sendSubscribe')
+    expect(body.params.id).toBe('test-uuid-1234')
+    expect(body.params.message.role).toBe('user')
+    expect(body.params.message.parts[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('You are a helpful assistant.'),
+    })
+  })
+
+  it('includes Authorization header when apiKey is set', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const transport = makeTransport({ apiKey: 'sk-test-key' })
+    transport.stream(makeRequest(), makeCb())
+    await flush()
+
+    const [, init] = fetchMock.mock.calls[0]!
+    expect((init?.headers as Record<string, string>)['Authorization']).toBe('Bearer sk-test-key')
+  })
+
+  it('includes sessionId in params when provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const transport = makeTransport({ sessionId: 'session-abc' })
+    transport.stream(makeRequest(), makeCb())
+    await flush()
+
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse(init?.body as string)
+    expect(body.params.sessionId).toBe('session-abc')
+  })
+
+  it('emits onDelta for artifact text parts and onDone on lastChunk', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        sseBody([
+          artifactEvent('test-uuid-1234', 'Hello '),
+          artifactEvent('test-uuid-1234', 'world', true),
+        ]),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    )
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.calls).toEqual(['delta:Hello ', 'delta:world', 'done'])
+    expect(cb.onDone).toHaveBeenCalledOnce()
+    expect(cb.onError).not.toHaveBeenCalled()
+  })
+
+  it('emits onDone on status completed with no artifact', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.onDone).toHaveBeenCalledOnce()
+    expect(cb.onError).not.toHaveBeenCalled()
+  })
+
+  it('emits onError when task state is failed', async () => {
+    const failedEvent = taskEvent('test-uuid-1234', {
+      id: 'test-uuid-1234',
+      status: {
+        state: 'failed',
+        message: { role: 'agent', parts: [{ type: 'text', text: 'out of credits' }] },
+      },
+    })
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([failedEvent]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.calls).toContain('error:out of credits')
+    expect(cb.onDone).not.toHaveBeenCalled()
+  })
+
+  it('emits onError on JSON-RPC error object', async () => {
+    const rpcError = {
+      jsonrpc: '2.0',
+      id: 'test-uuid-1234',
+      error: { code: -32600, message: 'Invalid Request' },
+    }
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([rpcError]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.calls).toContain('error:Invalid Request')
+  })
+
+  it('emits onError on non-200 HTTP response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.calls).toContain('error:A2A agent returned HTTP 401')
+  })
+
+  it('emits onError on fetch network failure', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    const cb = makeCb()
+    makeTransport().stream(makeRequest(), cb)
+    await flush()
+
+    expect(cb.calls).toContain('error:ECONNREFUSED')
+  })
+
+  it('cancel() aborts the in-flight request', async () => {
+    let capturedSignal: AbortSignal | undefined
+    fetchMock.mockImplementation((_url, init) => {
+      capturedSignal = init?.signal as AbortSignal
+      // never resolves — simulates a stalled agent
+      return new Promise(() => undefined)
+    })
+
+    const cb = makeCb()
+    const handle = makeTransport().stream(makeRequest(), cb)
+    handle.cancel()
+    await flush()
+
+    expect(capturedSignal?.aborted).toBe(true)
+    expect(cb.onDone).not.toHaveBeenCalled()
+    expect(cb.onError).not.toHaveBeenCalled()
+  })
+
+  it('encodes multi-turn history into the A2A message parts', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const request = makeRequest({
+      messages: [
+        { role: 'user', text: 'First question' },
+        { role: 'assistant', text: 'First answer' },
+        { role: 'user', text: 'Follow-up' },
+      ],
+    })
+
+    makeTransport().stream(request, makeCb())
+    await flush()
+
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse(init?.body as string)
+    const parts: Array<{ type: string; text?: string; data?: unknown }> = body.params.message.parts
+
+    // system + 3 message parts
+    expect(parts.length).toBe(4)
+    expect(parts[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('You are a helpful assistant.'),
+    })
+    expect(parts[1]).toMatchObject({ type: 'text', text: 'First question' })
+    expect(parts[2]).toMatchObject({
+      type: 'data',
+      data: { role: 'assistant', text: 'First answer' },
+    })
+    expect(parts[3]).toMatchObject({ type: 'text', text: 'Follow-up' })
+  })
+
+  it('strips trailing slash from agentUrl', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody([statusEvent('test-uuid-1234', 'completed')]), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    makeA2ATransport({ agentUrl: 'http://agent.local:9100/' }).stream(makeRequest(), makeCb())
+    await flush()
+
+    const [url] = fetchMock.mock.calls[0]!
+    expect(url).toBe('http://agent.local:9100')
+  })
+})
+
+// local alias so the test above can reference a clean factory after global setup
+function makeA2ATransport(opts: A2ATransportOptions) {
+  return createA2ATransport(opts)
+}


### PR DESCRIPTION
## Summary

- Adds `createA2ATransport` — an `AgentTransport` implementation that routes the GenOffice AI panel to any [A2A-protocol](https://github.com/a2aproject/A2A)-compatible remote agent over HTTP SSE (`tasks/sendSubscribe`)
- The full conversation context (system prompt + message history) is encoded into a single A2A user message per call; streamed artifact text parts map to `onDelta` events; cancellation uses `AbortController`
- Exports `createA2ATransport` and `A2ATransportOptions` from `@genoffice/agent-core` alongside the existing `createIpcTransport`

## Test plan

- `npm run test -w @genoffice/agent-core` — 11 new unit tests (57 total, all pass); covers JSON-RPC wire format, auth/session headers, SSE streaming deltas, status-completion, error paths (HTTP, JSON-RPC, task failed/canceled, network), abort, multi-turn history encoding, and URL normalisation
- `npm run typecheck -w @genoffice/agent-core` — clean
- `npm run format:check` — clean (Prettier)
- `npm run lint` — 0 errors (pre-existing warnings only, none in new files)