### PR TITLE
fix(docx): keep the original root namespaces when regenerating a part

### DIFF
--- a/packages/docx-engine/src/notes.ts
+++ b/packages/docx-engine/src/notes.ts
@@ -34,6 +34,22 @@ const NOTE_NS =
   'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
   'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
 
+/**
+ * Root attributes for a regenerated part. Entries are spliced back in as original bytes, so
+ * the root has to keep declaring whatever prefixes those bytes use: Word puts w14:paraId on
+ * every paragraph it writes, and a literal namespace list leaves that prefix unbound.
+ */
+export function rootAttributes(
+  originalXml: string | null,
+  rootTag: string,
+  fallback: string,
+): string {
+  const attrs = originalXml
+    ? new RegExp(`<${rootTag}\\b([^>]*?)/?>`).exec(originalXml)?.[1]?.trim()
+    : undefined
+  return attrs && attrs.includes('xmlns:') ? attrs : fallback
+}
+
 /** real notes (separator entries excluded), in file order */
 export function parseNotesXml(xml: string, kind: NoteKind): NoteInfo[] {
   return noteEntriesOf(xml, kind).map(({ id, text, xml: entryXml }) => {
@@ -185,7 +201,7 @@ export function buildNotesXml(
     .join('')
   return (
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-    `<${ROOT[kind]} ${NOTE_NS}>${structural}${body}</${ROOT[kind]}>`
+    `<${ROOT[kind]} ${rootAttributes(originalXml, ROOT[kind], NOTE_NS)}>${structural}${body}</${ROOT[kind]}>`
   )
 }
 

--- a/packages/docx-engine/src/patch.ts
+++ b/packages/docx-engine/src/patch.ts
@@ -5,6 +5,7 @@ import {
   NOTE_PART_PATH,
   NOTE_REL_TYPE,
   buildNotesXml,
+  rootAttributes,
   type NoteKind,
 } from './notes'
 import {
@@ -1353,6 +1354,10 @@ function headerFooterPartXml(
  * their original bytes (rich formatting/multiple paragraphs/inline hyperlinks are
  * preserved); only new or edited comments fall back to a plain-text rebuild.
  */
+const COMMENTS_NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"'
+
 function buildCommentsXml(comments: CommentInfo[], originalXml: string | null): string {
   const originals = new Map<string, { text: string; xml: string }>()
   if (originalXml) {
@@ -1387,12 +1392,8 @@ function buildCommentsXml(comments: CommentInfo[], originalXml: string | null): 
       return `<w:comment ${attrs}>${paras}</w:comment>`
     })
     .join('')
-  return (
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-    '<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
-    ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">' +
-    `${body}</w:comments>`
-  )
+  const ns = rootAttributes(originalXml, 'w:comments', COMMENTS_NS)
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:comments ${ns}>${body}</w:comments>`
 }
 
 /** word/commentsExtended.xml: one commentEx per comment (reply parent-child + resolved flag) */

--- a/packages/docx-engine/tests/part-namespaces.test.ts
+++ b/packages/docx-engine/tests/part-namespaces.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regenerated parts splice original entry bytes back in, so their root has to keep declaring
+ * every prefix those bytes use. A literal namespace list leaves prefixes unbound, which Word
+ * reports as unreadable content. fast-xml-parser's validator does not catch this: it is not
+ * namespace-aware, so the check here has to be.
+ */
+import { describe, expect, it } from 'vitest'
+import { buildNotesXml, rootAttributes } from '../src/notes'
+
+/** every prefix used on an element or attribute must be declared on the root */
+function unboundPrefixes(xml: string): string[] {
+  const root = /<([a-zA-Z][\w.-]*:[\w.-]+)\b([^>]*)>/.exec(xml.replace(/<\?[\s\S]*?\?>/, ''))
+  const declared = new Set(
+    [...(root?.[2] ?? '').matchAll(/xmlns:([\w.-]+)=/g)].map((m) => m[1]!).concat('xml'),
+  )
+  const used = new Set<string>()
+  for (const m of xml.matchAll(/<\/?([a-zA-Z][\w.-]*):/g)) used.add(m[1]!)
+  for (const m of xml.matchAll(/[\s"']([a-zA-Z][\w.-]*):[\w.-]+=["']/g)) used.add(m[1]!)
+  return [...used].filter((p) => !declared.has(p) && p !== 'xmlns')
+}
+
+describe('regenerated part namespaces', () => {
+  it('the check itself catches an unbound prefix', () => {
+    expect(unboundPrefixes('<w:x xmlns:w="w"><w:p w14:paraId="1"/></w:x>')).toEqual(['w14'])
+    expect(unboundPrefixes('<w:x xmlns:w="w" xmlns:w14="b"><w:p w14:paraId="1"/></w:x>')).toEqual(
+      [],
+    )
+  })
+
+  it('keeps the original root attributes when a part is regenerated', () => {
+    const original =
+      '<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
+      ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"' +
+      ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">' +
+      '<w:footnote w:id="2"><w:p w14:paraId="4A2B1C0D" w14:textId="77BB0011">' +
+      '<w:r><w:t>original</w:t></w:r></w:p></w:footnote></w:footnotes>'
+    const out = buildNotesXml(
+      'footnote',
+      [
+        { id: '2', text: 'original' },
+        { id: '3', text: 'added' },
+      ],
+      original,
+    )
+    expect(out).toContain('w14:paraId="4A2B1C0D"')
+    expect(unboundPrefixes(out)).toEqual([])
+  })
+
+  it('falls back to the literal namespaces when there is no original part', () => {
+    const out = buildNotesXml('footnote', [{ id: '2', text: 'fresh' }], null)
+    expect(unboundPrefixes(out)).toEqual([])
+    expect(out).toContain('xmlns:w=')
+  })
+
+  it('rootAttributes ignores a root that declares no namespaces', () => {
+    expect(rootAttributes('<w:comments>', 'w:comments', 'FALLBACK')).toBe('FALLBACK')
+    expect(rootAttributes(null, 'w:comments', 'FALLBACK')).toBe('FALLBACK')
+    expect(rootAttributes('<w:comments xmlns:w="a" xmlns:r="b">', 'w:comments', 'FALLBACK')).toBe(
+      'xmlns:w="a" xmlns:r="b"',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

**What changed?**

`word/comments.xml` and `word/footnotes.xml` / `word/endnotes.xml` are regenerated by splicing unchanged entries back in as their **original bytes**, then wrapping them in a root with a hardcoded namespace list. The bytes and the root disagree, so the part can reference prefixes the root never declares. They now reuse the original part's root attributes.

**Why is this change needed?**

Two hardcoded lists, each missing a prefix the spliced bytes routinely use:

```js
// patch.ts, buildCommentsXml: declares w and w14
'<w:comments xmlns:w="...wordprocessingml/2006/main" xmlns:w14="...word/2010/wordml">'

// notes.ts, NOTE_NS: declares w and r
const NOTE_NS = 'xmlns:w="...wordprocessingml/2006/main" xmlns:r="...relationships"'
```

- A preserved comment holding `<w:hyperlink r:id="rId7">` leaves **`r` unbound**, because `w:comments` never declares it.
- A preserved paragraph holding `w14:paraId` leaves **`w14` unbound**, because `NOTE_NS` never declares it. Word writes `w14:paraId` and `w14:textId` on essentially every paragraph it authors, so this is the common case, not an exotic one.

An unbound prefix is not well-formed XML. Word reports it as unreadable content and offers to repair the file. Reaching it takes one ordinary action: add a comment to a document that already has a linked comment, or add a footnote to any Word-authored document.

**Why the existing tests do not catch it**

`fast-xml-parser`'s `XMLValidator` is not namespace-aware. It reports all three of these as valid:

| emitted part | `XMLValidator` | namespace-aware parse |
| --- | --- | --- |
| `comments.xml` with a preserved `r:id` hyperlink | VALID | **unbound prefix: `r`** |
| `footnotes.xml` with a preserved `w14:paraId` | VALID | **unbound prefix: `w14`** |
| control: same footnote with `w14` declared | VALID | ok |

So every test that validates emitted XML through the parser the repo already depends on will keep passing while the file is broken. That is the reason the new test does its own prefix-binding check instead of calling the validator, and why it starts with a case asserting the *checker itself* fails on a known-unbound prefix. A regression test that cannot fail is worse than none.

**The fix**

One helper, used at both sites:

```js
export function rootAttributes(originalXml, rootTag, fallback) {
  const attrs = originalXml
    ? new RegExp(`<${rootTag}\\b([^>]*?)/?>`).exec(originalXml)?.[1]?.trim()
    : undefined
  return attrs && attrs.includes('xmlns:') ? attrs : fallback
}
```

Carrying the original root forward is the conservative option: the bytes underneath came from that root, so whatever they use is declared. The literal list is kept for parts created from scratch, and the `includes('xmlns:')` guard means a malformed or namespace-free root falls back rather than producing a root with no declarations at all.

## Related issue

None. Found while checking what else regenerates a part by splicing original bytes.

## Validation

- [x] `npm test`: exits 0. `packages/docx-engine` 449 passed, 1 skipped, 55 files
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors on the changed files
- [x] `npm run format:check`: `All matched files use Prettier code style!`
- [x] `keeps the original root attributes when a part is regenerated` fails against `main` and passes here, verified by restoring `main`'s two call sites and re-running
- [x] The other three cases guard the checker and the no-original fallback, and pass either way by design

## Screenshots or recordings

Not applicable, the defect is in the saved XML. The reproduction is: open a Word-authored document, add a footnote, save, reopen in Word.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable, no strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test.
