### PR TITLE
fix(docx): declare the prefixes a regenerated part writes, not only the inherited ones

### DIFF
--- a/packages/docx-engine/src/notes.ts
+++ b/packages/docx-engine/src/notes.ts
@@ -35,19 +35,27 @@ const NOTE_NS =
   'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
 
 /**
- * Root attributes for a regenerated part. Entries are spliced back in as original bytes, so
- * the root has to keep declaring whatever prefixes those bytes use: Word puts w14:paraId on
- * every paragraph it writes, and a literal namespace list leaves that prefix unbound.
+ * Root attributes for a regenerated part. The part mixes two sources, so the root has to
+ * declare the prefixes of both: entries spliced back in as original bytes may use anything
+ * the original root declared (Word puts w14:paraId on every paragraph it writes), and
+ * entries this engine writes use the prefixes in `required`. Keeping only one side leaves
+ * the other unbound, which Word reports as unreadable content.
  */
 export function rootAttributes(
   originalXml: string | null,
   rootTag: string,
-  fallback: string,
+  required: string,
 ): string {
   const attrs = originalXml
     ? new RegExp(`<${rootTag}\\b([^>]*?)/?>`).exec(originalXml)?.[1]?.trim()
     : undefined
-  return attrs && attrs.includes('xmlns:') ? attrs : fallback
+  if (!attrs || !attrs.includes('xmlns:')) return required
+  const prefixOf = (declaration: string) => /xmlns:([\w.-]+)=/.exec(declaration)?.[1] ?? ''
+  const declared = new Set([...attrs.matchAll(/xmlns:[\w.-]+=/g)].map((m) => prefixOf(m[0])))
+  const missing = [...required.matchAll(/xmlns:[\w.-]+="[^"]*"/g)]
+    .map((m) => m[0])
+    .filter((declaration) => !declared.has(prefixOf(declaration)))
+  return missing.length === 0 ? attrs : `${attrs} ${missing.join(' ')}`
 }
 
 /** real notes (separator entries excluded), in file order */

--- a/packages/docx-engine/tests/part-namespaces.test.ts
+++ b/packages/docx-engine/tests/part-namespaces.test.ts
@@ -60,3 +60,29 @@ describe('regenerated part namespaces', () => {
     )
   })
 })
+
+describe('regenerated parts declare what they write, not only what they inherited', () => {
+  // comments.xml is the case that bites: buildCommentsXml stamps w14:paraId on every
+  // comment it writes, so reusing a root that declares only w leaves that prefix unbound.
+  it('adds a required prefix the original root did not declare', () => {
+    const original =
+      '<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+    const required =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+      'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"'
+    const out = rootAttributes(original, 'w:comments', required)
+    expect(out).toContain('xmlns:w14=')
+    expect(unboundPrefixes(`<w:comments ${out}><w:p w14:paraId="1"/></w:comments>`)).toEqual([])
+  })
+
+  it('still keeps a prefix only the original had', () => {
+    const original =
+      '<w:comments xmlns:w="W" xmlns:r="R" xmlns:w14="W14" xmlns:mc="MC" mc:Ignorable="w14">'
+    const out = rootAttributes(original, 'w:comments', 'xmlns:w="W" xmlns:w14="W14"')
+    for (const prefix of ['xmlns:w=', 'xmlns:r=', 'xmlns:w14=', 'xmlns:mc=']) {
+      expect(out).toContain(prefix)
+    }
+    // and does not duplicate one both sides declare
+    expect(out.match(/xmlns:w14=/g)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

**What changed?**

#63 made regenerated parts reuse the original part's root attributes, so entries spliced back in as their original bytes keep their prefixes bound. That was right for footnotes and endnotes, and it left `comments.xml` half fixed. `buildCommentsXml` does not only splice: it also **generates** `w14:paraId`, and the original root is free not to declare `w14`.

This is a gap in my own change, not a pre-existing one.

**Why is this change needed?**

`saveDocx` stamps a `paraId` on every comment (`patch.ts:748-758`), and `buildCommentsXml` writes it onto the last paragraph of each comment it rebuilds (`patch.ts:1392-1394`). The root now comes from the original part, and `w14` is a Word 2010 extension namespace rather than part of the base schema, so a document whose `comments.xml` declares only `w` is perfectly legal. This repo's own fixture is exactly that shape (`tests/comments.test.ts:10`):

```xml
<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
```

Adding a comment to such a document, or editing one in a way that changes its paragraph count so the surgical patch falls back to a rebuild, emits `w14:paraId` with nothing binding it. Before #63 the hardcoded list always bound `w14`, so this is a regression I introduced rather than an old gap.

**The fix**

A regenerated part mixes two sources, so its root has to declare the prefixes of both. `rootAttributes` now keeps everything the original root had and adds only what the engine needs and the original lacked, instead of choosing one list or the other:

```js
const declared = new Set([...attrs.matchAll(/xmlns:[\w.-]+=/g)].map((m) => prefixOf(m[0])))
const missing = [...required.matchAll(/xmlns:[\w.-]+="[^"]*"/g)]
  .map((m) => m[0])
  .filter((declaration) => !declared.has(prefixOf(declaration)))
```

A prefix both sides declare is not duplicated, and a prefix only the original had, `mc` or `r` for instance, still survives, which is what #63 was for.

## Related issue

Follow-up to #63.

## Validation

- [x] `npm test`: exits 0. `packages/docx-engine` 455 passed, 1 skipped, 55 files
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors on the changed files
- [x] `npm run format:check`: `All matched files use Prettier code style!`
- [x] `adds a required prefix the original root did not declare` fails against `main` and passes here, verified by swapping in `origin/main`'s `notes.ts` and re-running
- [x] `still keeps a prefix only the original had` guards the #63 behaviour in the other direction and passes either way by design

As in #63 the test checks prefix binding directly rather than calling `XMLValidator`, which is not namespace-aware and reports all of these as valid.

## Screenshots or recordings

Not applicable, the defect is in the saved XML. Reproduction: open a document whose `comments.xml` declares only `w`, add a comment, save, reopen in Word.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable, no strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test.
