### PR TITLE
fix(sheets): open temp file r+ before fsync so Windows saves work

### DIFF
--- a/apps/sheets/src/gateway/xlsx-gateway.ts
+++ b/apps/sheets/src/gateway/xlsx-gateway.ts
@@ -1354,7 +1354,7 @@ export async function writeXlsxAtomically(path: string, buffer: Buffer): Promise
   const temporaryPath = join(dirname(path), `.${crypto.randomUUID()}.tmp.xlsx`)
   try {
     await writeFile(temporaryPath, buffer, { flag: 'wx' })
-    const handle = await open(temporaryPath, 'r')
+    const handle = await open(temporaryPath, 'r+')
     try {
       await handle.sync()
     } finally {

--- a/apps/sheets/src/gateway/xlsx-package-io.ts
+++ b/apps/sheets/src/gateway/xlsx-package-io.ts
@@ -320,7 +320,7 @@ export function assertManifestPreserved(
 }
 
 async function promoteFileAtomically(temporaryPath: string, path: string): Promise<void> {
-  const handle = await open(temporaryPath, 'r')
+  const handle = await open(temporaryPath, 'r+')
   try {
     await handle.sync()
   } finally {


### PR DESCRIPTION
Saving a workbook on Windows failed with "error invoking remote method 'workbook:save': EPERM: operation not permitted" — the save dialog appeared, then the save threw regardless of the chosen directory.

promoteFileAtomically (and writeXlsxAtomically) opened the freshly written temp file read-only ('r') and then called handle.sync(). On Windows, FlushFileBuffers requires a writable handle, so fsync on a read-only handle fails with "EPERM: operation not permitted, fsync" — before the rename that promotes the temp file over the target ever runs.

Open the handle read-write ('r+') at both sites.

Reproduced and verified fixed on Windows 11 Pro: with 'r' the save fails on fsync with EPERM; with 'r+' the sync and the rename over an existing file both succeed and the workbook saves.
