### PR TITLE
fix(docx): decode XML entities exactly once in parsed run text

### DIFF
--- a/packages/docx-engine/src/parse.ts
+++ b/packages/docx-engine/src/parse.ts
@@ -1858,7 +1858,7 @@ function extractTextboxes(
         for (const r of childrenOf(p)) {
           if (nameOf(r) !== 'a:r') continue
           const t = findChild(r, 'a:t')
-          const text = t ? decodeEntities(textOf(t)) : ''
+          const text = t ? decodeNumericCharRefs(textOf(t)) : ''
           if (text === '') continue
           const run: Run = { text }
           const rPr = findChild(r, 'a:rPr')
@@ -2056,7 +2056,9 @@ const SIMPLE_INLINE_FIELD_RE = /^\s*(DATE|TIME|CREATEDATE|SAVEDATE|NUMPAGES|FILE
 /** HYPERLINK "url" (optional \o "tip"): the only field form folded into an editable link run;
  * any other switch (\l bookmark, \t frame...) keeps the protected-passthrough path */
 function convertibleHyperlink(instr: string): { href: string; tooltip?: string } | null {
-  const m = /^\s*HYPERLINK\s+"([^"\\]+)"\s*(?:\\o\s+"([^"]*)"\s*)?$/.exec(decodeEntities(instr))
+  const m = /^\s*HYPERLINK\s+"([^"\\]+)"\s*(?:\\o\s+"([^"]*)"\s*)?$/.exec(
+    decodeNumericCharRefs(instr),
+  )
   if (!m) return null
   return { href: m[1], ...(m[2] ? { tooltip: m[2] } : {}) }
 }
@@ -2285,7 +2287,7 @@ function rubyPartText(rubyNode: XNode, part: 'w:rubyBase' | 'w:rt'): string {
   for (const r of childrenOf(partNode)) {
     if (nameOf(r) !== 'w:r') continue
     for (const c of childrenOf(r)) {
-      if (nameOf(c) === 'w:t') text += decodeEntities(textOf(c))
+      if (nameOf(c) === 'w:t') text += decodeNumericCharRefs(textOf(c))
     }
   }
   return text
@@ -2367,7 +2369,7 @@ function buildRun(
   let text = ''
   for (const child of childrenOf(rNode)) {
     const name = nameOf(child)
-    if (name === 'w:t' || name === 'w:delText') text += decodeEntities(textOf(child))
+    if (name === 'w:t' || name === 'w:delText') text += decodeNumericCharRefs(textOf(child))
     else if (name === 'w:tab') text += '\t'
     // In-paragraph page breaks (w:br w:type="page") are encoded as \f and preserved; column/soft breaks become \n
     else if (name === 'w:br') text += attrsOf(child)['w:type'] === 'page' ? '\f' : '\n'
@@ -3355,20 +3357,31 @@ function mathTokens(xml: string): string[] {
   return tokens
 }
 
+/**
+ * Numeric character references only (`&#65;` / `&#xF0B7;`), which fast-xml-parser
+ * leaves alone. Text and attribute values read off the parse tree have already had
+ * the five named entities resolved, so they must NOT be run through the named-entity
+ * replacements again: a document whose visible text is literally `&lt;` is stored as
+ * `&amp;lt;`, and a second decode would turn it into `<`.
+ */
+function decodeNumericCharRefs(text: string): string {
+  return text.replace(
+    /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
+    (entity, hex: string | undefined, decimal: string | undefined) => {
+      const codePoint = parseInt(hex ?? decimal ?? '', hex ? 16 : 10)
+      return Number.isFinite(codePoint) &&
+        codePoint >= 0 &&
+        codePoint <= 0x10ffff &&
+        !(codePoint >= 0xd800 && codePoint <= 0xdfff)
+        ? String.fromCodePoint(codePoint)
+        : entity
+    },
+  )
+}
+
+/** Full decode, for raw XML slices that never passed through the parser. */
 function decodeEntities(text: string): string {
-  return text
-    .replace(
-      /&#(?:x([0-9a-f]+)|([0-9]+));/gi,
-      (entity, hex: string | undefined, decimal: string | undefined) => {
-        const codePoint = parseInt(hex ?? decimal ?? '', hex ? 16 : 10)
-        return Number.isFinite(codePoint) &&
-          codePoint >= 0 &&
-          codePoint <= 0x10ffff &&
-          !(codePoint >= 0xd800 && codePoint <= 0xdfff)
-          ? String.fromCodePoint(codePoint)
-          : entity
-      },
-    )
+  return decodeNumericCharRefs(text)
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
@@ -3880,7 +3893,7 @@ function extractLockedCanvas(xml: string, ctx: BuildContext): DiagramDisplay | n
         const parts: string[] = []
         for (const r of findChildren(p, 'a:r')) {
           const t = findChild(r, 'a:t')
-          if (t) parts.push(decodeEntities(textOf(t)))
+          if (t) parts.push(decodeNumericCharRefs(textOf(t)))
           const rPr = findChild(r, 'a:rPr')
           if (rPr && sizePt === undefined) {
             const sz = parseInt(attrsOf(rPr)['sz'] ?? '', 10)
@@ -4054,7 +4067,7 @@ async function extractDiagramDrawing(
         const parts: string[] = []
         for (const r of findChildren(p, 'a:r')) {
           const t = findChild(r, 'a:t')
-          if (t) parts.push(decodeEntities(textOf(t)))
+          if (t) parts.push(decodeNumericCharRefs(textOf(t)))
           const rPr = findChild(r, 'a:rPr')
           if (rPr && sizePt === undefined) {
             const sz = parseInt(attrsOf(rPr)['sz'] ?? '', 10)
@@ -4586,7 +4599,7 @@ function parseNumberingLevel(lvlNode: XNode): NumberingLevel {
   const start = parseInt(attrsOf(findChild(lvlNode, 'w:start') ?? {})['w:val'] ?? '0', 10)
   const level: NumberingLevel = {
     numFmt: attrsOf(findChild(lvlNode, 'w:numFmt') ?? {})['w:val'] ?? 'decimal',
-    lvlText: decodeEntities(attrsOf(findChild(lvlNode, 'w:lvlText') ?? {})['w:val'] ?? ''),
+    lvlText: decodeNumericCharRefs(attrsOf(findChild(lvlNode, 'w:lvlText') ?? {})['w:val'] ?? ''),
     start: Number.isFinite(start) ? start : 0,
   }
   const lvlPPr = findChild(lvlNode, 'w:pPr')

--- a/packages/docx-engine/tests/entity-decoding.test.ts
+++ b/packages/docx-engine/tests/entity-decoding.test.ts
@@ -1,0 +1,49 @@
+import JSZip from 'jszip'
+import { describe, expect, it } from 'vitest'
+import { parseDocx, saveDocx } from '../src/index'
+import { buildDocx } from './helpers/build-docx'
+
+/**
+ * fast-xml-parser resolves the five named XML entities on its own, so text read off
+ * the parse tree only needs numeric character references resolved on top of it.
+ * Decoding the named entities a second time rewrites a document's own literal
+ * "&lt;" / "&amp;" text into "<" / "&", and regenerating the paragraph then persists
+ * that damage to word/document.xml.
+ */
+describe('entity decoding in run text', () => {
+  // XML 1.0 stores literal entity text with the ampersand escaped; Word displays
+  // this run as: Escape &amp; as &lt;b&gt; ok
+  const STORED = 'Escape &amp;amp; as &amp;lt;b&amp;gt; ok'
+  const DISPLAYED = 'Escape &amp; as &lt;b&gt; ok'
+
+  it('keeps text that is literally an entity reference', async () => {
+    const bytes = await buildDocx({
+      bodyXml: `<w:p><w:r><w:t xml:space="preserve">${STORED}</w:t></w:r></w:p>`,
+    })
+    const doc = await parseDocx(bytes)
+    expect(doc.blocks[0].runs!.map((r) => r.text).join('')).toBe(DISPLAYED)
+  })
+
+  it('still resolves a real numeric character reference beside literal entity text', async () => {
+    const bytes = await buildDocx({
+      bodyXml: '<w:p><w:r><w:t xml:space="preserve">&amp;lt; then &#x2713;</w:t></w:r></w:p>',
+    })
+    const doc = await parseDocx(bytes)
+    expect(doc.blocks[0].runs!.map((r) => r.text).join('')).toBe('&lt; then ✓')
+  })
+
+  it('does not rewrite an untouched run when a sibling run is edited', async () => {
+    const bytes = await buildDocx({
+      bodyXml:
+        `<w:p><w:r><w:t xml:space="preserve">${STORED} </w:t></w:r>` +
+        '<w:r><w:rPr><w:b/></w:rPr><w:t>tail</w:t></w:r></w:p>',
+    })
+    const doc = await parseDocx(bytes)
+    const runs = doc.blocks[0].runs!.map((r) => (r.bold ? { ...r, text: 'edited' } : r))
+    const saved = await saveDocx(doc, [{ kind: 'generated', block: { type: 'paragraph', runs } }])
+    const zip = await JSZip.loadAsync(saved)
+    const xml = await zip.file('word/document.xml')!.async('string')
+    expect(xml).toContain(`${STORED} `)
+    expect(xml).toContain('edited')
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** `decodeEntities()` was being applied to text that fast-xml-parser (with its `processEntities: true` default) had already entity-decoded once, so the five named entities were decoded twice. A document whose visible text literally contains `&lt;` / `&amp;` (docs about HTML/XML escaping, pasted markup, URLs written with `&amp;`) parsed as `<` / `&`, and editing that paragraph wrote the corrupted text back to `word/document.xml` permanently. This PR splits `decodeNumericCharRefs()` out of `decodeEntities()` — numeric character references like `&#xF0B7;` are the only thing the parser leaves unresolved — and uses it at the call sites that read text or attribute values off the parse tree: `buildRun` (every body/table run), ruby text, textbox runs, SmartArt/diagram text, numbering `lvlText`, and the HYPERLINK field instruction. Call sites that decode raw XML slices (`plainText`, TOC lines, bookmark names, image alt, `text-patch.ts`, `sources.ts`) still need and keep the full decode, unchanged.
- **Why is this change needed?** The double decode breaks the core byte-preservation promise (README: “only what you touched changes; Word never notices”): affected documents are misparsed on open and silently rewritten on save. Details and repro in the linked issue.
- Intentionally out of scope (see the issue's “known residual edge”): visible text `&#65;` stored as `&amp;#65;` is indistinguishable from a real numeric reference after the parser's first pass; fixing that would require single-pass decoding of the raw slice.

## Related issue

Fixes #88

## Validation

- [x] `npm run format:check` — “All matched files use Prettier code style!”
- [x] `npm run lint` — ESLint (repo flat config) run on the two changed files: 0 errors
- [x] `npm run typecheck` — `tsc --noEmit` for `@genoffice/docx-engine`: clean
- [x] `npm test` — full docx-engine suite (`npx vitest run` in `packages/docx-engine`): **60 files, 553 passed, 1 skipped, 0 failed**

List any checks not run and explain why: the repo-wide variants of lint/typecheck/test were not run — a full workspace `npm install` fails in my environment because my registry mirror 404s on `@fluentui/react-icons@2.0.333` (an app dependency unrelated to this change). The affected package passes all four checks as listed above.

**Regression evidence** — the three new tests in `tests/entity-decoding.test.ts` fail on `main` and pass with this fix:

```
main (fix stashed):  Tests  3 failed (3)
  × keeps text that is literally an entity reference
      expected 'Escape &amp; as &lt;b&gt; ok', got 'Escape & as <b> ok'
  × still resolves a real numeric character reference beside literal entity text
  × does not rewrite an untouched run when a sibling run is edited
      saved document.xml contains '<w:t xml:space="preserve">Escape &amp; as &lt;b&gt; ok </w:t>'
      instead of the original 'Escape &amp;amp; as &amp;lt;b&amp;gt; ok '

with this PR:        Tests  553 passed | 1 skipped (554)   ← includes the 550 pre-existing tests
```

## Screenshots or recordings

Not applicable — engine-level fix; test evidence above.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. *(No user-facing strings touched.)*
- [x] File open/save changes include an appropriate round-trip or fidelity test. *(`does not rewrite an untouched run when a sibling run is edited` asserts the untouched run's original bytes survive an edit–save cycle.)*

---
AI disclosure: this fix and its tests were prepared with AI assistance; I reproduced the bug and reviewed every change and test result locally.
