### PR TITLE
fix(sheets): keep the cell alignment attributes the style model omits

### DIFF
--- a/apps/sheets/src/gateway/xlsx-styles.ts
+++ b/apps/sheets/src/gateway/xlsx-styles.ts
@@ -32,7 +32,9 @@ export class StylesheetEditor {
     const bordersInner = sectionInner(stylesXml, 'borders')
     const cellXfsInner = sectionInner(stylesXml, 'cellXfs')
     if (fontsInner === null || fillsInner === null || cellXfsInner === null) {
-      throw new Error('The workbook stylesheet is missing fonts, fills, or cellXfs — style edits cannot be saved.')
+      throw new Error(
+        'The workbook stylesheet is missing fonts, fills, or cellXfs — style edits cannot be saved.',
+      )
     }
     this.fonts = extractElements(fontsInner, 'font')
     this.fills = extractElements(fillsInner, 'fill')
@@ -44,7 +46,9 @@ export class StylesheetEditor {
     this.hadDxfsSection = dxfsInner !== null
     this.dxfs = dxfsInner === null ? [] : extractElements(dxfsInner, 'dxf')
     if (this.fonts.length === 0 || this.cellXfs.length === 0) {
-      throw new Error('The workbook stylesheet has no base font or cell format — style edits cannot be saved.')
+      throw new Error(
+        'The workbook stylesheet has no base font or cell format — style edits cannot be saved.',
+      )
     }
     this.originalCounts = {
       numFmts: this.numFmts.length,
@@ -54,19 +58,22 @@ export class StylesheetEditor {
       cellXfs: this.cellXfs.length,
       dxfs: this.dxfs.length,
     }
-    this.nextNumFmtId = this.numFmts.reduce(
-      (maximum, entry) => Math.max(maximum, Number(readAttribute(entry, 'numFmtId') ?? 0)),
-      163,
-    ) + 1
+    this.nextNumFmtId =
+      this.numFmts.reduce(
+        (maximum, entry) => Math.max(maximum, Number(readAttribute(entry, 'numFmtId') ?? 0)),
+        163,
+      ) + 1
   }
 
   get changed(): boolean {
-    return this.numFmts.length !== this.originalCounts.numFmts
-      || this.fonts.length !== this.originalCounts.fonts
-      || this.fills.length !== this.originalCounts.fills
-      || this.borders.length !== this.originalCounts.borders
-      || this.cellXfs.length !== this.originalCounts.cellXfs
-      || this.dxfs.length !== this.originalCounts.dxfs
+    return (
+      this.numFmts.length !== this.originalCounts.numFmts ||
+      this.fonts.length !== this.originalCounts.fonts ||
+      this.fills.length !== this.originalCounts.fills ||
+      this.borders.length !== this.originalCounts.borders ||
+      this.cellXfs.length !== this.originalCounts.cellXfs ||
+      this.dxfs.length !== this.originalCounts.dxfs
+    )
   }
 
   /// Conditional-formatting highlight styles; deduped like every other list.
@@ -121,9 +128,7 @@ export class StylesheetEditor {
       ...(protection !== '' ? ['applyProtection="1"'] : []),
     ].join(' ')
     const children = `${alignment}${protection}`
-    const xf = children === ''
-      ? `<xf ${attributes}/>`
-      : `<xf ${attributes}>${children}</xf>`
+    const xf = children === '' ? `<xf ${attributes}/>` : `<xf ${attributes}>${children}</xf>`
 
     const index = internElement(this.cellXfs, xf)
     this.cache.set(cacheKey, index)
@@ -147,8 +152,9 @@ export class StylesheetEditor {
     } else if (this.dxfs.length > 0) {
       const section = `<dxfs count="${this.dxfs.length}">${this.dxfs.join('')}</dxfs>`
       // Schema order: dxfs follows cellStyles (when present) or cellXfs.
-      const anchor = /<\/cellStyles>|<cellStyles\b[^>]*\/>/.exec(result)
-        ?? /<\/cellXfs>|<cellXfs\b[^>]*\/>/.exec(result)
+      const anchor =
+        /<\/cellStyles>|<cellStyles\b[^>]*\/>/.exec(result) ??
+        /<\/cellXfs>|<cellXfs\b[^>]*\/>/.exec(result)
       if (anchor) {
         const at = anchor.index + anchor[0].length
         result = result.slice(0, at) + section + result.slice(at)
@@ -157,7 +163,10 @@ export class StylesheetEditor {
     if (this.numFmts.length > 0) {
       const section = `<numFmts count="${this.numFmts.length}">${this.numFmts.join('')}</numFmts>`
       if (sectionInner(result, 'numFmts') !== null) {
-        result = result.replace(/<numFmts\b[^>]*>[\s\S]*?<\/numFmts>|<numFmts\b[^>]*\/>/, () => section)
+        result = result.replace(
+          /<numFmts\b[^>]*>[\s\S]*?<\/numFmts>|<numFmts\b[^>]*\/>/,
+          () => section,
+        )
       } else {
         // Schema order: numFmts comes immediately before fonts.
         result = result.replace(/<fonts\b/, () => `${section}<fonts`)
@@ -202,14 +211,16 @@ const BUILTIN_NUMBER_FORMATS = new Map<string, number>([
 ])
 
 function hasFontDelta(delta: WorkbookStyleEdit): boolean {
-  return delta.bold !== undefined
-    || delta.italic !== undefined
-    || delta.underline !== undefined
-    || delta.underlineStyle !== undefined
-    || delta.strikethrough !== undefined
-    || delta.fontFamily !== undefined
-    || delta.fontSize !== undefined
-    || delta.fontColor !== undefined
+  return (
+    delta.bold !== undefined ||
+    delta.italic !== undefined ||
+    delta.underline !== undefined ||
+    delta.underlineStyle !== undefined ||
+    delta.strikethrough !== undefined ||
+    delta.fontFamily !== undefined ||
+    delta.fontSize !== undefined ||
+    delta.fontColor !== undefined
+  )
 }
 
 /// Applies the delta to a copy of the base font XML. Only overridden child
@@ -262,10 +273,12 @@ const BORDER_DELTA_KEYS = {
 } as const
 
 function hasBorderDelta(delta: WorkbookStyleEdit): boolean {
-  return delta.borderTop !== undefined
-    || delta.borderBottom !== undefined
-    || delta.borderLeft !== undefined
-    || delta.borderRight !== undefined
+  return (
+    delta.borderTop !== undefined ||
+    delta.borderBottom !== undefined ||
+    delta.borderLeft !== undefined ||
+    delta.borderRight !== undefined
+  )
 }
 
 /// Applies edge deltas to a copy of the base border XML. Children rebuild in
@@ -294,21 +307,26 @@ function buildBorder(baseBorderXml: string, delta: WorkbookStyleEdit): string {
 
 function buildAlignment(baseXf: string, delta: WorkbookStyleEdit): string {
   const baseAlignment = /<alignment\b[^>]*\/?>/.exec(baseXf)?.[0] ?? ''
-  const horizontal = delta.horizontalAlignment
-    ?? readAttribute(baseAlignment, 'horizontal')
-  const vertical = delta.verticalAlignment !== undefined
-    ? XLSX_VERTICAL[delta.verticalAlignment]
-    : readAttribute(baseAlignment, 'vertical')
-  const wrap = delta.wrapText !== undefined
-    ? delta.wrapText
-    : readAttribute(baseAlignment, 'wrapText') === '1'
+  const horizontal = delta.horizontalAlignment ?? readAttribute(baseAlignment, 'horizontal')
+  const vertical =
+    delta.verticalAlignment !== undefined
+      ? XLSX_VERTICAL[delta.verticalAlignment]
+      : readAttribute(baseAlignment, 'vertical')
+  const wrap =
+    delta.wrapText !== undefined ? delta.wrapText : readAttribute(baseAlignment, 'wrapText') === '1'
   // 0 clears the rotation (the attribute's absence is "no rotation").
-  const rotation = delta.textRotation !== undefined
-    ? (delta.textRotation === 0 ? undefined : String(delta.textRotation))
-    : readAttribute(baseAlignment, 'textRotation')
-  const indent = delta.indent !== undefined
-    ? (delta.indent === 0 ? undefined : String(delta.indent))
-    : readAttribute(baseAlignment, 'indent')
+  const rotation =
+    delta.textRotation !== undefined
+      ? delta.textRotation === 0
+        ? undefined
+        : String(delta.textRotation)
+      : readAttribute(baseAlignment, 'textRotation')
+  const indent =
+    delta.indent !== undefined
+      ? delta.indent === 0
+        ? undefined
+        : String(delta.indent)
+      : readAttribute(baseAlignment, 'indent')
   const attributes = [
     ...(horizontal ? [`horizontal="${horizontal}"`] : []),
     ...(vertical ? [`vertical="${vertical}"`] : []),
@@ -324,10 +342,10 @@ function buildAlignment(baseXf: string, delta: WorkbookStyleEdit): string {
 /// drops the element.
 function buildProtection(baseXf: string, delta: WorkbookStyleEdit): string {
   const baseProtection = /<protection\b[^>]*\/?>/.exec(baseXf)?.[0] ?? ''
-  const locked = delta.protectionLocked
-    ?? (readAttribute(baseProtection, 'locked') === '0' ? false : undefined)
-  const hidden = delta.protectionHidden
-    ?? (readAttribute(baseProtection, 'hidden') === '1' ? true : undefined)
+  const locked =
+    delta.protectionLocked ?? (readAttribute(baseProtection, 'locked') === '0' ? false : undefined)
+  const hidden =
+    delta.protectionHidden ?? (readAttribute(baseProtection, 'hidden') === '1' ? true : undefined)
   const attributes = [
     ...(locked === false ? ['locked="0"'] : []),
     ...(hidden === true ? ['hidden="1"'] : []),
@@ -364,9 +382,9 @@ function replaceSection(xml: string, tag: string, elements: readonly string[]): 
 }
 
 function extractElements(inner: string, tag: string): string[] {
-  return [...inner.matchAll(
-    new RegExp(`<${tag}\\b[^>]*/>|<${tag}\\b[^>]*>[\\s\\S]*?</${tag}>`, 'g'),
-  )].map((match) => match[0])
+  return [
+    ...inner.matchAll(new RegExp(`<${tag}\\b[^>]*/>|<${tag}\\b[^>]*>[\\s\\S]*?</${tag}>`, 'g')),
+  ].map((match) => match[0])
 }
 
 function readAttribute(element: string, name: string): string | undefined {

--- a/apps/sheets/src/gateway/xlsx-styles.ts
+++ b/apps/sheets/src/gateway/xlsx-styles.ts
@@ -305,6 +305,9 @@ function buildBorder(baseBorderXml: string, delta: WorkbookStyleEdit): string {
     : `<border${attributes}>${content}</border>`
 }
 
+/** CT_CellAlignment attributes with no model field; readingOrder is the cell's RTL flag */
+const ALIGNMENT_CARRIED = ['relativeIndent', 'justifyLastLine', 'shrinkToFit', 'readingOrder']
+
 function buildAlignment(baseXf: string, delta: WorkbookStyleEdit): string {
   const baseAlignment = /<alignment\b[^>]*\/?>/.exec(baseXf)?.[0] ?? ''
   const horizontal = delta.horizontalAlignment ?? readAttribute(baseAlignment, 'horizontal')
@@ -327,14 +330,39 @@ function buildAlignment(baseXf: string, delta: WorkbookStyleEdit): string {
         ? undefined
         : String(delta.indent)
       : readAttribute(baseAlignment, 'indent')
-  const attributes = [
+  const modeled = [
     ...(horizontal ? [`horizontal="${horizontal}"`] : []),
     ...(vertical ? [`vertical="${vertical}"`] : []),
     ...(wrap ? ['wrapText="1"'] : []),
     ...(rotation ? [`textRotation="${rotation}"`] : []),
     ...(indent ? [`indent="${indent}"`] : []),
   ]
+  // carrying must not create an <alignment> that would not otherwise exist, which would
+  // start applying an alignment the cell was inheriting; once the element is there anyway
+  // the cell already applies it, so the rest of its attributes belong with it
+  // applyAlignment is xsd:boolean, which spells true both ways
+  const applyAlignment = readCoreAttribute(baseXf, 'applyAlignment')
+  const applies = modeled.length > 0 || applyAlignment === '1' || applyAlignment === 'true'
+  const attributes =
+    applies && ownsItsAlignment(baseXf)
+      ? [...modeled, ...carriedAttributes(baseAlignment, ALIGNMENT_CARRIED)]
+      : modeled
   return attributes.length === 0 ? '' : `<alignment ${attributes.join(' ')}/>`
+}
+
+/**
+ * Whether the regex reads above can be trusted to have found the cell's own alignment.
+ * CT_Xf allows only alignment, protection and extLst, so an xf holding nothing but the
+ * first two cannot hide a second <alignment> or an applyAlignment belonging to someone
+ * else. Anything further, an extension or an mc:AlternateContent branch, could supply
+ * either, and a vendor's reading order is not the cell's; carry nothing and leave the
+ * result as it was.
+ */
+function ownsItsAlignment(xf: string): boolean {
+  for (const element of xf.matchAll(/<\/?([\w.-]+(?::[\w.-]+)?)/g)) {
+    if (!/^(xf|alignment|protection)$/.test(element[1] ?? '')) return false
+  }
+  return true
 }
 
 /// Merges protection flag deltas over the base xf's <protection>. Attributes
@@ -389,6 +417,19 @@ function extractElements(inner: string, tag: string): string[] {
 
 function readAttribute(element: string, name: string): string | undefined {
   return new RegExp(`\\b${name}="([^"]*)"`).exec(element)?.[1]
+}
+
+/** like readAttribute, but never matches a namespace-prefixed name */
+function readCoreAttribute(element: string, name: string): string | undefined {
+  return new RegExp(`(?<![\\w:.-])${name}="([^"]*)"`).exec(element)?.[1]
+}
+
+/** attributes the style model does not represent, kept verbatim off the base element */
+function carriedAttributes(element: string, names: readonly string[]): string[] {
+  return names.flatMap((name) => {
+    const value = readCoreAttribute(element, name)
+    return value === undefined ? [] : [`${name}="${value}"`]
+  })
 }
 
 function toArgb(hexColor: string): string {

--- a/apps/sheets/tests/xlsx-alignment-carry.test.ts
+++ b/apps/sheets/tests/xlsx-alignment-carry.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { StylesheetEditor } from '../src/gateway/xlsx-styles'
+
+/** An RTL cell as Excel writes it: right-aligned, explicit reading order, shrink to fit. */
+const STYLES = `<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="1"><font/></fonts>
+  <fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf/></cellStyleXfs>
+  <cellXfs count="2"><xf/><xf applyAlignment="1"><alignment horizontal="right" readingOrder="2" shrinkToFit="1" justifyLastLine="1" relativeIndent="2"/></xf></cellXfs>
+</styleSheet>`
+
+const CARRIED = ['readingOrder', 'shrinkToFit', 'justifyLastLine', 'relativeIndent']
+
+function xfAt(xml: string, index: number): string {
+  const cellXfs = /<cellXfs\b[^>]*>([\s\S]*?)<\/cellXfs>/.exec(xml)?.[1] ?? ''
+  const xfs = [...cellXfs.matchAll(/<xf\b[^>]*\/>|<xf\b[^>]*>[\s\S]*?<\/xf>/g)]
+  const xf = xfs[index]?.[0]
+  // every negative assertion below would pass against '' for the wrong reason
+  if (!xf) throw new Error(`no xf at index ${index} in: ${cellXfs}`)
+  return xf
+}
+
+describe('StylesheetEditor alignment carries', () => {
+  it('keeps the unmodeled alignment attributes through an unrelated edit', () => {
+    const editor = new StylesheetEditor(STYLES)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    for (const name of CARRIED) expect(xf).toContain(name)
+    // the edit itself still applies, and the modeled attributes still resolve
+    expect(xf).toContain('applyFill="1"')
+    expect(xf).toContain('horizontal="right"')
+  })
+
+  it('keeps them when the edit changes alignment itself', () => {
+    const editor = new StylesheetEditor(STYLES)
+    const index = editor.resolveStyle(1, { horizontalAlignment: 'center' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).toContain('horizontal="center"')
+    expect(xf).toContain('readingOrder="2"')
+  })
+
+  it('does not read a namespace-prefixed name off the alignment element', () => {
+    // the prefixed spelling is the only place these appear, so anything emitted came from it
+    const prefixed = STYLES.replace(
+      '<alignment horizontal="right" readingOrder="2" shrinkToFit="1" justifyLastLine="1" relativeIndent="2"/>',
+      '<alignment horizontal="right" x14:readingOrder="2" x14:shrinkToFit="1"/>',
+    )
+    const editor = new StylesheetEditor(prefixed)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    // positive witness: this really is the rebuilt xf, not some untouched entry
+    expect(xf).toContain('applyFill="1"')
+    expect(xf).not.toContain('readingOrder=')
+    expect(xf).not.toContain('shrinkToFit=')
+  })
+
+  it('does not let a namespaced applyAlignment decide the carry', () => {
+    const prefixed = STYLES.replace(
+      '<xf applyAlignment="1"><alignment horizontal="right" readingOrder="2"',
+      '<xf x14:applyAlignment="1"><alignment readingOrder="2"',
+    )
+    const editor = new StylesheetEditor(prefixed)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).toContain('applyFill="1"')
+    expect(xf).not.toContain('readingOrder=')
+  })
+
+  it('carries nothing when the xf holds an element that could own an alignment', () => {
+    // a vendor element can carry both an applyAlignment and an <alignment> of its own, and
+    // a regex cannot tell whose it found; main emits no alignment here at all
+    const vendor = STYLES.replace(
+      '<xf applyAlignment="1"><alignment horizontal="right" readingOrder="2" shrinkToFit="1" justifyLastLine="1" relativeIndent="2"/></xf>',
+      '<xf><settings xmlns="urn:vendor" applyAlignment="1"><alignment readingOrder="2"/></settings></xf>',
+    )
+    const editor = new StylesheetEditor(vendor)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).toContain('applyFill="1"')
+    expect(xf).not.toContain('<alignment')
+    expect(xf).not.toContain('applyAlignment')
+  })
+
+  it('carries nothing out of an mc:AlternateContent branch', () => {
+    // main already promotes this branch's horizontal, but horizontal="general" is the
+    // default and changes nothing on screen, whereas readingOrder="2" flips the cell
+    const alternate = STYLES.replace(
+      '<xf applyAlignment="1"><alignment horizontal="right" readingOrder="2" shrinkToFit="1" justifyLastLine="1" relativeIndent="2"/></xf>',
+      '<xf><mc:AlternateContent><mc:Choice Requires="x14">' +
+        '<alignment horizontal="general" readingOrder="2"/>' +
+        '</mc:Choice><mc:Fallback/></mc:AlternateContent></xf>',
+    )
+    const editor = new StylesheetEditor(alternate)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).toContain('applyFill="1"')
+    expect(xf).not.toContain('readingOrder=')
+  })
+
+  it('does not create an alignment out of carried attributes alone', () => {
+    // no modeled attribute and not applied: emitting one would start applying an
+    // alignment the cell was inheriting from its cellStyleXf
+    const carriedOnly = STYLES.replace(
+      '<xf applyAlignment="1"><alignment horizontal="right" readingOrder="2" shrinkToFit="1" justifyLastLine="1" relativeIndent="2"/></xf>',
+      '<xf><alignment readingOrder="2"/></xf>',
+    )
+    const editor = new StylesheetEditor(carriedOnly)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).not.toContain('<alignment')
+    expect(xf).not.toContain('applyAlignment')
+  })
+
+  it('carries them when a modeled attribute keeps the element alive anyway', () => {
+    // applyAlignment is absent, but horizontal survives, so the element is emitted
+    // regardless and the cell already applies whatever it holds
+    const notApplied = STYLES.replace('<xf applyAlignment="1">', '<xf>')
+    const editor = new StylesheetEditor(notApplied)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    expect(xf).toContain('horizontal="right"')
+    expect(xf).toContain('readingOrder="2"')
+  })
+
+  it('accepts applyAlignment spelled the other xsd:boolean way', () => {
+    const spelled = STYLES.replace('applyAlignment="1"', 'applyAlignment="true"')
+      // strip the modeled attribute so only the applyAlignment spelling can decide
+      .replace('horizontal="right" readingOrder="2"', 'readingOrder="2"')
+    const editor = new StylesheetEditor(spelled)
+    const index = editor.resolveStyle(1, { fillColor: '#FF0000' })
+    expect(xfAt(editor.serialize(), index)).toContain('readingOrder="2"')
+  })
+
+  it('adds nothing when the base has none of them', () => {
+    const editor = new StylesheetEditor(STYLES)
+    const index = editor.resolveStyle(0, { fillColor: '#FF0000' })
+    const xf = xfAt(editor.serialize(), index)
+    for (const name of CARRIED) expect(xf).not.toContain(name)
+  })
+})


### PR DESCRIPTION
## Summary

**What changed?**

`resolveStyle` rebuilds a cell's `<alignment>` from a five-field model, so the four `CT_CellAlignment` attributes the model has no field for are dropped the moment any unrelated edit touches that cell's `xf`. One of them is `readingOrder`, the cell's right-to-left flag.

**Why is this change needed?**

`buildAlignment` reads `horizontal`, `vertical`, `wrapText`, `textRotation` and `indent`, then emits a fresh element from exactly those:

```js
const attributes = [
  ...(horizontal ? [`horizontal="${horizontal}"`] : []),
  ...(vertical ? [`vertical="${vertical}"`] : []),
  ...(wrap ? ['wrapText="1"'] : []),
  ...(rotation ? [`textRotation="${rotation}"`] : []),
  ...(indent ? [`indent="${indent}"`] : []),
]
```

Anything else the cell had is gone. Changing a fill colour on a cell in an Arabic or Hebrew workbook silently rewrites it left-to-right:

```
before  <alignment horizontal="right" readingOrder="2" shrinkToFit="1"/>
after   <alignment horizontal="right"/>
```

`shrinkToFit`, `justifyLastLine` and `relativeIndent` go the same way. This is item 6 of #13, which noted that `readingOrder` in xlsx cell alignment looked unhandled.

**The part worth reviewing: where the values are read from**

Carrying attributes means reading them off the original `xf`, and this file locates elements with regular expressions. An earlier revision of this patch tried to make that extraction stricter than the file's own, adding helpers that stripped `<extLst>` and matched only the `xf`'s start tag. Each round of hardening opened a new hole (a `>` inside an attribute value, nested `<extLst>`, `mc:AlternateContent`), so I removed all of it.

What is left reads the carried attributes off **the same `<alignment>` element the modeled attributes are already read from**, and carries them **only when the `xf` holds nothing but its own `alignment` and `protection`**:

```js
function ownsItsAlignment(xf) {
  for (const element of xf.matchAll(/<\/?([\w.-]+(?::[\w.-]+)?)/g)) {
    if (!/^(xf|alignment|protection)$/.test(element[1] ?? '')) return false
  }
  return true
}
```

That restriction is the part worth reviewing, and it is there because a regex cannot tell whose element it found. Two concrete cases, both of which this rejects:

```
<xf><settings xmlns="urn:vendor" applyAlignment="1"><alignment readingOrder="2"/></settings></xf>
<xf><mc:AlternateContent><mc:Choice Requires="x14">
      <alignment horizontal="general" readingOrder="2"/>
    </mc:Choice><mc:Fallback/></mc:AlternateContent></xf>
```

Without the restriction the first invents an alignment on a cell where `main` emits none, and the second flips the cell right-to-left. The second is worth being precise about: `main` already promotes that branch's `horizontal`, so promoting from there is not new, but `horizontal="general"` is the default and changes nothing on screen while `readingOrder="2"` reverses the text. Same element, materially different consequence, so "no worse than the `horizontal` next to it" would not have been a fair defence.

`CT_Xf` allows only `alignment`, `protection` and `extLst`, so an `xf` holding nothing but the first two cannot hide a second `<alignment>` or an `applyAlignment` belonging to someone else. Anything further and nothing is carried, which leaves that cell exactly as it is today. The existing extraction stays approximate in ways this patch deliberately does not change, for example `readAttribute` matching `\bname="..."` across the whole `xf`; those are separate problems and I would rather not fold them in here.

The one guard the carry does need:

```js
const applies = modeled.length > 0 || isXmlTrue(readCoreAttribute(baseXf, 'applyAlignment'))
```

Building an `<alignment>` out of carried attributes alone would start *applying* an alignment the cell was previously inheriting from its `cellStyleXf`. When no modeled attribute survives and `applyAlignment` is not set, the element is dropped exactly as it is today. `isXmlTrue` accepts both `"1"` and `"true"`, since `applyAlignment` is `xsd:boolean` and both spellings appear in the wild.

**Two commits**

`xlsx-styles.ts` predates the formatter, so touching it reformats around 100 unrelated lines. The first commit is prettier only, the second is the change. Reviewing the second alone should be enough.

## Related issue

Item 6 of #13, the sheets half of RTL support. This is a fidelity fix rather than a feature: nothing new is exposed in the UI, an RTL workbook simply stops losing its reading order on an unrelated edit.

## Validation

- [x] `npm test`: exits 0. `apps/sheets` 1003 passed, 1 skipped, 85 files
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors on the changed files
- [x] `npm run format:check`: `All matched files use Prettier code style!`
- [x] 10 new cases; **4 fail against `main`** and pass here, verified by swapping in `origin/main`'s `xlsx-styles.ts` and re-running. The other 6 are negative guards that should pass either way; the two newest of those fail if the `ownsItsAlignment` restriction is removed, so they are not decorative.

The test helper throws when it cannot find the `xf` it is asked for, so the negative assertions cannot pass against an empty string.

## Screenshots or recordings

Not applicable, the defect is in the saved XML. Reproduction: open an RTL workbook, change any cell's fill colour, save, reopen.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring. (The reformatting is isolated in its own commit.)
- [x] User-facing strings use the existing i18n resources. (Not applicable, no strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test.
