### PR TITLE
fix(docx): keep table cell paragraph properties through a rebuild

### DIFF
--- a/packages/docx-engine/src/generate.ts
+++ b/packages/docx-engine/src/generate.ts
@@ -1221,9 +1221,13 @@ export function mergePPrFormat(rawPPr: string, format: ParaFormat | undefined): 
   const rebuilt = new Set(
     [...managedTags].filter((tag) => !pprGroupUnchanged(tag, rawOf(tag), format ?? {})),
   )
-  const freshOut = fresh.filter((c) => rebuilt.has(c.name))
-  const kept = rawChildren.filter((c) => !rebuilt.has(c.name))
   const rank = (n: string) => PPR_CHILD_ORDER.indexOf(n)
+  // the interleave below walks freshOut once with a monotonic index, so it has to arrive in
+  // schema order; formatPPrChildren emits by concern and leaves framePr and tabs until last
+  const freshOut = fresh
+    .filter((c) => rebuilt.has(c.name))
+    .sort((a, b) => rank(a.name) - rank(b.name))
+  const kept = rawChildren.filter((c) => !rebuilt.has(c.name))
   const parts: string[] = []
   let fi = 0
   let prevRank = -1
@@ -1489,14 +1493,22 @@ function tableCellXml(
         runs: text === '' ? [] : [{ text, bold: cell.bold, color: cell.color }],
       }))
   const paraXmls = paragraphs.map((paragraph) => {
-    const align = paragraph.align ?? cell.align
+    // cell.align is a raw w:jc, so it is Word's logical value, while paragraph.align has already
+    // been converted to a visual one and the format model converts it back on the way out. Only
+    // left and right differ between the two, so an RTL paragraph still takes the cell fallback
+    // for centre and justify and skips it for the sided values, which cannot be placed in either
+    // coordinate system with confidence.
+    const bidi = 'bidi' in paragraph && paragraph.bidi === true
+    const sided = cell.align === 'left' || cell.align === 'right'
+    const align = paragraph.align ?? (bidi && sided ? undefined : cell.align)
     const list = 'list' in paragraph ? paragraph.list : undefined
-    // schema order inside pPr: numPr before jc
     const numPr = list
       ? `<w:numPr><w:ilvl w:val="${list.ilvl}"/><w:numId w:val="${escapeXmlAttr(list.numId)}"/></w:numPr>`
       : ''
-    const jc = align ? `<w:jc w:val="${align === 'justify' ? 'both' : align}"/>` : ''
-    const pPr = numPr || jc ? `<w:pPr>${numPr}${jc}</w:pPr>` : ''
+    // the parsed format, not just w:jc: hand-building it here dropped w:bidi and wrote the visual
+    // align back as the logical one, flipping RTL cells to LTR, and discarded every other
+    // paragraph property the model carries
+    const pPr = mergePPrFormat(`<w:pPr>${numPr}</w:pPr>`, { ...paragraph, align })
     return `<w:p>${pPr}${runsXml(paragraph.runs, null)}</w:p>`
   })
   // nested tables are regenerated from the model at their paragraph anchors (reverse

--- a/packages/docx-engine/tests/schema-order.test.ts
+++ b/packages/docx-engine/tests/schema-order.test.ts
@@ -102,3 +102,25 @@ describe('pPr schema order (mergePPrFormat)', () => {
     assertSchemaOrder(mergePPrFormat('<w:pPr/>', format), 'w:pPr', PPR_CHILD_ORDER)
   })
 })
+
+describe('CT_PPr order through the interleave branch', () => {
+  // A raw pPr that already has children takes the merge path instead of the fresh-build one.
+  // That path walks the fresh children once with a monotonic index, so they have to reach it
+  // in schema order; formatPPrChildren emits by concern and leaves framePr and tabs until last.
+  const WITH_NUMPR = '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>'
+
+  it.each([
+    ['tabs + align', { align: 'center' as const, tabStops: [{ pos: 720, val: 'left' as const }] }],
+    [
+      'framePr + tabs + bidi + align',
+      {
+        align: 'center' as const,
+        bidi: true,
+        tabStops: [{ pos: 1440, val: 'right' as const }],
+        dropCap: { type: 'drop' as const, lines: 3 },
+      },
+    ],
+  ])('%s keeps CT_PPr child order when merged into an existing pPr', (_label, format) => {
+    assertSchemaOrder(mergePPrFormat(WITH_NUMPR, format), 'w:pPr', PPR_CHILD_ORDER)
+  })
+})

--- a/packages/docx-engine/tests/table-edit.test.ts
+++ b/packages/docx-engine/tests/table-edit.test.ts
@@ -258,3 +258,71 @@ describe('tblStyleId table style reference', () => {
     expect(kept).toContain('<w:tblStyle w:val="TableGrid"/>')
   })
 })
+
+describe('cell paragraph properties survive a table rebuild', () => {
+  /** Word writes an RTL cell as w:bidi plus a LOGICAL w:jc: "left" means start, i.e. flush right. */
+  const RTL_TABLE =
+    '<w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:bidiVisual/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+    '<w:tr>' +
+    '<w:tc><w:p><w:pPr><w:bidi/><w:jc w:val="left"/><w:spacing w:after="80"/>' +
+    '<w:ind w:left="120"/><w:shd w:val="clear" w:color="auto" w:fill="DDEEFF"/>' +
+    '</w:pPr><w:r><w:t>الاسم</w:t></w:r></w:p></w:tc>' +
+    '<w:tc><w:p><w:pPr><w:bidi/></w:pPr><w:r><w:t>القيمة</w:t></w:r></w:p></w:tc>' +
+    '</w:tr></w:tbl>'
+
+  const rebuild = async (tableXml: string) => {
+    const doc = await parseDocx(await buildDocx({ bodyXml: tableXml }))
+    const model = doc.blocks.find((b) => b.table)?.table
+    expect(model).toBeDefined()
+    return generateTableModelXml(model!)
+  }
+
+  it('keeps w:bidi and writes the logical w:jc back', async () => {
+    const out = await rebuild(RTL_TABLE)
+    expect(out.match(/<w:bidi\/>/g)).toHaveLength(2)
+    // parsed as visual "right", so Word's logical value on the way out is "left"
+    expect(out.match(/<w:jc w:val="[^"]*"\/>/g)).toEqual(['<w:jc w:val="left"/>'])
+  })
+
+  it('leaves a bidi cell that declared no alignment without one', async () => {
+    const out = await rebuild(RTL_TABLE)
+    // the second cell had w:bidi and no w:jc; dropping w:bidi would flip it from the RTL
+    // default (flush right) to the LTR default (flush left)
+    const second = out.slice(out.lastIndexOf('<w:tc>'))
+    expect(second).toContain('<w:bidi/>')
+    expect(second).not.toContain('<w:jc ')
+  })
+
+  it('keeps spacing, indent and shading', async () => {
+    const out = await rebuild(RTL_TABLE)
+    expect(out).toContain('<w:spacing w:after="80"/>')
+    expect(out).toContain('<w:ind w:left="120"/>')
+    expect(out).toContain('<w:shd w:val="clear" w:color="auto" w:fill="DDEEFF"/>')
+  })
+
+  it('still falls back to the cell alignment for a paragraph that declared none', async () => {
+    // control: this case is unchanged from before, and passes with or without the fix
+    const out = await rebuild(
+      '<w:tbl><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+        '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>a</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>b</w:t></w:r></w:p>' +
+        '</w:tc></w:tr></w:tbl>',
+    )
+    expect(out.match(/<w:jc w:val="center"\/>/g)).toHaveLength(2)
+  })
+
+  it('keeps a direction-neutral cell alignment on a bidi paragraph', async () => {
+    // only left/right are swapped between logical and visual, so centre and justify are safe
+    // to take from the cell even when the paragraph is RTL
+    const out = await rebuild(
+      '<w:tbl><w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid><w:tr><w:tc>' +
+        '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>a</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:bidi/></w:pPr><w:r><w:t>عربي</w:t></w:r></w:p>' +
+        '</w:tc></w:tr></w:tbl>',
+    )
+    const second = out.slice(out.lastIndexOf('<w:p>'))
+    expect(second).toContain('<w:bidi/>')
+    expect(second).toContain('<w:jc w:val="center"/>')
+  })
+})


### PR DESCRIPTION
`tableCellXml` hand-builds each cell paragraph's `w:pPr` from `w:numPr` and `w:jc` alone, so every other property the parser captured is discarded when a structural table edit regenerates the table. `w:bidi` is one of them.

## What it looks like

Word writes an RTL cell as `w:bidi` plus a **logical** `w:jc`, where `left` means start and renders flush right. `extractParaFormat` converts that to a visual value, and the hand-built emitter wrote the visual value back as though it were the logical one.

Same input table through `parseDocx` + `generateTableModelXml`, `origin/main` sources against this branch:

| | `origin/main` | this branch |
|---|---|---|
| `<w:bidi/>` | 0 | 2 |
| `w:jc` | `right` | `left` |
| `w:spacing` / `w:ind` / `w:shd` | dropped | kept |

Two distinct failures. The cell that declared `<w:bidi/><w:jc w:val="left"/>` comes back LTR. The cell that declared `<w:bidi/>` and no `w:jc` comes back with no `w:pPr` at all, so it moves from the RTL default (flush right) to the LTR default (flush left). The table keeps `w:bidiVisual` from its original `tblPr` throughout, so the result is right-to-left columns holding left-to-right paragraphs, which is a shape Word never writes.

## The fix

Route the cell through `mergePPrFormat`, the helper #62 used for the same defect in headers and footers. Shading, spacing, indent, page-break-before, paragraph borders, tab stops and the drop-cap frame come back with it.

### A prerequisite inside `mergePPrFormat`

Its interleave branch walks the fresh children once with a monotonic index, so they have to arrive in schema order, but only the fresh-build branch sorted them. `formatPPrChildren` emits by concern and leaves `framePr` and `tabs` until last, so a paragraph carrying a tab stop came back as `w:jc` followed by `w:tabs`, which is the ordering Word offers to repair. Every table paragraph takes the interleave branch, so this had to be correct before the rest could be. The fresh children are now sorted on both branches, and `tests/schema-order.test.ts` gains coverage for the branch that had none.

### The alignment trap

`cell.align` is read straight off `w:jc` at `parse.ts:2506`, so it holds Word's logical value, while `paragraph.align` has already been converted to a visual one. Only `left` and `right` differ between the two, so a bidi paragraph takes the cell fallback for `center` and `justify` and skips it for the sided values, where the cell value cannot be placed in either coordinate system with confidence. Outside bidi the fallback is unchanged.

## Verification

Six of the seven added cases fail against `origin/main` sources and pass here. The seventh, `still falls back to the cell alignment for a paragraph that declared none`, passes on both: it is a control for the path that should not change, not regression coverage.

`packages/docx-engine` 532 passed, `apps/docs` 733 passed.

## What this does not fix

- `keepNext`, `keepLines`, `widowControl` and `contextualSpacing` are parsed into the format model, but `formatPPrChildren` emits none of them, so they are still lost on every rebuild, in tables and elsewhere alike.
- `w:tblPrEx` is neither parsed nor emitted, so a row-level property exception is still dropped.
- A cell paragraph carries neither `rawPPr` nor `pPrChange`, so a paragraph-level tracked revision inside a cell does not survive regeneration. That is equally true before this change.
