### PR TITLE
Replace unrecognizable SaveIcon with floppy disk

### DIFF
--- a/apps/sheets/src/renderer/ribbon-icons.tsx
+++ b/apps/sheets/src/renderer/ribbon-icons.tsx
@@ -42,10 +42,9 @@ export function CaretIcon(): ReactElement {
 export function SaveIcon(): ReactElement {
   return (
     <Icon>
-      <path d="M3 4.5C3 3.67158 3.67158 3 4.5 3H17.1407L21 6.60325V19.5C21 20.3285 20.3285 21 19.5 21H4.5C3.67158 21 3 20.3285 3 19.5V4.5Z" />
-      <path d="M12.0042 3L12 6.6923C12 6.86225 11.7761 7 11.5 7H7.5C7.22385 7 7 6.86225 7 6.6923V3H12.0042Z" />
-      <path d="M7 13H17" />
-      <path d="M7 17H12.0042" />
+      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+      <path d="M17 21v-8H7v8" />
+      <path d="M7 3v5h8V3" />
     </Icon>
   )
 }


### PR DESCRIPTION
The SaveIcon was not recognizable as a "Save" function, because the used Icon was not a typical floppy disk. Improved UI/UX with the a new standard floppy disk path.

## Summary

- This pull request changes the Save Icon to a more standard and recognizeable one.
- This change is needed so that users can understand where to save the document.

## Screenshots or recordings

"Not applicable"

## Contributor checklist

- [X] The change is focused and does not include unrelated reformatting or refactoring.
- [X] User-facing strings use the existing i18n resources.
- [X] File open/save changes include an appropriate round-trip or fidelity test.
