### PR TITLE
fix(shell): keep file actions menu in viewport

### DIFF
--- a/apps/shell/src/renderer/src/Home.tsx
+++ b/apps/shell/src/renderer/src/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { ReactElement } from 'react'
 import logoLockup from './assets/genoffice-logo.svg'
 import iconDocx from './assets/file-docx.svg'
@@ -1481,7 +1481,14 @@ export function Home() {
   // Genspark web projects take over the content area (like a selected project)
   const [cloudMode, setCloudMode] = useState(false)
   const [filter, setFilter] = useState('all')
-  const [rowMenu, setRowMenu] = useState<string | null>(null)
+  const [rowMenu, setRowMenu] = useState<{
+    path: string
+    right: number
+    anchorTop: number
+    anchorBottom: number
+    openUpward: boolean
+  } | null>(null)
+  const rowMenuRef = useRef<HTMLDivElement>(null)
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set())
   const [renaming, setRenaming] = useState<{ path: string; value: string } | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null)
@@ -1607,7 +1614,7 @@ export function Home() {
     if (rowMenu === null && confirmDelete === null) return
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as Element | null
-      if (rowMenu !== null && !target?.closest?.('.recent-actions')) setRowMenu(null)
+      if (rowMenu !== null && !target?.closest?.('.recent-actions, .row-menu')) setRowMenu(null)
     }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -1622,6 +1629,23 @@ export function Home() {
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [rowMenu, confirmDelete])
+
+  // Measure the rendered menu instead of relying on an action-count estimate.
+  // Some rows include project actions, so the actual height can differ enough
+  // that an estimate opens the menu on the wrong side of its trigger.
+  useLayoutEffect(() => {
+    if (rowMenu === null || rowMenuRef.current === null) return
+
+    const gap = 6
+    const menuHeight = rowMenuRef.current.getBoundingClientRect().height
+    const spaceBelow = window.innerHeight - rowMenu.anchorBottom - gap
+    const spaceAbove = rowMenu.anchorTop - gap
+    const openUpward = menuHeight > spaceBelow && spaceAbove > spaceBelow
+
+    if (openUpward !== rowMenu.openUpward) {
+      setRowMenu({ ...rowMenu, openUpward })
+    }
+  }, [rowMenu])
 
   // ── Project files state ────────────────────────────────
 
@@ -1960,8 +1984,23 @@ export function Home() {
             <button
               className="more-btn"
               aria-label={t('moreActions')}
-              aria-expanded={rowMenu === entry.path}
-              onClick={() => setRowMenu(rowMenu === entry.path ? null : entry.path)}
+              aria-expanded={rowMenu?.path === entry.path}
+              onClick={(event) => {
+                if (rowMenu?.path === entry.path) {
+                  setRowMenu(null)
+                  return
+                }
+                const rect = event.currentTarget.getBoundingClientRect()
+                setRowMenu({
+                  path: entry.path,
+                  right: Math.max(8, window.innerWidth - rect.right),
+                  anchorTop: rect.top,
+                  anchorBottom: rect.bottom,
+                  // Render downward first, then use the actual menu height to
+                  // flip only when opening upward provides more visible space.
+                  openUpward: false,
+                })
+              }}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                 <circle cx="3.2" cy="8" r="1.4" fill="currentColor" />
@@ -1969,8 +2008,20 @@ export function Home() {
                 <circle cx="12.8" cy="8" r="1.4" fill="currentColor" />
               </svg>
             </button>
-            {rowMenu === entry.path && (
-              <div className="row-menu" role="menu">
+            {rowMenu?.path === entry.path && (
+              <div
+                className="row-menu"
+                role="menu"
+                ref={rowMenuRef}
+                style={
+                  rowMenu.openUpward
+                    ? {
+                        right: rowMenu.right,
+                        bottom: Math.max(8, window.innerHeight - rowMenu.anchorTop + 6),
+                      }
+                    : { right: rowMenu.right, top: rowMenu.anchorBottom + 6 }
+                }
+              >
                 <button
                   role="menuitem"
                   onClick={() => {

--- a/apps/shell/src/renderer/src/home.css
+++ b/apps/shell/src/renderer/src/home.css
@@ -1029,11 +1029,11 @@ body.vib .home {
 }
 
 .row-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 20;
+  position: fixed;
+  z-index: 40;
   min-width: 160px;
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: 6px;
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

- Positions the Home screen’s file-actions menu relative to the viewport.
- Measures the rendered menu and opens it upward when there is more available space above the trigger.
- Constrains the menu height to the viewport so its actions remain reachable.

## Why is this change needed?

The file-actions menu could extend beyond the bottom of the Home screen, making actions inaccessible. Estimating menu height was unreliable because different file types expose different actions.

## Related issue

Closes #

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

Focused validation completed:

- [x] `npx.cmd prettier --check apps/shell/src/renderer/src/Home.tsx apps/shell/src/renderer/src/home.css`
- [x] `npm.cmd run typecheck -w @genoffice/shell`
- [x] `git diff --check`

Checks not run:

- Full repository format, lint, typecheck, and test suites were not run locally because they cover the entire monorepo and are handled by CI.
- Manual Electron visual verification was not run for this separate PR.

## Screenshots or recordings

Not available. The change affects the menu position near the bottom of the Home screen.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.