### PR TITLE
fix(file-parse): keep xlsx and pptx attachment text verbatim

### DIFF
--- a/packages/file-parse/src/pptx.ts
+++ b/packages/file-parse/src/pptx.ts
@@ -1,7 +1,9 @@
 import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 
-const parser = new XMLParser({ ignoreAttributes: true })
+// Text fidelity: no trim (xml:space="preserve" runs carry the spaces between words),
+// no numeric coercion of tag values (otherwise <a:t>02139</a:t> becomes a number and loses characters)
+const parser = new XMLParser({ ignoreAttributes: true, trimValues: false, parseTagValue: false })
 
 function slideNumber(path: string): number {
   const m = /slide(\d+)\.xml$/.exec(path)
@@ -9,19 +11,20 @@ function slideNumber(path: string): number {
 }
 
 /** collect the text of all a:t descendants of one node */
-function collectText(node: unknown, out: string[]): void {
+function collectText(node: unknown, out: string[], isText = false): void {
   if (node == null) return
   if (typeof node === 'string' || typeof node === 'number') {
-    out.push(String(node))
+    // untrimmed, a non-a:t element written across lines carries its whitespace as a value
+    if (isText) out.push(String(node))
     return
   }
   if (Array.isArray(node)) {
-    for (const item of node) collectText(item, out)
+    for (const item of node) collectText(item, out, isText)
     return
   }
   if (typeof node === 'object') {
     for (const [key, value] of Object.entries(node)) {
-      if (key === 'a:t') collectText(value, out)
+      if (key === 'a:t') collectText(value, out, true)
       else if (typeof value === 'object') collectText(value, out)
     }
   }

--- a/packages/file-parse/src/xlsx.ts
+++ b/packages/file-parse/src/xlsx.ts
@@ -1,7 +1,18 @@
 import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 
-const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' })
+// Text fidelity: no trim (xml:space="preserve" runs carry the spaces between words),
+// no numeric coercion of tag values (otherwise <t>02139</t> becomes a number and loses characters)
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  trimValues: false,
+  parseTagValue: false,
+  // trimValues also governs attributes; nothing read here (r:id, Target, cell ref, sheet
+  // name) carries meaningful edge whitespace, and an untrimmed Target builds the wrong zip
+  // path, which silently drops the whole sheet
+  attributeValueProcessor: (_name, value) => value.trim(),
+})
 
 function asArray<T>(value: T | T[] | undefined): T[] {
   if (value === undefined || value === null) return []
@@ -44,10 +55,13 @@ interface Cell {
 
 function cellText(cell: Cell, shared: string[]): string {
   const type = cell['@_t'] ?? ''
-  if (type === 's') return shared[Number(textOf(cell.v))] ?? ''
   if (type === 'inlineStr') return cell.is ? sharedStringText(cell.is) : ''
-  if (type === 'b') return textOf(cell.v) === '1' ? 'TRUE' : 'FALSE'
-  return textOf(cell.v)
+  // <v> is ST_Xstring so it reaches the caller verbatim; the two reads that need it as a
+  // scalar handle their own whitespace (Number tolerates it, the boolean compare strips it)
+  const value = textOf(cell.v)
+  if (type === 's') return shared[Number(value)] ?? ''
+  if (type === 'b') return value.trim() === '1' ? 'TRUE' : 'FALSE'
+  return value
 }
 
 async function zipText(zip: JSZip, path: string): Promise<string | undefined> {
@@ -94,7 +108,9 @@ export async function xlsxToText(bytes: Uint8Array): Promise<string> {
     if (!sheetXml) continue
     const worksheet = parser.parse(sheetXml) as Record<string, any>
     const lines: string[] = [`# ${String(sheet['@_name'] ?? '')}`]
-    for (const row of asArray(worksheet.worksheet?.sheetData?.row) as Array<Record<string, unknown>>) {
+    for (const row of asArray(worksheet.worksheet?.sheetData?.row) as Array<
+      Record<string, unknown>
+    >) {
       const cells: string[] = []
       for (const cell of asArray(row.c as Cell | Cell[])) {
         const text = cellText(cell, shared)

--- a/packages/file-parse/tests/helpers/fixtures.ts
+++ b/packages/file-parse/tests/helpers/fixtures.ts
@@ -76,7 +76,10 @@ export async function buildDocxFixture(): Promise<Uint8Array> {
 
 function slideXml(paragraphs: string[][]): string {
   const paras = paragraphs
-    .map((runs) => `<a:p>${runs.map((t) => `<a:r><a:t>${t}</a:t></a:r>`).join('')}</a:p>`)
+    .map(
+      (runs) =>
+        `<a:p>${runs.map((t) => `<a:r><a:t xml:space="preserve">${t}</a:t></a:r>`).join('')}</a:p>`,
+    )
     .join('')
   return (
     `${XML_DECL}<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
@@ -85,11 +88,20 @@ function slideXml(paragraphs: string[][]): string {
   )
 }
 
-/** minimal pptx: only the slide parts our parser reads (3 slides incl. slide10 for numeric ordering) */
+/** minimal pptx: only the slide parts our parser reads (4 slides incl. slide10 for numeric ordering) */
 export async function buildPptxFixture(): Promise<Uint8Array> {
   const zip = new JSZip()
   zip.file('ppt/slides/slide1.xml', slideXml([['Product', 'Intro'], ['First slide subtitle']]))
-  zip.file('ppt/slides/slide2.xml', slideXml([['Market Analysis']]))
+  zip.file('ppt/slides/slide2.xml', slideXml([['Market Analysis'], ['Order ', '0042']]))
+  // <a:br> as an open/close pair rather than self-closing, the way XML reformatters emit it
+  zip.file(
+    'ppt/slides/slide3.xml',
+    `${XML_DECL}<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+      'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+      '<p:cSld><p:spTree><p:sp><p:txBody><a:p>' +
+      '<a:r><a:t>Before</a:t></a:r><a:br>\n  </a:br><a:br>\n  </a:br><a:r><a:t>After</a:t></a:r>' +
+      '</a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>',
+  )
   zip.file('ppt/slides/slide10.xml', slideXml([['Summary Slide']]))
   return zip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' })
 }
@@ -106,14 +118,17 @@ export async function buildXlsxFixture(): Promise<Uint8Array> {
   zip.file(
     'xl/_rels/workbook.xml.rels',
     `${XML_DECL}<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
-      '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+      // Target is padded on purpose: xsd:anyURI collapses whitespace, so the reader must too
+      '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target=" worksheets/sheet1.xml "/>' +
       '</Relationships>',
   )
   zip.file(
     'xl/sharedStrings.xml',
-    `${XML_DECL}<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2" uniqueCount="2">` +
+    `${XML_DECL}<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">` +
       '<si><t>Name</t></si>' +
       '<si><r><t>Sco</t></r><r><t>res</t></r></si>' +
+      '<si><t>02139</t></si>' +
+      '<si><r><t xml:space="preserve">Total </t></r><r><t>due</t></r></si>' +
       '</sst>',
   )
   zip.file(
@@ -121,6 +136,9 @@ export async function buildXlsxFixture(): Promise<Uint8Array> {
     `${XML_DECL}<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>` +
       '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>' +
       '<row r="2"><c r="A2" t="inlineStr"><is><t>Alice</t></is></c><c r="B2"><v>95</v></c><c r="D2" t="b"><v>1</v></c></row>' +
+      '<row r="3"><c r="A3" t="s"><v>2</v></c><c r="B3" t="s"><v>3</v></c></row>' +
+      '<row r="4"><c r="A4" t="str"><f>A2&amp;" pts"</f><v xml:space="preserve"> Alice pts </v></c></row>' +
+      '<row r="5"><c r="A5" t="e"><v xml:space="preserve"> #N/A </v></c></row>' +
       '</sheetData></worksheet>',
   )
   return zip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' })

--- a/packages/file-parse/tests/office-formats.test.ts
+++ b/packages/file-parse/tests/office-formats.test.ts
@@ -31,6 +31,18 @@ describe('parseFileToText: pptx', () => {
     expect(result.text!.indexOf('## Slide 10')).toBeGreaterThan(result.text!.indexOf('## Slide 2'))
     expect(result.text).toContain('## Slide 10\nSummary Slide')
   })
+
+  it('keeps run text verbatim: leading zeros and the spaces between runs', async () => {
+    const path = writeFixture('deck.pptx', await buildPptxFixture())
+    const result = await parseFileToText(path)
+    expect(result.text).toContain('Order 0042')
+  })
+
+  it('takes text from a:t only, not from whitespace inside sibling elements', async () => {
+    const path = writeFixture('deck.pptx', await buildPptxFixture())
+    const result = await parseFileToText(path)
+    expect(result.text!.split('\n\n')).toContain('## Slide 3\nBeforeAfter')
+  })
 })
 
 describe('parseFileToText: xlsx', () => {
@@ -42,6 +54,18 @@ describe('parseFileToText: xlsx', () => {
     expect(result.text).toContain('Name | Scores')
     // C2 is missing so the boolean in D2 lands in the 4th column
     expect(result.text).toContain('Alice | 95 |  | TRUE')
+  })
+
+  it('keeps cell text verbatim: leading zeros and the spaces between rich-text runs', async () => {
+    const path = writeFixture('table.xlsx', await buildXlsxFixture())
+    const result = await parseFileToText(path)
+    expect(result.text).toContain('02139 | Total due')
+  })
+
+  it('keeps the spaces in a <v> value (cached formula string, error literal)', async () => {
+    const path = writeFixture('table.xlsx', await buildXlsxFixture())
+    const result = await parseFileToText(path)
+    expect(result.text).toContain('\n Alice pts \n #N/A ')
   })
 
   it('fails gracefully on a corrupt file', async () => {


### PR DESCRIPTION
## Summary

**What changed?**

`packages/file-parse` builds its two `fast-xml-parser` instances without `trimValues: false` and `parseTagValue: false`, so text pulled out of an xlsx or pptx attachment is trimmed and numerically coerced before it reaches the model. This sets both options on those parsers, matching `packages/docx-engine/src/xml-utils.ts:6` and `packages/pptx-engine/src/parse.ts:55`, which already set them for exactly this reason, and adjusts the two read sites that were relying on the parser to normalise for them.

**Why is this change needed?**

`parseFileToText` is the attachment path into the AI panel in docs, sheets and slides. Two fast-xml-parser defaults corrupt the text on the way.

`parseTagValue` (default `true`) arithmetically evaluates anything number-shaped:

| in the file | reached the model as |
| --- | --- |
| `<t>02139</t>` | `2139` |
| `<is><t>0x1A</t></is>` | `26` |
| `<t>+15551234567</t>` | `15551234567` |
| `<a:t>1e3</a:t>` | `1000` |

`trimValues` (default `true`) is the larger problem: it strips the spaces carried by `xml:space="preserve"` runs, which is where PowerPoint and Excel put the space whenever formatting splits a sentence into separate runs. A single bold word is enough:

```xml
<a:r><a:t xml:space="preserve">Quarterly </a:t></a:r>
<a:r><a:rPr b="1"/><a:t>revenue</a:t></a:r>
<a:r><a:t xml:space="preserve"> grew </a:t></a:r>
<a:r><a:rPr b="1"/><a:t>12%</a:t></a:r>
<a:r><a:t xml:space="preserve"> in </a:t></a:r>
<a:r><a:t>Q3</a:t></a:r>
```

before: `Quarterlyrevenuegrew12%inQ3`
after: `Quarterly revenue grew 12% in Q3`

The same happens to xlsx rich-text cells, where `Total ` + `due` + ` today` arrived as `Totalduetoday`. So the model was receiving attachment prose with its word boundaries removed, which is not an edge case: it is any deck or sheet with mixed formatting inside a paragraph or cell. `packages/pptx-engine/src/parse.ts:58-61` already carries the rationale in a comment; `file-parse` is the one text-reading package that missed it.

**Why two other things change with it**

`trimValues` is per parser, not per element, so turning it off also stops trimming things that are not user text. Two places were quietly relying on it:

- **Attributes.** `r:id`, `Id`, `Target` and the cell ref `r` are structural, and their schema types collapse whitespace (`Target` is `xsd:anyURI`). Untrimmed, a conforming `Target=" worksheets/sheet1.xml "` builds the wrong ZIP path and the sheet is skipped, so a whole sheet silently disappears from the attachment. The xlsx parser therefore keeps trimming attributes via `attributeValueProcessor`, and the fixture now carries a padded `Target` so removing that line fails three tests.
- **`collectText`.** It pushed every primitive it reached, not only `a:t` content, so an `<a:br>` written as an open/close pair contributed its formatting whitespace to the paragraph. It now pushes a primitive only when that primitive came from an `a:t`, which is what its docstring always claimed.

`<v>` itself is left alone. It is `ST_Xstring`, so it reaches the caller verbatim for every cell type, the same way the sheets xlsx sidecar reads it (`apps/sheets/native/xlsx-engine/src/lib.rs:2314`). The one exception is the `t="b"` comparison, which needs the scalar and emits `TRUE`/`FALSE` rather than whitespace; `t="s"` needs no change because `Number()` already tolerates it.

Verified by building the `origin/main` modules from `git show` and diffing real output across every shape I could construct: `t` in `{b, s, str, e, n, d, inlineStr, absent}`, each plain, padded, newline-wrapped and CDATA-wrapped; empty and missing `<v>`; float and big-integer values; padded `Target`, `Id`, `r:id`, sheet `name` and cell `r`; self-closing and expanded `<a:br>`; CJK and emoji runs. Every one is identical to `main` except the `<t>` and `<a:t>` fidelity fixes, plus whitespace inside a `<v>` now being preserved rather than trimmed, which is the same `ST_Xstring` rule.

Three of the four new tests fail against `main`. The fourth, the `<a:br>` one, fails if the parser options are applied without the `collectText` guard.

One hunk in `xlsx.ts` is not mine: the `for (const row of ...)` line is 103 characters on `main`, over the 100 `printWidth`, so `npm run format:check` wraps it once the file is part of a change. That is the incremental formatting `CONTRIBUTING.md` describes, not a reformat I chose.

## Related issue

None. Found while reading the attachment parse path.

## Validation

Run from a clean tree rebased on `origin/main`.

- [x] `npm run format:check -- --base origin/main`: `All matched files use Prettier code style!`
- [x] `npm run lint`: `7 problems (0 errors, 7 warnings)`, all pre-existing
- [x] `npm run typecheck`: clean across every workspace
- [x] `npm test`: exits 0, no failures, including the Rust sidecar tests (`52 passed; 0 failed`). `@genoffice/file-parse` goes 21 to 25 tests.
- [x] `npm run licenses`: `All production npm dependency licenses are within the allowlist.`
- [x] `npm run fixtures && git diff --exit-code -- fixtures/generated`: no drift
- [x] `npm run fixtures -w @genoffice/sheets && npm run compat -w @genoffice/sheets`: every fixture `"passed": true`, no unexpected changes
- [x] `npm run build:all && npm run test:e2e`: 22 Playwright tests passed

## Screenshots or recordings

Not applicable. Attachment text extraction, no UI surface.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable, no UI strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (Not an open/save path: `file-parse` is read-only text extraction and never writes a document back. The four new tests are the fidelity equivalent, asserting the extracted text matches the source runs verbatim.)
