### PR TITLE
fix(build): include the markdown app's dependencies in the third-party notices

### DIFF
--- a/tools/gen-third-party-notices.mjs
+++ b/tools/gen-third-party-notices.mjs
@@ -29,6 +29,7 @@ const BUILTIN = new Set(builtinModules)
  */
 const SRC_GLOBS = [
   'apps/docs/src',
+  'apps/markdown/src',
   'apps/pdf/src',
   'apps/sheets/src',
   'apps/shell/src',
@@ -123,15 +124,30 @@ function importedNames() {
   return names
 }
 
+const WORKSPACE_MODULES = SRC_GLOBS.map((g) => join(ROOT, g.replace(/\/src$/, ''), 'node_modules'))
+
+/** installed package names, unscoped first so existing resolutions keep winning */
+function topLevelPackages() {
+  const dirs = (at) => readdirSync(at, { withFileTypes: true }).filter((e) => e.isDirectory())
+  const top = dirs(join(ROOT, 'node_modules')).map((e) => e.name)
+  const scoped = top.filter((n) => n.startsWith('@'))
+  return [
+    ...top.filter((n) => !n.startsWith('@')),
+    ...scoped.flatMap((s) => dirs(join(ROOT, 'node_modules', s)).map((e) => `${s}/${e.name}`)),
+  ]
+}
+
 /** npm hoists, so the root copy is the usual answer; fall back to a nested one */
 function pkgDir(name) {
   const root = join(ROOT, 'node_modules', name)
   if (existsSync(join(root, 'package.json'))) return root
-  const scopes = readdirSync(join(ROOT, 'node_modules'), { withFileTypes: true })
-  for (const e of scopes) {
-    if (!e.isDirectory()) continue
-    const nested = join(ROOT, 'node_modules', e.name, 'node_modules', name)
+  for (const owner of topLevelPackages()) {
+    const nested = join(ROOT, 'node_modules', owner, 'node_modules', name)
     if (existsSync(join(nested, 'package.json'))) return nested
+  }
+  for (const modules of WORKSPACE_MODULES) {
+    const own = join(modules, name)
+    if (existsSync(join(own, 'package.json'))) return own
   }
   return null
 }


### PR DESCRIPTION
## Summary

**What changed?**

`tools/gen-third-party-notices.mjs` never scanned `apps/markdown/src`, and `pkgDir` could not find two classes of installed package, so the notices file that ships inside every installer is missing 29 third-party licenses. This adds the missing source tree and the two missing lookups.

**Why is this change needed?**

`SRC_GLOBS` lists the app source trees by hand while enumerating `packages/*` dynamically, so the app added in the 2026-08-07 snapshot was silently skipped:

```js
const SRC_GLOBS = [
  'apps/docs/src',
  'apps/pdf/src',
  ...
```

That app ships. `apps/shell/electron-builder.cjs:106` copies `../markdown/out` into every installer and its `beforePack` hook asserts the directory exists. `npm run notices` is a prerequisite of `dist:mac`, `dist:win` and `dist:linux` (`package.json:35-37`), and its output ships as `extraResources` (`electron-builder.cjs:82`). So the licenses of everything only `apps/markdown` imports never reach a released build.

Adding the source tree alone is not enough, and this is the part worth reviewing. It recovers exactly one package and leaves 26 reported as `not installed, skipped`, because `pkgDir` misses two real locations:

- **Workspace copies.** `apps/markdown` pins `@tiptap 3.29.2` while `apps/docs` takes `^3.28.0`, so npm cannot hoist markdown's copies and keeps them in `apps/markdown/node_modules`. `pkgDir` looked only at the root tree.
- **Scoped owners.** `@tiptap/starter-kit` keeps its own extensions at `node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bold`. The nested search iterated the entries of the root `node_modules`, which for a scoped package is the scope directory `@tiptap` rather than the package, so it built `node_modules/@tiptap/node_modules/...` and never matched. Nothing on `main` needs this lookup today, so the gap was invisible until `apps/markdown` arrived.

Unscoped owners are searched before scoped ones so that every package that already resolved keeps resolving to the same copy. That ordering is deliberate: a package can exist at several versions under different owners and `pkgDir` is first-match-wins, so flattening the two into one list silently moved `fs-extra` from v10.1.0 to v9.1.0 in an earlier revision of this patch. A notices file is a legal artifact and a changed version is worse than a missing one.

**Effect on the generated file**

| | before | after |
| --- | --- | --- |
| npm packages | 260 | 289 |
| `not installed, skipped` | (none reported) | empty |

29 packages added, **none removed, and no version changed**, verified by diffing the generated file in both directions. The additions are `@tiptap/*` (26), `marked`, `linkifyjs` and `at-least-node`, all reachable only from `apps/markdown/src`. Running the generator twice produces an identical file.

## Related issue

None. Found while checking what else the markdown app's arrival left stale.

## Validation

- [x] `npm run licenses`: `All production npm dependency licenses are within the allowlist.`
- [x] `npm run format:check -- --base origin/main`: `All matched files use Prettier code style!`
- [x] `npm run lint`: `7 problems (0 errors, 7 warnings)`, all pre-existing
- [x] `npm run typecheck`: clean across every workspace
- [x] `npm test`: exits 0, no failures, including the Rust sidecar tests
- [x] `npm run notices` run repeatedly: byte-identical output, and the skipped-package warning is empty

`tools/` has no test harness, so the evidence here is the before and after of the generated file rather than a unit test. Happy to add one if you would like the resolution order pinned down.

## Screenshots or recordings

Not applicable. Build tooling.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (Not applicable, no document path touched.)
