### PR TITLE
fix(sheets): allow Save As without edits

### DIFF
--- a/apps/sheets/src/gateway/xlsx-gateway.ts
+++ b/apps/sheets/src/gateway/xlsx-gateway.ts
@@ -584,29 +584,6 @@ export async function planCellEditsToXlsx(
   sparklineAdditions: readonly SheetSparklineAddition[] = [],
   formulaValues: readonly SheetFormulaValues[] = [],
 ): Promise<MutationPlan> {
-  if (
-    edits.length === 0 &&
-    structuralOps.length === 0 &&
-    chartEdits.length === 0 &&
-    sheetPlan === undefined &&
-    filterStates.length === 0 &&
-    hyperlinkEdits.length === 0 &&
-    cfStates.length === 0 &&
-    dvStates.length === 0 &&
-    sheetProtections.length === 0 &&
-    definedNamesState === null &&
-    visualAdditions.length === 0 &&
-    pageSetupStates.length === 0 &&
-    noteStates.length === 0 &&
-    tableAdditions.length === 0 &&
-    pivotAdditions.length === 0 &&
-    pivotCacheRefreshPaths.length === 0 &&
-    pivotRefreshUpdates.length === 0 &&
-    visualEdits.length === 0 &&
-    sparklineAdditions.length === 0
-  ) {
-    throw new Error('There are no edits to save.')
-  }
   // A pending pivot pins final coordinates for its source and output; shifts
   // on either sheet, and sheet renames (worksheetSource@sheet), would desync
   // the recorded ranges. Fail closed, mirroring the table-add guard.

--- a/apps/sheets/src/preload/index.ts
+++ b/apps/sheets/src/preload/index.ts
@@ -1078,7 +1078,8 @@ function parseSaveRequest(input: WorkbookSaveRequest): WorkbookSaveRequest {
         typeof state.protected !== 'boolean',
     ) ||
     !isDefinedNamesState(input.definedNamesState) ||
-    (input.edits.length === 0 &&
+    (input.mode !== 'save-as' &&
+      input.edits.length === 0 &&
       input.structuralOps.length === 0 &&
       input.chartEdits.length === 0 &&
       input.visualEdits.length === 0 &&

--- a/apps/sheets/src/renderer/save-actions.ts
+++ b/apps/sheets/src/renderer/save-actions.ts
@@ -148,7 +148,7 @@ export async function handleSave(
     visualEdits.length +
     tableAdditions.length +
     pivotAdditions.length
-  if (total === 0) {
+  if (total === 0 && mode !== 'save-as') {
     if (mode !== 'recovery') ctx.setMessage(t('appNoEditsToSave'))
     return
   }


### PR DESCRIPTION
## Thinking

Save As should be independent of whether the workbook has pending edits. A clean workbook may have no mutations to apply, but the user should still be able to save the current workbook to a new path. Previously, Sheets treated “no edits” as “nothing to save” and returned before opening the Save As dialog. This change allows empty Save As requests to pass through the existing XLSX save pipeline, while ordinary Save remains a no-op for unchanged workbooks.

## Summary

- make explicit Save As independent of whether the workbook has pending edits
- allow an empty Save As request through the preload boundary
- let the existing XLSX save pipeline write an unchanged workbook to the selected path

Docs and Slides already perform explicit Save As regardless of dirty state, so they require no code changes.

## Verification

- `npm run typecheck -w @genoffice/sheets`
- `npx eslint apps/sheets/src/preload/index.ts apps/sheets/src/renderer/save-actions.ts apps/sheets/src/gateway/xlsx-gateway.ts`