### PR TITLE
fix(docx): do not read a nil paragraph border as a real one

### DIFF
--- a/packages/docx-engine/src/parse.ts
+++ b/packages/docx-engine/src/parse.ts
@@ -1387,7 +1387,10 @@ function extractParaFormat(pPr: XNode): ParaFormat | undefined {
       ['right', 'r'],
     ] as const) {
       const el = findChild(pBdr, `w:${side}`)
-      if (el && attrsOf(el)['w:val'] !== 'none') borders += ch
+      // ST_Border spells "no border" both ways, and Word writes nil whenever a style-level
+      // border is reset, so treating it as present stamps a rule the document never had
+      const val = el ? attrsOf(el)['w:val'] : undefined
+      if (el && val !== 'none' && val !== 'nil') borders += ch
     }
     if (borders) format.borders = borders
   }

--- a/packages/docx-engine/tests/header-footer-rich.test.ts
+++ b/packages/docx-engine/tests/header-footer-rich.test.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip'
 import { describe, expect, it } from 'vitest'
 import { parseDocx, saveDocx, TOTAL_PAGES_MARK, type SaveBlock } from '../src/index'
 import { buildDocx } from './helpers/build-docx'
@@ -224,5 +225,50 @@ describe('header edits keep image paragraphs', () => {
     expect(hdr).toContain(LOGO_P) // the logo paragraph keeps its original bytes
     expect(hdr).toContain('新页眉文字')
     expect(hdr).not.toContain('旧页眉文字')
+  })
+})
+
+describe('header paragraph borders', () => {
+  const HDR_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+
+  /** a header whose side borders are reset with w:val="nil", as a style-level reset writes them */
+  async function withNilBorderHeader() {
+    const bytes = await buildDocx({
+      bodyXml: '<w:p><w:r><w:t>body</w:t></w:r></w:p>',
+      sectPrExtra: '<w:headerReference w:type="default" r:id="rIdHdr"/>',
+      extraRels:
+        '<Relationship Id="rIdHdr" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>',
+      extraParts: [
+        {
+          path: 'word/header1.xml',
+          xml:
+            `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:hdr ${HDR_NS}>` +
+            '<w:p><w:pPr><w:pBdr><w:top w:val="nil"/><w:left w:val="nil"/><w:right w:val="nil"/>' +
+            '<w:bottom w:val="single" w:sz="18" w:color="4472C4"/></w:pBdr></w:pPr>' +
+            '<w:r><w:t>Quarterly report</w:t></w:r></w:p></w:hdr>',
+          contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
+        },
+      ],
+    })
+    return parseDocx(bytes)
+  }
+
+  it('does not read a nil side as a border', async () => {
+    const parsed = await withNilBorderHeader()
+    expect(parsed.headerParas?.[0]?.borders).toBe('b')
+  })
+
+  it('does not stamp rules the header never had when it is saved back', async () => {
+    const parsed = await withNilBorderHeader()
+    const blocks: SaveBlock[] = [{ kind: 'original', docxIndex: parsed.blocks[0].docxIndex! }]
+    const saved = await saveDocx(parsed, blocks, {
+      header: { text: '', paras: parsed.headerParas ?? [] },
+    })
+    const header = await (await JSZip.loadAsync(saved)).file('word/header1.xml')!.async('text')
+    const pBdr = /<w:pBdr>[\s\S]*?<\/w:pBdr>/.exec(header)?.[0] ?? ''
+    expect(pBdr).toContain('<w:bottom ')
+    for (const side of ['<w:top ', '<w:left ', '<w:right ']) {
+      expect(pBdr).not.toContain(side)
+    }
   })
 })


### PR DESCRIPTION
## Summary

**What changed?**

`ST_Border` spells "no border" two ways, `none` and `nil`, and `extractParaFormat` only knew the first:

```js
if (el && attrsOf(el)['w:val'] !== 'none') borders += ch
```

So every `nil` side was recorded as a border that exists. Word writes `nil` whenever a style-level border is reset, which is common in real documents.

**Why is this change needed?**

This was harmless while nothing in production rebuilt a paragraph's properties from the format model alone. #62 changed that: header and footer paragraphs now go through `mergePPrFormat`, and `formatPPrChildren` re-emits every recorded side as a real rule (`generate.ts:889-894`). A header carrying one blue bottom rule and three `nil` sides comes back with four solid black ones.

Round trip through `parseDocx` then `saveDocx` with a real `word/header1.xml` part:

```
in the document
  <w:top w:val="nil"/><w:left w:val="nil"/><w:right w:val="nil"/>
  <w:bottom w:val="single" w:sz="18" w:color="4472C4"/>

parsed          headerParas[0].borders = "tblr"      <- three phantom sides
saved header    <w:pBdr><w:top .../><w:left .../><w:bottom .../><w:right .../></w:pBdr>
                all four w:val="single" w:sz="4" w:color="auto"
```

`file-actions.ts:197-204` seeds the header context from the parse and passes it straight back on save, so editing one character of header text is enough to stamp a box around it. With the fix the parse yields `"b"` and the saved header keeps its single bottom rule.

Body paragraphs are unaffected either way, because they keep their original `pPr` bytes through the merge branch rather than being rebuilt.

**What this does not fix**

The format model records *which* sides have a border, not how they look, so the surviving bottom rule is still rewritten from `sz="18" color="4472C4"` to `sz="4" color="auto"`. That predates #62 and is a separate change; headers dropped their borders entirely before #62, so it is not a new loss, but I did not want to imply it is solved.

## Related issue

Follow-up to #62, which made a latent parse gap reachable.

## Validation

- [x] `npm test`: exits 0. `packages/docx-engine` 455 passed, 1 skipped, 55 files
- [x] `npm run typecheck`: clean
- [x] `npm run lint`: 0 errors on the changed files
- [x] `npm run format:check`: `All matched files use Prettier code style!`
- [x] Both new cases fail against `main` and pass here, verified by swapping in `origin/main`'s `parse.ts` and re-running:
  - `does not read a nil side as a border` (the read)
  - `does not stamp rules the header never had when it is saved back` (the write)

## Screenshots or recordings

Not applicable, the defect is in the saved XML, though its effect is visible in Word: four black rules around a header paragraph that had one blue rule under it.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Not applicable, no strings.)
- [x] File open/save changes include an appropriate round-trip or fidelity test.
