### PR TITLE
fix(docx): carry bold and italic to complex-script text

### DIFF
--- a/packages/docx-engine/src/generate.ts
+++ b/packages/docx-engine/src/generate.ts
@@ -2014,6 +2014,10 @@ function revisionRPrChangeXml(run: Run): string | null {
   const props: string[] = []
   if (old.styleId) props.push(`<w:rStyle w:val="${escapeXmlAttr(old.styleId)}"/>`)
   if (old.font || old.fontAscii) props.push(freshRFontsXml(old.font, old.fontAscii))
+  // no Cs twins here: this nested w:rPr records what the run looked like before the tracked
+  // revision, and old.bold cannot tell w:b from w:b plus w:bCs. Adding them would invent a
+  // complex-script flag the document never had, so rejecting the revision would bold Arabic
+  // that was never bold.
   if (old.bold) props.push('<w:b/>')
   if (old.italic) props.push('<w:i/>')
   if (old.strike) props.push('<w:strike/>')
@@ -2043,8 +2047,14 @@ function modelRPrChildren(run: Run, insideLink: boolean): PPrChild[] {
   if (run.font || run.fontAscii) {
     out.push({ name: 'w:rFonts', xml: freshRFontsXml(run.font, run.fontAscii) })
   }
-  if (run.bold) out.push({ name: 'w:b', xml: '<w:b/>' })
-  if (run.italic) out.push({ name: 'w:i', xml: '<w:i/>' })
+  // the Cs twins carry the same flag for complex-script text; without them clicking Bold
+  // on Arabic or Hebrew changes nothing on screen, which is what Word writes too
+  if (run.bold) {
+    out.push({ name: 'w:b', xml: '<w:b/>' }, { name: 'w:bCs', xml: '<w:bCs/>' })
+  }
+  if (run.italic) {
+    out.push({ name: 'w:i', xml: '<w:i/>' }, { name: 'w:iCs', xml: '<w:iCs/>' })
+  }
   if (run.strike) out.push({ name: 'w:strike', xml: '<w:strike/>' })
   if (run.color)
     out.push({ name: 'w:color', xml: `<w:color w:val="${escapeXmlAttr(run.color)}"/>` })

--- a/packages/docx-engine/tests/bidi.test.ts
+++ b/packages/docx-engine/tests/bidi.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { mergePPrFormat, parseDocx, saveDocx } from '../src/index'
+import { mergeRPrModel } from '../src/generate'
 import { buildDocx } from './helpers/build-docx'
 
 const BIDI_BODY =
@@ -53,5 +54,45 @@ describe('RTL tables (tblPr w:bidiVisual)', () => {
       '<w:tr><w:tc><w:p><w:r><w:t>א</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
     const doc = await parseDocx(await buildDocx({ bodyXml: xml }))
     expect(doc.blocks[0].table?.bidiVisual).toBe(true)
+  })
+})
+
+describe('complex-script bold and italic', () => {
+  // Word renders Arabic and Hebrew bold from w:bCs, not w:b, so emitting only w:b makes
+  // the Bold button do nothing to that text.
+  const CS_RUN = '<w:rPr><w:rFonts w:cs="Traditional Arabic"/><w:szCs w:val="28"/></w:rPr>'
+
+  it('emits the Cs twin when bold is turned on', () => {
+    const out = mergeRPrModel(CS_RUN, { text: 'مرحبا', bold: true }, false)
+    expect(out).toContain('<w:b/>')
+    expect(out).toContain('<w:bCs/>')
+  })
+
+  it('emits the Cs twin when italic is turned on', () => {
+    const out = mergeRPrModel(CS_RUN, { text: 'مرحبا', italic: true }, false)
+    expect(out).toContain('<w:i/>')
+    expect(out).toContain('<w:iCs/>')
+  })
+
+  it('restores it after the flag is turned off and on again', () => {
+    const bold = '<w:rPr><w:rFonts w:cs="Traditional Arabic"/><w:b/><w:bCs/></w:rPr>'
+    const off = mergeRPrModel(bold, { text: 'مرحبا', bold: false }, false)
+    expect(off).not.toContain('<w:b/>')
+    expect(off).not.toContain('<w:bCs/>')
+    expect(mergeRPrModel(off, { text: 'مرحبا', bold: true }, false)).toContain('<w:bCs/>')
+  })
+
+  it('leaves an unchanged run on its original bytes', () => {
+    const bold = '<w:rPr><w:rFonts w:cs="Traditional Arabic"/><w:b/><w:bCs/></w:rPr>'
+    expect(mergeRPrModel(bold, { text: 'مرحبا', bold: true }, false)).toBe(bold)
+  })
+
+  it('rebuilds the twins the way size already does', () => {
+    // w:sz has written its w:szCs companion from the model for as long as this path has
+    // existed, so a rebuild has always restored a Cs value the original may not have carried.
+    // Bold and italic were the two properties left out of that.
+    const fresh = mergeRPrModel('', { text: 'مرحبا', bold: true, sizeHalfPoints: 28 }, false)
+    expect(fresh).toContain('<w:szCs w:val="28"/>')
+    expect(fresh).toContain('<w:b/><w:bCs/>')
   })
 })

--- a/packages/docx-engine/tests/textbox-edit.test.ts
+++ b/packages/docx-engine/tests/textbox-edit.test.ts
@@ -161,7 +161,7 @@ describe('textbox editing', () => {
       '<w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t xml:space="preserve">red part</w:t></w:r>',
     )
     expect(out).toContain(
-      '<w:r><w:rPr><w:b/><w:sz w:val="28"/><w:szCs w:val="28"/></w:rPr><w:t xml:space="preserve"> bold part</w:t></w:r>',
+      '<w:r><w:rPr><w:b/><w:bCs/><w:sz w:val="28"/><w:szCs w:val="28"/></w:rPr><w:t xml:space="preserve"> bold part</w:t></w:r>',
     )
   })
 
@@ -178,7 +178,7 @@ describe('textbox editing', () => {
       [null, para({ runs: [{ text: 'STILL', bold: true }] })],
     ])
     expect(kept).toContain(
-      '<w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">STILL</w:t></w:r>',
+      '<w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:b/><w:bCs/></w:rPr><w:t xml:space="preserve">STILL</w:t></w:r>',
     )
 
     // align null strips the centered jc from the second paragraph
@@ -186,7 +186,7 @@ describe('textbox editing', () => {
       [null, para({ runs: [{ text: 'LEFT', bold: true }], align: null })],
     ])
     expect(removed).toContain(
-      '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">LEFT</w:t></w:r></w:p>',
+      '<w:p><w:r><w:rPr><w:b/><w:bCs/></w:rPr><w:t xml:space="preserve">LEFT</w:t></w:r></w:p>',
     )
   })
 
@@ -203,7 +203,7 @@ describe('textbox editing', () => {
     ])
     // new paragraph reuses the centered pPr of the last original
     expect(out).toContain(
-      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">line3</w:t></w:r></w:p>',
+      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:rPr><w:b/><w:bCs/></w:rPr><w:t xml:space="preserve">line3</w:t></w:r></w:p>',
     )
     // empty paragraph keeps pPr only
     expect(out).toContain('<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>')


### PR DESCRIPTION
Word renders Arabic and Hebrew **bold** from `w:bCs` and **italic** from `w:iCs`, not from `w:b` and `w:i`. `modelRPrChildren` writes only the Latin half, so selecting Arabic text and clicking Bold changes nothing on screen.

## What happens

`w:b` and `w:bCs` are one managed group, so while the value is unchanged the original bytes survive untouched. The moment the value changes the group is rebuilt from the model, and only `w:b` comes back.

Executed against `origin/main` sources, a plain Arabic run with Bold turned on:

```
in   <w:rPr><w:rFonts w:cs="Traditional Arabic"/><w:szCs w:val="28"/></w:rPr>
out  <w:rPr><w:rFonts w:cs="Traditional Arabic"/><w:b/><w:szCs w:val="28"/></w:rPr>
```

Un-bolding and re-bolding is worse: the `w:bCs` the document arrived with is gone for good.

## The fix

Emit the Cs twin alongside its Latin half. That is what Word writes for either script, and what this emitter already does one property over. `RUN_MANAGED_GROUPS` pairs `w:sz` with `w:szCs`, and `modelRPrChildren` has always written both:

```
mergeRPrModel('', { bold: true })          -> <w:rPr><w:b/></w:rPr>
mergeRPrModel('', { sizeHalfPoints: 28 })  -> <w:rPr><w:sz w:val="28"/><w:szCs w:val="28"/></w:rPr>
```

A run whose flag has not changed still keeps its original bytes exactly.

## Verification

Four of the nine cases in `bidi.test.ts` fail against `origin/main` sources and pass here. The other five are controls for behaviour that must not change, including a run whose bold was never toggled coming back byte for byte.

`packages/docx-engine` 530 passed, `apps/docs` 737 passed. Four assertions in `textbox-edit.test.ts` pinned the old byte output and are updated; the neighbouring run they leave alone is the one whose bold was never toggled.

## What this does not fix

The model holds one flag per property and cannot tell `w:b` from `w:b` plus `w:bCs`, so any path that rebuilds a run from the model writes the Cs twin whether or not the original carried it. Rejecting a tracked format revision is such a path. That is already true of `w:szCs` today.

The model does not see the Cs flags at all, either: the parser reads `w:b` and `w:i` and nothing complex-script, so a run carrying `w:bCs` without `w:b` arrives with no bold and any rebuild drops it. Same gap from the other side.

I tried to repair the reject path by reading the previous properties back out of the `w:rPr` that `w:rPrChange` nests, and took it out again. The snapshot the editor keeps is a string with no namespace or entity context, and three shapes of the fix each broke on that:

- taking the nested `w:rPr` whole carries the namespace declarations it inherited, so a property under a prefix bound above it returns unbound and the part no longer parses;
- taking only the six toggle and size elements avoids that, but names are compared lexically, so a `w:rPrChange` that rebinds the `w` prefix launders a foreign `w:bCs` in, and an ignorable wrapper under a Unicode prefix hides history that is then restored as the run's own;
- a `w:val` written as a numeric character reference survives the round trip already escaped, so passing it through again yields a value that no longer parses as a number.

Doing it properly means carrying real namespace and entity context through the revision snapshot. That is a change to the editor model rather than to this emitter, and it belongs to `w:sz` exactly as much as to `w:b`, so I have left it alone rather than half done. Happy to take it on separately if you would like it.
