### PR TITLE
fix(file-parse): keep pptx line breaks and fields in document order

### DIFF
--- a/packages/file-parse/src/pptx.ts
+++ b/packages/file-parse/src/pptx.ts
@@ -2,56 +2,60 @@ import JSZip from 'jszip'
 import { XMLParser } from 'fast-xml-parser'
 
 // Text fidelity: no trim (xml:space="preserve" runs carry the spaces between words),
-// no numeric coercion of tag values (otherwise <a:t>02139</a:t> becomes a number and loses characters)
-const parser = new XMLParser({ ignoreAttributes: true, trimValues: false, parseTagValue: false })
+// no numeric coercion of tag values (otherwise <a:t>02139</a:t> becomes a number and loses characters).
+// preserveOrder keeps <a:br> and <a:fld> in sequence with the <a:r> runs around them; grouped by
+// tag name they lose that position, and a deck's soft breaks and field text land in the wrong place.
+const parser = new XMLParser({
+  ignoreAttributes: true,
+  trimValues: false,
+  parseTagValue: false,
+  preserveOrder: true,
+})
 
 function slideNumber(path: string): number {
   const m = /slide(\d+)\.xml$/.exec(path)
   return m ? Number(m[1]) : 0
 }
 
-/** collect the text of all a:t descendants of one node */
-function collectText(node: unknown, out: string[], isText = false): void {
-  if (node == null) return
-  if (typeof node === 'string' || typeof node === 'number') {
-    // untrimmed, a non-a:t element written across lines carries its whitespace as a value
-    if (isText) out.push(String(node))
-    return
-  }
-  if (Array.isArray(node)) {
-    for (const item of node) collectText(item, out, isText)
-    return
-  }
-  if (typeof node === 'object') {
+/**
+ * One paragraph's text in document order. Only #text directly under a:t counts: untrimmed, the
+ * whitespace laying out any other element is a value too. <a:br> is a soft line break, and
+ * <a:fld> (slide number, date) contributes its own a:t where it sits.
+ */
+function collectText(nodes: readonly unknown[], out: string[], isText = false): void {
+  for (const node of nodes) {
+    if (node == null || typeof node !== 'object') continue
     for (const [key, value] of Object.entries(node)) {
-      if (key === 'a:t') collectText(value, out, true)
-      else if (typeof value === 'object') collectText(value, out)
+      if (key === '#text') {
+        if (isText) out.push(String(value))
+      } else if (key === 'a:br') {
+        out.push('\n')
+      } else if (Array.isArray(value)) {
+        collectText(value, out, key === 'a:t')
+      }
     }
   }
 }
 
-/** walk the slide tree; each a:p paragraph becomes one output line */
-function collectParagraphs(node: unknown, out: string[]): void {
-  if (node == null || typeof node !== 'object') return
-  if (Array.isArray(node)) {
-    for (const item of node) collectParagraphs(item, out)
-    return
-  }
-  for (const [key, value] of Object.entries(node)) {
-    if (key === 'a:p') {
-      for (const para of Array.isArray(value) ? value : [value]) {
+/** walk the slide tree; each a:p paragraph becomes one output entry (a:br splits it further) */
+function collectParagraphs(nodes: readonly unknown[], out: string[]): void {
+  for (const node of nodes) {
+    if (node == null || typeof node !== 'object') continue
+    for (const [key, value] of Object.entries(node)) {
+      if (!Array.isArray(value)) continue
+      if (key === 'a:p') {
         const texts: string[] = []
-        collectText(para, texts)
+        collectText(value, texts)
         const line = texts.join('')
         if (line.trim()) out.push(line)
+      } else {
+        collectParagraphs(value, out)
       }
-    } else {
-      collectParagraphs(value, out)
     }
   }
 }
 
-/** extract slide text from a pptx: one "## Slide N" section per slide, one line per paragraph */
+/** extract slide text from a pptx: one "## Slide N" section per slide, a line per paragraph */
 export async function pptxToText(bytes: Uint8Array): Promise<string> {
   const zip = await JSZip.loadAsync(bytes)
   const slidePaths = Object.keys(zip.files)

--- a/packages/file-parse/tests/helpers/fixtures.ts
+++ b/packages/file-parse/tests/helpers/fixtures.ts
@@ -98,8 +98,16 @@ export async function buildPptxFixture(): Promise<Uint8Array> {
     'ppt/slides/slide3.xml',
     `${XML_DECL}<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
       'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
-      '<p:cSld><p:spTree><p:sp><p:txBody><a:p>' +
+      '<p:cSld><p:spTree><p:sp><p:txBody>' +
+      // a comment naming the very tags the walker looks for: rewriting markup as text
+      // instead of parsing it consumes the terminator and the whole slide fails to parse
+      '<!-- authoring note: <a:br/> and <a:fld> -->' +
+      '<a:p>' +
       '<a:r><a:t>Before</a:t></a:r><a:br>\n  </a:br><a:br>\n  </a:br><a:r><a:t>After</a:t></a:r>' +
+      '</a:p>\n  <a:p>\n    ' +
+      '<a:r><a:t xml:space="preserve">Page </a:t></a:r>\n    ' +
+      '<a:fld id="{G}" type="slidenum"><a:t>3</a:t></a:fld>\n    ' +
+      '<a:r><a:t xml:space="preserve"> of 10</a:t></a:r>\n  ' +
       '</a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>',
   )
   zip.file('ppt/slides/slide10.xml', slideXml([['Summary Slide']]))

--- a/packages/file-parse/tests/office-formats.test.ts
+++ b/packages/file-parse/tests/office-formats.test.ts
@@ -38,10 +38,22 @@ describe('parseFileToText: pptx', () => {
     expect(result.text).toContain('Order 0042')
   })
 
+  it('keeps a:br as a line break and a:fld in document order', async () => {
+    const path = writeFixture('deck.pptx', await buildPptxFixture())
+    const result = await parseFileToText(path)
+    // two breaks, so the run text is not concatenated and the field lands between its runs;
+    // the slide also carries a comment naming those tags, which must not reach the walker
+    expect(result.text).toContain('## Slide 3\nBefore\n\nAfter\nPage 3 of 10')
+  })
+
   it('takes text from a:t only, not from whitespace inside sibling elements', async () => {
     const path = writeFixture('deck.pptx', await buildPptxFixture())
     const result = await parseFileToText(path)
-    expect(result.text!.split('\n\n')).toContain('## Slide 3\nBeforeAfter')
+    // the a:br elements are written across lines; that layout whitespace is a value too
+    expect(result.text).toContain('Before')
+    expect(result.text).not.toMatch(/Before\n[^\S\n]/)
+    // and the comment the slide carries is markup, not text
+    expect(result.text).not.toContain('authoring note')
   })
 })
 


### PR DESCRIPTION
## Summary

**What changed?**

`pptxToText` grouped a paragraph's children by tag name, which destroys their document order, so a deck's soft line breaks vanished and field text was appended after all the plain runs. It now parses with `preserveOrder` and walks the children in sequence.

**Why is this change needed?**

`<a:br>` and `<a:fld>` are siblings of `<a:r>` inside an `<a:p>`. `fast-xml-parser` returns `{"a:r": [...], "a:br": [...]}`, so the collector sees every run first and every break afterwards:

| slide XML | before | after |
| --- | --- | --- |
| `Q3 results<a:br/>up 12%` | `Q3 resultsup 12%` | `Q3 results` ⏎ `up 12%` |
| `Page <a:fld>7</a:fld> of 20` | `Page  of 207` | `Page 7 of 20` |

Both go into the AI panel as attachment context, so a slide-number field lands in the wrong place in the text the model reads, and two lines of a title merge into one word.

**The part worth reviewing**

My first attempt rewrote `<a:br>` and `<a:fld>` into `<a:r>` with a string replace before parsing, mirroring what `packages/pptx-engine/src/parse.ts` does. That is a regression, and it is worth recording why so nobody repeats it:

```
<a:p><!-- literal <a:br> --><a:r><a:t>KEEP</a:t></a:r><a:br></a:br></a:p>
```

Rewriting text before parsing does not respect XML lexical structure, so the replacement lands inside the comment, consumes its terminator, and the parser throws `Comment is not closed.` The whole attachment then fails, where `main` returned `KEEP` perfectly well. `<![CDATA[<a:fld>7</a:fld>]]>` had its visible text corrupted the same way.

`preserveOrder` avoids the problem instead of patching around it: the parser hands back the paragraph's children as an ordered array, so no raw-XML surgery is needed at all. The collector keeps the `isText` rule from #51, taking only `#text` directly under `a:t`, so the layout whitespace around the other elements still stays out of the result.

**Diffed against main across every paragraph shape**

I built both versions in memory and ran 21 slide shapes through each:

- **0 failures** on this side. The comment case no longer throws. Its output is not identical to
  `main`, because the paragraph printed above ends in `<a:br></a:br>`: `main` gives
  `"## Slide 1\nKEEP"` and this gives `"## Slide 1\nKEEP\n"`, which is the intended break. Drop
  the trailing break and the two agree exactly.
- **CDATA identical to `main`**: `<a:fld>7</a:fld>` stays literal text.
- **The lookalikes are identical to `main`**: `<a:brk>`, `<a:fldChar>`, self-closing `<a:fld/>`, and an escaped `&lt;a:br/&gt;` written as visible text.
- The 8 shapes that differ are the intended ones: breaks now break, fields land in place, and a pretty-printed paragraph gains its break without gaining the whitespace that lays it out.

**One limitation, stated rather than hidden**

This module matches DrawingML by its conventional prefix throughout: `a:p`, `a:t`, `a:r`, `a:fld`
and now `a:br` are all compared as literal keys, so namespace bindings are not consulted. A deck
that rebinds `a:` to another namespace on a break element, `<a:br xmlns:a="urn:vendor"/>`, gets a
line break it should not:

```
main  "## Slide 1\nAB"
here  "## Slide 1\nA\nB"
```

Main only avoids that by ignoring every break, including all the legitimate ones, so its result is
accidental rather than principled. A vendor break under its own prefix (`v:br`) is correctly
ignored by both. Making this right means namespace-aware matching for the whole module, including
paragraph and text extraction, which is a larger change than this one and I would rather not
smuggle it in here. Happy to follow up with it if you want it.

## Related issue

None.

## Validation

- [x] `npm test`: exits 0. `packages/file-parse` 26 passed
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors on the changed files
- [x] `npm run format:check`: `All matched files use Prettier code style!`
- [x] The new assertion fails against `main` and passes here, verified by swapping in
      `origin/main`'s `pptx.ts` and re-running. The other changed assertion passes on both by
      design: it guards the `a:t`-only rule from #51 against regression rather than proving this
      change. Dropping that rule now fails the suite, which it did not before I laid the field
      paragraph out across lines.

The fixture slide now carries two adjacent breaks, a mid-paragraph slide-number field, and a comment naming both tags, so the text-level rewrite that used to be here cannot come back unnoticed.

## Screenshots or recordings

Not applicable. The output is the text handed to the AI panel.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable, no strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test.
