### PR TITLE
fix(slides): allow adding text to shapes without text body

### DIFF
--- a/apps/slides/src/main/ops/text-ops.ts
+++ b/apps/slides/src/main/ops/text-ops.ts
@@ -67,7 +67,8 @@ register({
       }
       const textChild = child as TextElement
       if (!textChild.text) {
-        throw new GuidedError(`op "setText": group child "${id}" has no editable text body.`)
+        // Initialize an empty text body so the engine can inject <p:txBody>
+        textChild.text = { paragraphs: [], insets: { l: 0, t: 0, r: 0, b: 0 } }
       }
       const previousXml = patchSlideXml(slide)
       const before = plainText(textChild.text.paragraphs)
@@ -87,8 +88,10 @@ register({
     }
     const { el } = resolveElement(ctx, op, { types: ['text', 'shape'], allowPart: true })
     const te = el as TextElement
-    if (!te.text)
-      throw new GuidedError(`op "setText": element "${te.id}" has no editable text body.`)
+    if (!te.text) {
+      // Initialize an empty text body so the engine can inject <p:txBody>
+      te.text = { paragraphs: [], insets: { l: 0, t: 0, r: 0, b: 0 } }
+    }
     const previousXml = patchSlideXml(slide)
     const before = plainText(te.text.paragraphs)
     const levelDirty = levelsChanged(te.text.paragraphs, paragraphs)

--- a/apps/slides/src/renderer/konva-adapter.ts
+++ b/apps/slides/src/renderer/konva-adapter.ts
@@ -1152,7 +1152,8 @@ export function normalizeColor(c: string): string {
 }
 
 export function isEditableText(node: RenderNode): node is ShapeRenderNode {
-  return (node.type === 'text' || node.type === 'shape') && !!(node as ShapeRenderNode).text
+  // Allow editing shapes without text body — the engine injects <p:txBody> on setText
+  return node.type === 'text' || node.type === 'shape'
 }
 
 /** Polyline smooth → Konva Line tension (0 = polyline, 0.4 ≈ PPT smooth curve). */


### PR DESCRIPTION
## Summary
- Allow double-click text editing on shapes without existing `<p:txBody>`
- Initialize empty text body in `setText` op instead of throwing error
- Engine's `rebuildTxBody` handles injecting `<p:txBody>` into the XML

Closes #127.

## Changes
1. **`text-ops.ts`**: When `te.text` is undefined, initialize with `{ paragraphs: [], insets: { l: 0, t: 0, r: 0, b: 0 } }` instead of throwing
2. **`konva-adapter.ts`**: Remove `.text` check from `isEditableText` — shapes and text elements are now always editable

## Test plan
- [ ] Double-click a shape without text body → should enter text editing mode
- [ ] Type text and commit → should save without error
- [ ] Reload the file → text should persist in the shape
- [ ] Group child shapes without text body → same behavior


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Qf8o71U5AMi9kh65pi4DT