### PR TITLE
fix(sheets): track span occupancy as intervals so fully-deleted ranges map to null

### DIFF
--- a/apps/sheets/src/renderer/view-transform.ts
+++ b/apps/sheets/src/renderer/view-transform.ts
@@ -141,73 +141,133 @@ interface Span {
   end: number
 }
 
-/// Envelope of a span's image through an insertion: a monotone shift, so the
-/// span ends map to the envelope ends.
-function insertEnvelope(span: Span, index: number, count: number): Span {
-  return {
-    start: span.start >= index ? span.start + count : span.start,
-    end: span.end >= index ? span.end + count : span.end,
+/// The image of a span after structural ops, as a sorted list of disjoint
+/// intervals. A single bounding box cannot represent it: a move tears a span
+/// into pieces, and a later removal can delete one piece while sparing
+/// another — the box would then claim survivors that no longer exist.
+type SpanList = { start: number; end: number }[]
+
+/// Insert `count` lines at `index`: a monotone shift of everything at/after it.
+function insertEnvelopeList(list: SpanList, index: number, count: number): SpanList {
+  return list.map((seg) => ({
+    start: seg.start >= index ? seg.start + count : seg.start,
+    end: seg.end >= index ? seg.end + count : seg.end,
+  }))
+}
+
+/// Remove `count` lines at `index`: intervals overlapping the block are cut
+/// in place; survivors right of it shift left. Empty pieces vanish.
+function removeEnvelopeList(list: SpanList, index: number, count: number): SpanList {
+  const result: SpanList = []
+  for (const seg of list) {
+    if (seg.end < index) {
+      result.push(seg)
+      continue
+    }
+    if (seg.start >= index + count) {
+      result.push({ start: seg.start - count, end: seg.end - count })
+      continue
+    }
+    const leftEnd = Math.min(seg.end, index - 1)
+    if (seg.start <= leftEnd) result.push({ start: seg.start, end: leftEnd })
+    const rightStart = Math.max(seg.start, index + count)
+    if (rightStart <= seg.end) {
+      result.push({ start: rightStart - count, end: seg.end - count })
+    }
+  }
+  return result
+}
+
+/// Image of one interval through one move: the map is piecewise (shift by
+/// +len(second) inside the first block, -len(first) inside the second,
+/// identity elsewhere), so the interval is split at block boundaries and
+/// each piece shifts. Pieces are appended in order; the caller keeps the
+/// list sorted because moves can reorder pieces.
+function moveEnvelopeSegment(seg: Span, a: Span, b: Span, forward: boolean, out: SpanList): void {
+  // Cut points inside the segment where the mapping changes.
+  const cuts: number[] = [seg.start]
+  for (const boundary of [a.start, a.end + 1, b.start, b.end + 1]) {
+    if (boundary > seg.start && boundary <= seg.end) cuts.push(boundary)
+  }
+  cuts.push(seg.end + 1)
+  const unique = [...new Set(cuts)].sort((x, y) => x - y)
+  const secondLength = b.end - b.start + 1
+  const firstLength = a.end - a.start + 1
+  for (let i = 0; i < unique.length - 1; i += 1) {
+    const subStart = unique[i] ?? seg.start
+    const subEnd = (unique[i + 1] ?? seg.end + 1) - 1
+    const mid = (subStart + subEnd) >> 1
+    let mappedStart = subStart
+    let mappedEnd = subEnd
+    if (mid >= a.start && mid <= a.end) {
+      // Original swapMap: inside a → position + len(b) (forward) or the
+      // inverse's a-block (the post-image of second) → position + len(b).
+      mappedStart = subStart + secondLength
+      mappedEnd = subEnd + secondLength
+    } else if (mid >= b.start && mid <= b.end) {
+      mappedStart = subStart - firstLength
+      mappedEnd = subEnd - firstLength
+    }
+    if (mappedStart <= mappedEnd) out.push({ start: mappedStart, end: mappedEnd })
   }
 }
 
-/// Envelope of a span's image through a removal; null when the whole span
-/// falls inside the removed block.
-function removeEnvelope(span: Span, index: number, count: number): Span | null {
-  const left = span.start < index ? { start: span.start, end: Math.min(span.end, index - 1) } : null
-  const right =
-    span.end >= index + count
-      ? { start: Math.max(span.start, index + count) - count, end: span.end - count }
-      : null
-  if (left && right) return { start: left.start, end: right.end }
-  return left ?? right
-}
-
-/// Envelope of a span's image through one move. The map is a translation on
-/// each swap block and the identity elsewhere, so extremes over the span sit
-/// at the span ends or at block boundaries inside the span.
-function moveEnvelope(
-  span: Span,
+/// Image of a whole interval list through one move.
+function moveEnvelopeList(
+  list: SpanList,
   op: Extract<RowColumnOp, { before: number }>,
   forward: boolean,
-): Span {
+): SpanList {
   const [a, b] = swapImageBlocks(op, forward)
-  let start = Infinity
-  let end = -Infinity
-  for (const position of [span.start, span.end, a.start, a.end, b.start, b.end]) {
-    if (position < span.start || position > span.end) continue
-    const mapped = swapMap(position, op, forward)
-    start = Math.min(start, mapped)
-    end = Math.max(end, mapped)
-  }
-  return { start, end }
+  const out: SpanList = []
+  for (const seg of list) moveEnvelopeSegment(seg, a, b, forward, out)
+  out.sort((x, y) => x.start - y.start)
+  return out
 }
 
 /// Envelope of a span's image through the whole op sequence (`forward` =
-/// file → screen). Moves make the composite non-monotonic, so the envelope is
-/// tracked op by op: each op's blocks are evaluated in the intermediate
-/// coordinate space that op actually ran in. Over-reading is safe, tearing is
-/// not. Null when nothing in the span survives the mapping.
+/// file → screen). Moves make the composite non-monotonic, so the image is
+/// tracked op by op as an interval list: each op's blocks are evaluated in
+/// the intermediate coordinate space that op actually ran in. Over-reading
+/// within the surviving extremes is safe, tearing is not; an empty list
+/// means nothing in the span survives the mapping.
+function spanEnvelopeList(
+  ops: readonly StructuralOp[],
+  axis: Axis,
+  span: Span,
+  forward: boolean,
+): SpanList {
+  const relevant = rowColumnOps(ops, axis)
+  if (!forward) relevant.reverse()
+  let current: SpanList = [{ start: span.start, end: span.end }]
+  for (const op of relevant) {
+    if (current.length === 0) return current
+    if ('before' in op) {
+      current = moveEnvelopeList(current, op, forward)
+    } else if (isInsert(op) === forward) {
+      // Inserts applied forward and removals inverted both shift lines apart.
+      current = insertEnvelopeList(current, op.index, op.count)
+    } else {
+      current = removeEnvelopeList(current, op.index, op.count)
+    }
+  }
+  return current
+}
+
+/// Bounding box of a span image. Null when nothing survives — the fix for
+/// the phantom-range bug: a box tracked op-by-op can keep claiming survivors
+/// after a later removal deleted the last real occupant.
 function spanEnvelope(
   ops: readonly StructuralOp[],
   axis: Axis,
   span: Span,
   forward: boolean,
 ): Span | null {
-  const relevant = rowColumnOps(ops, axis)
-  if (!forward) relevant.reverse()
-  let current: Span | null = span
-  for (const op of relevant) {
-    if (!current) return null
-    if ('before' in op) {
-      current = moveEnvelope(current, op, forward)
-    } else if (isInsert(op) === forward) {
-      // Inserts applied forward and removals inverted both shift lines apart.
-      current = insertEnvelope(current, op.index, op.count)
-    } else {
-      current = removeEnvelope(current, op.index, op.count)
-    }
-  }
-  return current
+  const image = spanEnvelopeList(ops, axis, span, forward)
+  const first = image[0]
+  const last = image[image.length - 1]
+  if (!first || !last) return null
+  return { start: first.start, end: last.end }
 }
 
 /// File-space range backing a screen-space range. The result may span file

--- a/apps/sheets/tests/view-transform.test.ts
+++ b/apps/sheets/tests/view-transform.test.ts
@@ -263,3 +263,48 @@ describe('move-rows mapping', () => {
     expect(range?.endRow).toBeGreaterThanOrEqual(5)
   })
 })
+
+describe('fileRangeToScreenRange: fully-deleted spans return null (no phantom survivors)', () => {
+  it('returns null when a move+delete stack deletes every row of the range', () => {
+    // The minimal repro from the phantom-range bug: track file span [6..7]
+    // through a stack where both rows end up deleted, yet a box-tracked
+    // envelope keeps a phantom survivor.
+    const ops: StructuralOp[] = [
+      { kind: 'move-rows', index: 11, count: 1, before: 7 }, // box [6..8]
+      { kind: 'remove-rows', index: 8, count: 1 }, // deletes file row 7 → [6..7]
+      { kind: 'move-rows', index: 10, count: 2, before: 2 }, // box [8..9]
+      { kind: 'remove-rows', index: 8, count: 1 }, // deletes file row 6
+    ]
+    // Both file rows 6 and 7 are gone — the screen range must be null, not a
+    // phantom {startRow:8, endRow:8} occupied by unrelated content.
+    expect(
+      fileRangeToScreenRange(ops, { startRow: 6, endRow: 7, startColumn: 0, endColumn: 0 }),
+    ).toBeNull()
+    // Sanity: neither deleted file row maps anywhere.
+    expect(fileToScreen(ops, 'row', 6)).toBeNull()
+    expect(fileToScreen(ops, 'row', 7)).toBeNull()
+  })
+
+  it('still returns the bounding box when some rows survive', () => {
+    // Same stack, but track a span that includes a surviving row alongside
+    // the fully-deleted [6..7] — the envelope must cover the survivor.
+    const ops: StructuralOp[] = [
+      { kind: 'move-rows', index: 11, count: 1, before: 7 },
+      { kind: 'remove-rows', index: 8, count: 1 },
+      { kind: 'move-rows', index: 10, count: 2, before: 2 },
+      { kind: 'remove-rows', index: 8, count: 1 },
+    ]
+    // File row 5 survives: op 3 (move 10..11 before 2) shifts rows 2..9 down
+    // by 2, so file 5 lands at screen 7; the removal at 8 doesn't touch it.
+    expect(fileToScreen(ops, 'row', 5)).toBe(7)
+    const range = fileRangeToScreenRange(ops, {
+      startRow: 5,
+      endRow: 7,
+      startColumn: 0,
+      endColumn: 0,
+    })
+    expect(range).not.toBeNull()
+    expect(range?.startRow).toBeLessThanOrEqual(7)
+    expect(range?.endRow).toBeGreaterThanOrEqual(7)
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** The coordinate-mapping envelope tracker (`view-transform.ts`) now represents the image of a file span as a sorted list of disjoint intervals instead of a single bounding box. Insertions shift intervals, removals cut them, and moves split them at block boundaries — so when every line of a span is deleted, the image list is genuinely empty and the exported range functions return `null`, exactly as their contract documents. When some lines survive, the returned bounding box is identical to before.
- **Why is this change needed?** Fixes #135. The old box-tracked envelope could keep claiming phantom survivors: a move pulls unrelated rows *into* the tracked box, and a later removal that deletes all actual occupants but not the whole box left a non-null range behind. `collectArrayFollowers` then added unrelated screen cells to the CSE array-follower set, and `patchWorksheetRangeInner` stripped their content on every stream-in — cells rendered permanently blank in formula-mode workbooks after a stacked move+delete near a legacy array formula.

The minimal repro (verified in the new regression test): track file span `[6..7]` through `move-rows(11,1,before=7)` → `remove-rows(8,1)` → `move-rows(10,2,before=2)` → `remove-rows(8,1)`. Both file rows 6 and 7 are deleted, yet the old box tracker returned `{startRow:8, endRow:8}` — a screen row occupied by unrelated content.

Design notes:

- The exported signatures (`fileRangeToScreenRange`, `screenRangeToFileRange`) are unchanged; the interval list is internal, and the public result is still a single bounding box (over-reading within surviving extremes remains safe by design — only the phantom-null case changes).
- `moveEnvelopeSegment` splits intervals at swap-block boundaries and applies the same per-block shifts the point-mapping `swapMap` uses, so the list stays exact; pieces are re-sorted after each move.
- The existing test suite (15 cases, including the brute-force bijection and chained-move extremes tests) passes unchanged, confirming no behavioral drift on non-phantom inputs.

## Related issue

Fixes #135

## Validation

- [x] `npm run format:check`
- [x] `npm run lint` — scoped ESLint run over both changed files: 0 errors
- [x] `npm run typecheck`
- [x] `npm test` — 2 new regression tests in `tests/view-transform.test.ts`: (1) the minimal 4-op repro returns `null` with both deleted file rows confirmed unmapped by `fileToScreen`; (2) a span including a surviving row still returns a bounding box covering it. All 15 pre-existing view-transform tests pass, plus the dependent `univer-range-loading` (27) and `lazy-find` (20) suites.

List any checks not run and explain why:

- Sidecar-dependent tests cannot run locally on this Windows machine (no MSVC toolchain to link the Rust sidecar); CI builds the sidecar first. No Rust code is touched.

## Screenshots or recordings

Not applicable — correctness fix visible as: array-follower cells no longer go blank after move+delete stacks near legacy CSE arrays in formula-mode workbooks.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: mapping-only change; the save side reshapes through the same op stream, which is untouched.
