### PR TITLE
fix(slides): apply a font change to complex-script text as well

### DIFF
--- a/packages/pptx-engine/src/generate.ts
+++ b/packages/pptx-engine/src/generate.ts
@@ -330,16 +330,17 @@ function patchRunProps(runXml: string, run: TextRun): string {
     }
     runXml = patchRunHlink(runXml, run)
   } else {
-    // No rPr: inject a minimal rPr after <a:r> (no latin/ea injected when the font is untouched — inheritance applies)
+    // No rPr: inject a minimal rPr after <a:r> (no font slots injected when the font is untouched,
+    // so inheritance applies)
     const attrs = buildRPrAttrs(run)
     const color = run.color
       ? `<a:solidFill><a:srgbClr val="${hex6(run.color)}"/></a:solidFill>`
       : ''
     const font =
       run.fontFamily && !run.fontImplicit && !run.latinFont && !run.eaFont
-        ? `<a:latin typeface="${escapeXmlAttr(run.fontFamily)}"/><a:ea typeface="${escapeXmlAttr(run.fontFamily)}"/>`
+        ? fontSlotsXml(escapeXmlAttr(run.fontFamily))
         : ''
-    const inner = color + font + hlinkXml(run) // schema order: fill before latin/ea, hlinkClick after
+    const inner = color + font + hlinkXml(run) // schema order: fill before the font slots, hlinkClick after
     const rpr = inner ? `<a:rPr${attrs}>${inner}</a:rPr>` : `<a:rPr${attrs}/>`
     runXml = runXml.replace(/(<a:r(?:\s[^>]*)?>)/, `$1${rpr}`)
   }
@@ -378,9 +379,78 @@ function patchRunHlink(runXml: string, run: TextRun): string {
   return runXml.replace(/<\/a:rPr>/, `${hlink}</a:rPr>`)
 }
 
-/** Patch or inject the run font: <a:latin>/<a:ea> typeface (ea written in sync for CJK, avoiding the theme ea font). */
-function patchRunFont(runXml: string, family: string): string {
-  const esc = escapeXmlAttr(family)
+/** The three script slots written together: with a:latin alone PowerPoint still renders CJK from
+ *  the theme ea font and Arabic/Hebrew/Indic from the theme cs font, so a font change appears to
+ *  do nothing to that text. Takes an already-escaped typeface. */
+function fontSlotsXml(esc: string): string {
+  return `<a:latin typeface="${esc}"/><a:ea typeface="${esc}"/><a:cs typeface="${esc}"/>`
+}
+
+/** The font slots, in CT_TextCharacterProperties order. */
+const FONT_SLOTS = ['a:latin', 'a:ea', 'a:cs']
+const IS_FONT_SLOT = new Set(FONT_SLOTS)
+/** The rPr children that follow the font slots, so the group is inserted ahead of the first one. */
+const AFTER_FONT_SLOTS = new Set(['a:sym', 'a:hlinkClick', 'a:hlinkMouseOver', 'a:rtl', 'a:extLst'])
+
+/**
+ * Point an element's own typeface attribute at a new value. Only the start tag's own attributes
+ * are considered, so a payload nested inside a paired element keeps whatever it declared, and the
+ * attribute name is read as a whole token so one merely ending in "typeface" is left alone.
+ */
+function setTypeface(el: string, esc: string): string {
+  const tag = /^<[^\s/>]+(?:"[^"]*"|'[^']*'|[^"'>])*>/.exec(el)?.[0]
+  if (!tag) return el
+  // sliced rather than grouped: an attribute pattern permissive enough for unquoted values also
+  // swallows the '/' of a self-closing tag, which then reappears in front of whatever is added
+  const name = /^<[^\s/>]+/.exec(tag)![0]
+  const close = tag.endsWith('/>') ? '/>' : '>'
+  let had = false
+  const attrs = tag
+    .slice(name.length, tag.length - close.length)
+    .replace(/\s([^\s=/>]+)\s*=\s*("[^"]*"|'[^']*')/g, (whole, attr: string) => {
+      if (attr !== 'typeface') return whole
+      had = true
+      return ` typeface="${esc}"`
+    })
+  // added here rather than letting a caller infer absence from an unchanged string: setting a slot
+  // to the typeface it already carries returns the element untouched, which is not the same as it
+  // having no typeface at all
+  return name + (had ? attrs : `${attrs} typeface="${esc}"`) + close + el.slice(tag.length)
+}
+
+/** CT_TextCharacterProperties children. Anything else means the scan below cannot be trusted. */
+const RPR_KNOWN_CHILDREN = new Set([
+  'a:ln',
+  'a:noFill',
+  'a:solidFill',
+  'a:gradFill',
+  'a:blipFill',
+  'a:pattFill',
+  'a:grpFill',
+  'a:effectLst',
+  'a:effectDag',
+  'a:highlight',
+  'a:uLnTx',
+  'a:uLn',
+  'a:uFillTx',
+  'a:uFill',
+  'a:latin',
+  'a:ea',
+  'a:cs',
+  'a:sym',
+  'a:hlinkClick',
+  'a:hlinkMouseOver',
+  'a:rtl',
+  'a:extLst',
+])
+
+/**
+ * The font patch as it stood before complex-script support, kept verbatim for any run this file
+ * cannot scan structurally. Markup compatibility branches, comments, CDATA and processing
+ * instructions can all make element-looking text appear where a child is not, so rather than
+ * guess, such a run gets exactly the previous behaviour and a:cs is left untouched.
+ */
+function patchRunFontUnscannable(runXml: string, esc: string): string {
   if (/<a:latin\b/.test(runXml)) {
     runXml = runXml.replace(/(<a:latin\b[^>]*?\btypeface=")[^"]*(")/, `$1${esc}$2`)
     if (/<a:ea\b/.test(runXml)) {
@@ -394,12 +464,83 @@ function patchRunFont(runXml: string, family: string): string {
     return runXml
   }
   const fonts = `<a:latin typeface="${esc}"/><a:ea typeface="${esc}"/>`
-  // Self-closing rPr → expand to a pair, then insert
   if (/<a:rPr\b[^>]*\/>/.test(runXml)) {
     return runXml.replace(/<a:rPr\b([^>]*?)\/>/, `<a:rPr$1>${fonts}</a:rPr>`)
   }
-  // Paired rPr → append at the end (latin/ea after ln/fill, per the CT_TextCharacterProperties order)
   return runXml.replace(/<\/a:rPr>/, `${fonts}</a:rPr>`)
+}
+
+/**
+ * Patch or inject the run font: <a:latin>/<a:ea>/<a:cs> typeface, kept in sync per fontSlotsXml.
+ * Works on the direct children of the run's own <a:rPr>, so a typeface nested inside a:ln, an
+ * a:extLst extension payload or any other subtree stays with whatever owns it.
+ */
+function patchRunFont(runXml: string, family: string): string {
+  const esc = escapeXmlAttr(family)
+  // Comments, CDATA and processing instructions can all carry element-looking text, so the scan
+  // below would read structure that is not there
+  if (/<!--|<!\[CDATA\[|<\?/.test(runXml)) return patchRunFontUnscannable(runXml, esc)
+  // topLevelChildren reads a name as [a-zA-Z][\w:]*, while XML allows a leading underscore, a
+  // non-ASCII character and an interior middle dot among others. A name outside what it reads
+  // would be taken short and the element mistaken for a different one, so refuse the run rather
+  // than widen a scanner five other callers share.
+  for (const [, name] of runXml.matchAll(/<\/?([^\s/>!?][^\s/>]*)/g)) {
+    if (!/^[a-zA-Z][\w:]*$/.test(name!)) return patchRunFontUnscannable(runXml, esc)
+  }
+  // The run's OWN properties, taken as a direct child rather than as the first a:rPr in the text:
+  // an extension payload may carry one of its own, and filling that one in would leave the real
+  // slots untouched.
+  const runOpen = /^<[^\s/>]+(?:"[^"]*"|'[^']*'|[^"'>])*?>/.exec(runXml)?.[0]
+  if (!runOpen) return patchRunFontUnscannable(runXml, esc)
+  const rPr = topLevelChildren(runXml, runOpen.length, runXml.length).find(
+    (c) => c.name === 'a:rPr',
+  )
+  // could not be located structurally, so hand it to the previous behaviour rather than
+  // silently doing nothing: a payload's own closing tag can truncate the slice this is given
+  if (!rPr) return patchRunFontUnscannable(runXml, esc)
+  const el = runXml.slice(rPr.start, rPr.end)
+  const rPrOpen = /^<a:rPr\b(?:"[^"]*"|'[^']*'|[^"'>])*?>/.exec(el)?.[0]
+  // Self-closing rPr → expand to a pair around the slots
+  if (!rPrOpen) {
+    const attrs = /^<a:rPr\b((?:"[^"]*"|'[^']*'|[^"'>])*?)\/>$/.exec(el)?.[1]
+    if (attrs === undefined) return patchRunFontUnscannable(runXml, esc)
+    return (
+      runXml.slice(0, rPr.start) +
+      `<a:rPr${attrs}>${fontSlotsXml(esc)}</a:rPr>` +
+      runXml.slice(rPr.end)
+    )
+  }
+  const innerStart = rPr.start + rPrOpen.length
+  // the closing tag's own start, since a valid one may carry whitespace before its '>'
+  const innerEnd = rPr.start + el.lastIndexOf('</')
+  if (innerEnd <= innerStart) return patchRunFontUnscannable(runXml, esc)
+  const children = topLevelChildren(runXml, innerStart, innerEnd)
+  // An unrecognised child is a markup-compatibility wrapper or something else that supplies the
+  // real children indirectly, whatever prefix it was bound to. Recognising the whole list is the
+  // only way to know the slots found here are the run's own.
+  if (children.some((c) => !RPR_KNOWN_CHILDREN.has(c.name))) {
+    return patchRunFontUnscannable(runXml, esc)
+  }
+  const slots = children.filter((c) => IS_FONT_SLOT.has(c.name))
+  // A repeated slot is not something to reason about: the group is rebuilt from one of them and
+  // the others would be dropped along with their attributes. The schema allows one of each.
+  if (new Set(slots.map((c) => c.name)).size !== slots.length) {
+    return patchRunFontUnscannable(runXml, esc)
+  }
+  // Rebuild the group whole so it comes out as latin, ea, cs however few of the three the run
+  // arrived with, keeping each existing element's other attributes (pitchFamily, charset, panose)
+  const block = FONT_SLOTS.map((tag) => {
+    const found = slots.find((s) => s.name === tag)
+    if (!found) return `<${tag} typeface="${esc}"/>`
+    return setTypeface(runXml.slice(found.start, found.end), esc)
+  }).join('')
+  // Every removal below sits at or after this point, so the index stays valid through them
+  const at = slots.length
+    ? slots[0]!.start
+    : (children.find((c) => AFTER_FONT_SLOTS.has(c.name))?.start ?? innerEnd)
+  let out = runXml
+  for (const c of [...slots].reverse()) out = out.slice(0, c.start) + out.slice(c.end)
+  return out.slice(0, at) + block + out.slice(at)
 }
 
 function patchRunColor(runXml: string, color: string): string {
@@ -428,7 +569,8 @@ function buildRPrAttrs(run: TextRun): string {
   if (run.fontSize != null && !run.fontSizeImplicit) s += ` sz="${Math.round(run.fontSize * 100)}"`
   if (run.bold) s += ' b="1"'
   if (run.italic) s += ' i="1"'
-  if (run.underline && !run.underlineImplicit) s += ` u="${escapeXmlAttr(run.underlineStyle ?? 'sng')}"`
+  if (run.underline && !run.underlineImplicit)
+    s += ` u="${escapeXmlAttr(run.underlineStyle ?? 'sng')}"`
   if (run.strike) s += ` strike="${escapeXmlAttr(run.strikeStyle ?? 'sngStrike')}"`
   if (run.letterSpacing) s += ` spc="${Math.round(run.letterSpacing * 100)}"`
   if (run.baseline) s += ` baseline="${Math.round(run.baseline * 1000)}"`
@@ -563,14 +705,14 @@ function generateRunXml(r: TextRun): string {
       ? `<a:solidFill><a:srgbClr val="${hex6(r.color)}"/></a:solidFill>`
       : ''
   // Original dual fonts/theme references restored first; no declaration (inherited) writes nothing;
-  // a user-changed font writes latin + ea together — with latin alone, CJK characters in PowerPoint still use the theme ea font
+  // a user-changed font writes all three slots, so a rebuilt run keeps the typeface the user picked
   const font =
     r.latinFont || r.eaFont || r.csFont
       ? (r.latinFont ? `<a:latin typeface="${escapeXmlAttr(r.latinFont)}"/>` : '') +
         (r.eaFont ? `<a:ea typeface="${escapeXmlAttr(r.eaFont)}"/>` : '') +
         (r.csFont ? `<a:cs typeface="${escapeXmlAttr(r.csFont)}"/>` : '')
       : r.fontFamily && !r.fontImplicit
-        ? `<a:latin typeface="${escapeXmlAttr(r.fontFamily)}"/><a:ea typeface="${escapeXmlAttr(r.fontFamily)}"/>`
+        ? fontSlotsXml(escapeXmlAttr(r.fontFamily))
         : ''
   // Run-level hyperlink: rId written back (allocated by ensureRunLinkRels for links set this session)
   const hlink = hlinkXml(r)

--- a/packages/pptx-engine/src/index.ts
+++ b/packages/pptx-engine/src/index.ts
@@ -1950,9 +1950,12 @@ function applyFontPatch(paragraphs: Paragraph[], patch: ElementFontPatch): void 
     for (const r of p.runs) {
       if (patch.fontFamily !== undefined) {
         r.fontFamily = patch.fontFamily
-        // User explicitly changed the font: the original latin/ea keep-flags no longer apply, write the new font back
+        // User explicitly changed the font: the original latin/ea/cs keep-flags no longer
+        // apply, write the new font back. csFont has to go with them or a rebuilt run
+        // re-emits the old complex-script typeface and Arabic text never changes.
         delete r.latinFont
         delete r.eaFont
+        delete r.csFont
         delete r.fontImplicit
       }
       if (patch.fontSizePt !== undefined) {

--- a/packages/pptx-engine/tests/run-format-fidelity.test.ts
+++ b/packages/pptx-engine/tests/run-format-fidelity.test.ts
@@ -104,3 +104,267 @@ describe('underline style not collapsed', () => {
     expect(out).toContain('u="sng"')
   })
 })
+
+describe('complex-script font follows the font change', () => {
+  // Arabic, Hebrew and Indic text renders from a:cs, not a:latin, so a font change that
+  // leaves a:cs alone looks like it did nothing at all.
+  const ARABIC =
+    '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Calibri"/><a:cs typeface="Traditional Arabic"/></a:rPr>' +
+    '<a:t>مرحبا</a:t></a:r>'
+
+  it('parses csFont verbatim', () => {
+    const { el } = parseEl(ARABIC)
+    expect(el.text!.paragraphs[0]!.runs[0]!.csFont).toBe('Traditional Arabic')
+  })
+
+  it('changing the font rewrites a:cs as well as a:latin', () => {
+    const { slide, el } = parseEl(ARABIC)
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  /** The three slots a font change writes, in the order CT_TextCharacterProperties requires. */
+  const slotOrder = (xml: string) => [...xml.matchAll(/<a:(latin|ea|cs)\b/g)].map((m) => m[1])
+
+  it('injects a:cs for a run that declared no fonts at all', () => {
+    // the shape of the repo's own Arabic fixture: a bare run inheriting everything
+    const { slide, el } = parseEl('<a:r><a:t>مرحبا</a:t></a:r>')
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(slotOrder(out)).toEqual(['latin', 'ea', 'cs'])
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  it('keeps the schema order when the run declares only a:cs', () => {
+    const { slide, el } = parseEl(
+      '<a:r><a:rPr lang="ar-SA"><a:cs typeface="Traditional Arabic"/></a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(slotOrder(out)).toEqual(['latin', 'ea', 'cs'])
+  })
+
+  it('leaves a typeface inside an extension payload alone', () => {
+    const { slide, el } = parseEl(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Calibri"/>' +
+        '<a:extLst><a:ext uri="{FF2B5EF4}"><a:cs typeface="Opaque Extension Font"/></a:ext></a:extLst>' +
+        '</a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(out).toContain('typeface="Opaque Extension Font"')
+    const ownProps = out.slice(0, out.indexOf('<a:extLst'))
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(ownProps)?.[1]).toBe('Amiri')
+  })
+
+  it('leaves a typeface nested in a subtree alone and sets the run own slots', () => {
+    // a:ln may carry its own extension payload with its own font reference; only the run's
+    // direct children are ours. Note the nested one comes first in document order.
+    const { slide, el } = parseEl(
+      '<a:r><a:rPr lang="ar-SA">' +
+        '<a:ln><a:extLst><a:ext uri="{FF2B5EF4}"><a:latin typeface="Nested Outline Font"/></a:ext>' +
+        '</a:extLst></a:ln><a:latin typeface="Calibri"/>' +
+        '</a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(out).toContain('typeface="Nested Outline Font"')
+    const own = out.slice(out.indexOf('</a:ln>'))
+    expect(slotOrder(own)).toEqual(['latin', 'ea', 'cs'])
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(own)?.[1]).toBe('Amiri')
+  })
+
+  it('a structural rebuild keeps the font the user picked in a:cs', () => {
+    const { slide, el } = parseEl(ARABIC)
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    el.text!.paragraphs[0]!.runs.push({ text: ' added' }) // forces the rebuild path
+    const out = patchTextElementXml(el, el.anchor.originalXml)
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  const refont = (runXml: string) => {
+    const { slide, el } = parseEl(runXml)
+    expect(setElementFont(slide, el.id, { fontFamily: 'Amiri' })).toBe(true)
+    return patchTextElementXml(el, el.anchor.originalXml)
+  }
+
+  it('rewrites a single-quoted typeface rather than adding a second one', () => {
+    const out = refont(
+      "<a:r><a:rPr lang='ar-SA'><a:latin pitchFamily='34' typeface='Old'/></a:rPr>" +
+        '<a:t>مرحبا</a:t></a:r>',
+    )
+    expect(out.match(/typeface\s*=/g)).toHaveLength(3) // latin, ea, cs: one each
+    expect(out).toContain("pitchFamily='34'")
+    expect(out).not.toContain("typeface='Old'")
+  })
+
+  it('does not add a second slot group to a run using mc:AlternateContent', () => {
+    // the branch children only exist once a consumer picks a branch, so injecting a direct
+    // group alongside them would leave two a:latin after preprocessing
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><mc:AlternateContent>' +
+        '<mc:Choice Requires="a14"><a:latin typeface="Old"/></mc:Choice>' +
+        '<mc:Fallback><a:latin typeface="Old"/></mc:Fallback>' +
+        '</mc:AlternateContent></a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    expect(out.match(/<a:latin\b/g)).toHaveLength(2)
+  })
+
+  it('changes the real slot when a comment holds element-looking text', () => {
+    // note the run attribute writer already reaches inside a comment on main too, so the comment
+    // bytes are not asserted here; what matters is that the font lands on the actual slot
+    const out = refont(
+      '<a:r><!-- marker <a:rPr/> --><a:rPr lang="ar-SA"><a:latin typeface="Old"/></a:rPr>' +
+        '<a:t>مرحبا</a:t></a:r>',
+    )
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+    expect(out.match(/<a:latin\b/g)).toHaveLength(1)
+  })
+
+  it('still injects a font into an unscannable run that declared none', () => {
+    // the unscannable path has to keep doing everything the engine did before, injection included
+    const out = refont('<a:r><a:rPr/><!-- guard --><a:t>مرحبا</a:t></a:r>')
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+    expect(/<a:ea[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  it('changes only the attribute actually named typeface', () => {
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin z:data="typeface=\'Trap\'" typeface="Own"/></a:rPr>' +
+        '<a:t>مرحبا</a:t></a:r>',
+    )
+    expect(out).toContain('z:data="typeface=\'Trap\'"')
+    expect(out).toContain('<a:latin z:data="typeface=\'Trap\'" typeface="Amiri"/>')
+  })
+
+  it('fills in a slot that carries no attributes at all', () => {
+    // an attribute pattern permissive enough for unquoted values also swallows the slash of a
+    // self-closing tag, which then reappears in front of whatever is added
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Old"/><a:cs/></a:rPr>' +
+        '<a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    expect(out).not.toContain('/ typeface')
+    expect(out).toContain('<a:cs typeface="Amiri"/>')
+    expect(slotOrder(out)).toEqual(['latin', 'ea', 'cs'])
+  })
+
+  it('does not repeat the attribute when the slot already carries the target font', () => {
+    // setting a slot to the typeface it already has leaves the element untouched, which is not
+    // the same as the element having no typeface
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Amiri"/><a:cs typeface="Traditional Arabic"/>' +
+        '</a:rPr><a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    expect(out).not.toMatch(/typeface="[^"]*"\s+typeface=/)
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  it('still applies the font when the properties cannot be located', () => {
+    // a payload carrying its own a:r closes the slice early; falling back beats doing nothing
+    const out = refont(
+      '<a:r><a:rPr lang="en"><a:latin typeface="Old"/><a:extLst><a:ext uri="{x}">' +
+        '<x:payload xmlns:x="urn:x" xmlns:a="urn:payload"><a:r><a:t>payload</a:t></a:r></x:payload>' +
+        '</a:ext></a:extLst></a:rPr><a:t>visible</a:t></a:r>',
+    )
+    expect(out).toContain('typeface="Amiri"')
+    expect(out).not.toContain('typeface="Old"')
+  })
+
+  it('uses the run own properties, not an a:rPr that appears earlier in the text', () => {
+    const out = refont(
+      '<a:r><a:ext uri="{FF2B5EF4}"><a:rPr/></a:ext>' +
+        '<a:rPr lang="ar-SA"><a:latin typeface="OldLatin"/><a:cs typeface="OldCS"/></a:rPr>' +
+        '<a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    // no font slot goes into the payload; the run attribute writer touches its rPr on main too
+    const payload = out.slice(out.indexOf('<a:ext uri='), out.indexOf('</a:ext>'))
+    expect(payload).not.toContain('<a:latin')
+    expect(payload).not.toContain('<a:cs')
+    const own = out.slice(out.indexOf('</a:ext>'))
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(own)?.[1]).toBe('Amiri')
+    expect(/<a:cs[^>]*typeface="([^"]*)"/.exec(own)?.[1]).toBe('Amiri')
+  })
+
+  it('handles a closing tag carrying whitespace before its bracket', () => {
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Old"/></a:rPr ><a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    // the closing tag survives intact rather than being spliced through
+    expect(out).toContain('</a:rPr >')
+    expect(out).not.toContain('<<')
+    expect(slotOrder(out)).toEqual(['latin', 'ea', 'cs'])
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(out)?.[1]).toBe('Amiri')
+  })
+
+  it('is not cut short by an a:rPr nested in an extension payload', () => {
+    // the run's own closing tag has to be found by depth: the payload's closing tag comes first
+    // in the text, and stopping there would leave the real slots untouched
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Old"/>' +
+        '<a:extLst><a:ext uri="{FF2B5EF4}">' +
+        '<a:rPr><a:latin typeface="Payload"/></a:rPr>' +
+        '</a:ext></a:extLst></a:rPr><a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    expect(out).toContain('typeface="Payload"')
+    const own = out.slice(0, out.indexOf('<a:extLst'))
+    expect(slotOrder(own)).toEqual(['latin', 'ea', 'cs'])
+    expect(/<a:latin[^>]*typeface="([^"]*)"/.exec(own)?.[1]).toBe('Amiri')
+  })
+
+  it('reads a name containing a middle dot whole', () => {
+    // U+00B7 continues an XML name, so a scan that stopped short would read a:latin\u00B7ext as
+    // a:latin and write the typeface into the middle of the tag
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin\u00B7ext><z:payload keep="yes"/></a:latin\u00B7ext>' +
+        '</a:rPr><a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    expect(out).toContain('<z:payload keep="yes"/>')
+    expect(out).not.toMatch(/<a:latin typeface="Amiri"\u00B7/)
+  })
+
+  it('does not drop a repeated slot and its attributes', () => {
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="L1" charset="00"/>' +
+        '<a:latin typeface="L2" pitchFamily="34"/></a:rPr><a:t>\u0645\u0631\u062d\u0628\u0627</a:t></a:r>',
+    )
+    expect(out).toContain('charset="00"')
+    expect(out).toContain('pitchFamily="34"')
+    expect(out.match(/<a:latin\b/g)).toHaveLength(2)
+  })
+
+  it('sees a wrapper whose prefix starts with an underscore', () => {
+    // XML names may begin with _, so a scan anchored on ASCII letters would miss the wrapper
+    // entirely and then empty its branch
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><_mc:AlternateContent>' +
+        '<_mc:Fallback><a:latin typeface="Fallback"/></_mc:Fallback>' +
+        '</_mc:AlternateContent></a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    // the branch keeps its content and the font lands inside it, byte for byte as before
+    expect(out).toContain('<_mc:Fallback><a:latin typeface="Amiri"/>')
+    expect(out).toContain('</_mc:Fallback>')
+  })
+
+  it('leaves a payload nested inside a paired slot alone', () => {
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><a:latin typeface="Own">' +
+        '<z:payload typeface="Nested"/></a:latin></a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    expect(out).toContain('<z:payload typeface="Nested"/>')
+    expect(out).toContain('<a:latin typeface="Amiri">')
+  })
+
+  it('treats a markup-compatibility wrapper as unscannable whatever prefix it uses', () => {
+    const out = refont(
+      '<a:r><a:rPr lang="ar-SA"><x:AlternateContent>' +
+        '<x:Choice Requires="a14"><a:latin typeface="Old"/></x:Choice>' +
+        '</x:AlternateContent></a:rPr><a:t>مرحبا</a:t></a:r>',
+    )
+    // no second group appended alongside the branch-supplied one
+    expect(out.match(/<a:latin\b/g)).toHaveLength(1)
+    expect(out).not.toContain('<a:cs')
+  })
+})


### PR DESCRIPTION
OOXML splits a run's font into three slots and picks by script: `a:latin`, `a:ea` for CJK, and `a:cs` for complex scripts. Changing an element's font never wrote `a:cs`, so Arabic, Hebrew and Indic text stayed on the old typeface and the control looked broken for anyone writing in those scripts.

## What happens

Executed against `origin/main` sources, picking Amiri on a mixed run:

```
before  <a:latin typeface="Calibri"/><a:cs typeface="Traditional Arabic"/>
after   <a:latin typeface="Amiri"/><a:cs typeface="Traditional Arabic"/>
```

The Latin half of the run changes and the Arabic half does not. A run that declares no fonts at all, which is the shape the deck fixtures actually use, got `a:latin` and `a:ea` injected and still no `a:cs`.

## The fix

Write the three slots together wherever the font is set, and clear `csFont` with its `latinFont` and `eaFont` siblings so a rebuilt run re-derives it from the choice the user made instead of re-emitting the old typeface.

`patchRunFont` works on the direct children of the run's own `a:rPr`, and the group is rebuilt whole, so the slots always come back as `latin, ea, cs` however few of them the run arrived with, and each element that was already there keeps its other attributes (`pitchFamily`, `charset`, `panose`).

### Where it deliberately does nothing new

The structured path is taken only when the run can actually be read: no comment, CDATA or processing instruction; every tag name inside it readable exactly as the existing child scanner reads one; the run's own `a:rPr` locatable as a direct child; every direct child of it a known `CT_TextCharacterProperties` element; and no repeated font slot.

Anything else falls back to the previous function unchanged, with `a:cs` untouched. So a run carrying a markup-compatibility branch, an extension payload with its own `a:rPr`, or a name the scanner would read short is handled exactly as it was before rather than guessed at. The shared child scanner itself is untouched, so no other caller moves.

## Verification

Twelve of the thirty-one cases in `run-format-fidelity.test.ts` fail against `origin/main` sources and pass here. The other nineteen are existing baselines plus guards for the preservation and fallback behaviour, so they pass on both revisions by design.

A differential over a large corpus of valid and well-formed-but-invalid runs, comparing this branch against `origin/main` side by side, found no divergence outside the font slots.

`packages/pptx-engine` 557 passed.

## What this does not fix

- An empty or self-closing `a:rPr` still comes back with `a:latin` and `a:ea` only, so the complex-script slot is not created for a run that declared no properties at all. That is the previous behaviour, unchanged.
- Structural editing, the format painter and the AI font path still leave a stale `csFont` on the model. Also unchanged, and a separate thing to fix.
- An empty `a:rPr` whose opening tag carries a `>` inside a quoted attribute value is still mangled by the pre-existing injection path. Equally broken before and after.
