### PR TITLE
fix(sheets): row-batch over-cap sidecar reads so streaming survives big viewports

### DIFF
--- a/apps/sheets/src/renderer/univer-sync.ts
+++ b/apps/sheets/src/renderer/univer-sync.ts
@@ -1177,11 +1177,16 @@ export interface MappedRangeRead {
   readonly fileEndRow: number
 }
 
+/// Per-request cell budget for sidecar range reads; row batches are sized to
+/// stay under it (mirrors MAX_RANGE_CELLS in shared/desktop-api.ts).
+const SIDECAR_READ_BATCH_CELLS = 18_000
+
 /// Reads a screen-space range, translating through the sheet's journaled
 /// structural operations. Returns null when the range is entirely
 /// journal-owned (inserted this session — nothing streams into it). A
-/// request spanning deleted file rows can exceed the sidecar's per-read
-/// cell budget, so file reads are split into row batches.
+/// request spanning deleted file rows — or simply a large one, like the
+/// buffered viewport at far zoom-out — can exceed the sidecar's per-read
+/// cell budget, so reads are split into row batches.
 export async function readSheetRangeMapped(
   state: LazyWorkbookState,
   sheetId: string,
@@ -1190,13 +1195,44 @@ export async function readSheetRangeMapped(
 ): Promise<MappedRangeRead | null> {
   const ops = state.editJournal.structuralOps.get(sheetId) ?? []
   if (ops.length === 0) {
-    const raw = await window.desktopApi.readWorkbookRange({
-      sessionId: state.file.sessionId,
-      sheetId,
-      range: screenRange,
-    })
+    const width = screenRange.endColumn - screenRange.startColumn + 1
+    const batchRows = Math.max(1, Math.floor(SIDECAR_READ_BATCH_CELLS / width))
+    const cells: WorkbookRangeResult['cells'] = []
+    const rows: WorkbookRangeResult['rows'] = []
+    const merges: WorkbookRangeResult['merges'] = []
+    const hyperlinks: WorkbookRangeResult['hyperlinks'] = []
+    let raw: WorkbookRangeResult | null = null
+    for (
+      let startRow = screenRange.startRow;
+      startRow <= screenRange.endRow;
+      startRow += batchRows
+    ) {
+      const endRow = Math.min(startRow + batchRows - 1, screenRange.endRow)
+      const batch = await window.desktopApi.readWorkbookRange({
+        sessionId: state.file.sessionId,
+        sheetId,
+        range: { ...screenRange, startRow, endRow },
+      })
+      cells.push(...batch.cells)
+      rows.push(...batch.rows)
+      merges.push(...batch.merges)
+      hyperlinks.push(...batch.hyperlinks)
+      raw = batch
+      // Later batches cannot have data before indexing reaches them; the
+      // regular retry poll picks the rest up.
+      if (batch.indexedThroughRow === null || batch.indexedThroughRow < endRow) break
+    }
+    if (!raw) {
+      // Degenerate empty range (endRow < startRow): let the sidecar answer,
+      // preserving the pre-batching behavior for out-of-contract input.
+      raw = await window.desktopApi.readWorkbookRange({
+        sessionId: state.file.sessionId,
+        sheetId,
+        range: screenRange,
+      })
+    }
     return {
-      screen: raw,
+      screen: { ...raw, cells, rows, merges, hyperlinks },
       raw,
       indexedThroughScreen: raw.indexedThroughRow,
       fileEndRow: screenRange.endRow,
@@ -1217,7 +1253,7 @@ export async function readSheetRangeMapped(
     endColumn: Math.min(mappedRange.endColumn, sheet.columnCount - 1),
   }
   const width = fileRange.endColumn - fileRange.startColumn + 1
-  const batchRows = Math.max(1, Math.floor(18_000 / width))
+  const batchRows = Math.max(1, Math.floor(SIDECAR_READ_BATCH_CELLS / width))
   const cells: WorkbookRangeResult['cells'] = []
   const rows: WorkbookRangeResult['rows'] = []
   const merges: WorkbookRangeResult['merges'] = []

--- a/apps/sheets/tests/read-sheet-range-batching.test.ts
+++ b/apps/sheets/tests/read-sheet-range-batching.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { readSheetRangeMapped } from '../src/renderer/univer-sync'
+import type { LazyWorkbookState } from '../src/renderer/univer-state'
+
+type RangeCall = { sessionId: string; sheetId: string; range: Record<string, number> }
+
+const readWorkbookRange = vi.fn(async (call: RangeCall) => ({
+  cells: [],
+  rows: [],
+  merges: [],
+  hyperlinks: [],
+  conditionalRules: [],
+  dataValidations: [],
+  indexedThroughRow: call.range.endRow,
+}))
+
+function state(): LazyWorkbookState {
+  return {
+    file: { sessionId: 'session-1', sheets: [] },
+    generation: 1,
+    loadedRanges: new Map(),
+    loadingKeys: new Map(),
+    retryTimers: new Map(),
+    appliedMerges: new Map(),
+    appliedRowKeys: new Map(),
+    sheetProtections: new Map(),
+    sheetPageBreaks: new Map(),
+    sheetProtectedRanges: new Map(),
+    uninstalledDefinedNames: new Set(),
+    appliedCfSheets: new Set(),
+    appliedFilterSheets: new Set(),
+    appliedDvSheets: new Set(),
+    decorationsPendingSheets: new Set(),
+    hyperlinkTargets: new Map(),
+    frozenStripKeys: new Map(),
+    filterOrigins: new Map(),
+    showFormulaSheets: new Set(),
+    formulaMode: false,
+    editJournal: { cells: new Map(), structuralOps: new Map() },
+    flags: { preloadComplete: false },
+    closure: { status: 'idle', pinned: new Map() },
+    formulaText: new Map(),
+    cachedFormulaValues: new Map(),
+    pivotDefinitions: new Map(),
+    outline: new Map(),
+    recalc: {
+      timer: null,
+      generation: 0,
+      failures: 0,
+      formulaCells: new Map(),
+      overlay: new Map(),
+    },
+  } as unknown as LazyWorkbookState
+}
+
+const sheetMeta = {
+  id: 's1',
+  name: 'Sheet1',
+  rowCount: 100_000,
+  columnCount: 200,
+} as unknown as LazyWorkbookState['file']['sheets'][number]
+
+describe('readSheetRangeMapped: over-cap reads are row-batched', () => {
+  beforeEach(() => {
+    readWorkbookRange.mockClear()
+    vi.stubGlobal('window', { desktopApi: { readWorkbookRange } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('splits a range that would exceed the sidecar cell budget', async () => {
+    // 200 columns x 300 rows = 60,000 cells; batches of floor(18_000/200)=90 rows.
+    const result = await readSheetRangeMapped(
+      state(),
+      's1',
+      { startRow: 0, endRow: 299, startColumn: 0, endColumn: 199 },
+      sheetMeta,
+    )
+    expect(readWorkbookRange).toHaveBeenCalledTimes(4)
+    const calls = readWorkbookRange.mock.calls.map(([call]) => call.range)
+    expect(calls[0]).toMatchObject({ startRow: 0, endRow: 89 })
+    expect(calls[1]).toMatchObject({ startRow: 90, endRow: 179 })
+    expect(calls[2]).toMatchObject({ startRow: 180, endRow: 269 })
+    expect(calls[3]).toMatchObject({ startRow: 270, endRow: 299 })
+    expect(result?.fileEndRow).toBe(299)
+    expect(result?.indexedThroughScreen).toBe(299)
+  })
+
+  it('stops early when indexing lags behind a batch', async () => {
+    readWorkbookRange.mockImplementationOnce(async () => ({
+      cells: [],
+      rows: [],
+      merges: [],
+      hyperlinks: [],
+      conditionalRules: [],
+      dataValidations: [],
+      // Indexing only reached row 20 of the requested 0..89 — later batches
+      // cannot have data yet, so the read must not continue past this one.
+      indexedThroughRow: 20,
+    }))
+    const result = await readSheetRangeMapped(
+      state(),
+      's1',
+      { startRow: 0, endRow: 299, startColumn: 0, endColumn: 199 },
+      sheetMeta,
+    )
+    expect(readWorkbookRange).toHaveBeenCalledTimes(1)
+    expect(result?.indexedThroughScreen).toBe(20)
+  })
+
+  it('keeps small ranges on a single request', async () => {
+    const result = await readSheetRangeMapped(
+      state(),
+      's1',
+      { startRow: 5, endRow: 20, startColumn: 0, endColumn: 9 },
+      sheetMeta,
+    )
+    expect(readWorkbookRange).toHaveBeenCalledTimes(1)
+    expect(readWorkbookRange.mock.calls[0]?.[0]?.range).toMatchObject({
+      startRow: 5,
+      endRow: 20,
+      startColumn: 0,
+      endColumn: 9,
+    })
+    expect(result?.indexedThroughScreen).toBe(20)
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** `readSheetRangeMapped` now row-batches **every** sidecar range read, not just the structural-ops path: the direct (no-ops) path applies the same `floor(18_000 / width)`-row batching with the same early stop when indexing lags, and both paths share one `SIDECAR_READ_BATCH_CELLS` constant instead of a magic number.
- **Why is this change needed?** Fixes #137. The direct path sent requests unbatched, so a buffered viewport at far zoom-out (visible range + the ±80-row/±8-column buffer) could exceed the sidecar's 20,000-cell request cap. The schema rejected the request, `loadRange` surfaced an error, and since every Scroll event regenerated similar over-cap geometry, the sheet stopped streaming entirely until zoom or window size changed — exactly as diagnosed in the issue. Batching at this single choke point also future-proofs every other caller (`ensureLazyRangeLoaded`, find-bridge jumps, frozen strips) against over-cap geometry, which is the "step further" direction suggested in the issue thread.

Behavior notes:

- Batch merging, ordering, and the indexing-lag early break are byte-identical in semantics to the existing ops-path loop; small ranges still produce exactly one request (covered by test).
- A degenerate empty range (`endRow < startRow`) falls through to the old single-request behavior so out-of-contract input fails the same way it did before.

## Related issue

Fixes #137

## Validation

- [x] `npm run format:check`
- [x] `npm run lint` — scoped ESLint run over both changed files: 0 errors
- [x] `npm run typecheck`
- [x] `npm test` — new `tests/read-sheet-range-batching.test.ts` (3 cases): a 60,000-cell request splits into four ≤18k batches with correct row boundaries; an indexing-lagged first batch stops the loop after one request; a small range stays on a single request. Neighboring suites (`univer-range-loading`, `lazy-find`) pass alongside.

List any checks not run and explain why:

- Sidecar-dependent tests cannot run locally on this Windows machine (no MSVC toolchain to link the Rust sidecar); CI builds the sidecar before running the suite. No Rust code is touched.

## Screenshots or recordings

Not applicable — behavior change visible as: zooming far out on a large streamed sheet now keeps streaming rows instead of stalling with request errors.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: read-path only.
