### PR TITLE
fix(sheets): re-check structural edits inside the closure install loop

### DIFF
--- a/apps/sheets/src/renderer/univer-sync.ts
+++ b/apps/sheets/src/renderer/univer-sync.ts
@@ -1042,6 +1042,11 @@ export async function activateFormulaClosure(
         return giveUp()
       }
       if (lazyWorkbookRef.current !== state) return
+      // The pre-analysis guard above ran before these awaits: a structural
+      // edit landing mid-install would shift the coordinates every later
+      // patch and pin is written at, corrupting the live view. Give up
+      // instead — the same rule the analysis phase already applies.
+      if (state.editJournal.structuralOps.size > 0) return giveUp()
       const picked = result.cells.filter((cell) => cells.has(cellKey(cell.row, cell.column)))
       recordCachedFormulaValues(state, sheetId, picked)
       const wanted = degradeCostlyFormulas(state, sheetMeta.name, picked)

--- a/apps/sheets/tests/closure-structural-recheck.test.ts
+++ b/apps/sheets/tests/closure-structural-recheck.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { activateFormulaClosure } from '../src/renderer/univer-sync'
+import type { LazyWorkbookState, UniverRuntime } from '../src/renderer/univer-state'
+
+type FormulaCall = { sessionId: string; sheetId: string }
+type RangeCall = { sessionId: string; sheetId: string; range: Record<string, number> }
+
+function state(): LazyWorkbookState {
+  return {
+    file: {
+      sessionId: 'session-1',
+      sheets: [
+        {
+          id: 's1',
+          name: 'Sheet1',
+          rowCount: 100,
+          columnCount: 10,
+          tables: [],
+          pivotTables: [],
+          columnWidths: [],
+        },
+      ],
+    },
+    generation: 1,
+    loadedRanges: new Map(),
+    loadingKeys: new Map(),
+    retryTimers: new Map(),
+    appliedMerges: new Map(),
+    appliedRowKeys: new Map(),
+    sheetProtections: new Map(),
+    sheetPageBreaks: new Map(),
+    sheetProtectedRanges: new Map(),
+    uninstalledDefinedNames: new Set(),
+    appliedCfSheets: new Set(),
+    appliedFilterSheets: new Set(),
+    appliedDvSheets: new Set(),
+    decorationsPendingSheets: new Set(),
+    hyperlinkTargets: new Map(),
+    frozenStripKeys: new Map(),
+    filterOrigins: new Map(),
+    showFormulaSheets: new Set(),
+    formulaMode: false,
+    rowColStyleKeys: new Map(),
+    editJournal: {
+      cells: new Map(),
+      structuralOps: new Map(),
+    },
+    flags: { preloadComplete: false },
+    closure: { status: 'idle', pinned: new Map() },
+    formulaText: new Map(),
+    cachedFormulaValues: new Map(),
+    pivotDefinitions: new Map(),
+    outline: new Map(),
+    recalc: {
+      timer: null,
+      generation: 0,
+      failures: 0,
+      formulaCells: new Map(),
+      overlay: new Map(),
+    },
+  } as unknown as LazyWorkbookState
+}
+
+function runtime(): UniverRuntime {
+  const worksheet = {
+    getSheetId: () => 's1',
+  }
+  const workbook = {
+    getSheetBySheetId: (sheetId: string) => (sheetId === 's1' ? worksheet : null),
+  }
+  return {
+    univerAPI: { getActiveWorkbook: () => workbook },
+  } as unknown as UniverRuntime
+}
+
+describe('activateFormulaClosure: structural edit during install', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { desktopApi: {} })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('gives up instead of installing when a structural op lands mid-install', async () => {
+    const lazyState = state()
+    const desktop = window.desktopApi as unknown as {
+      readWorkbookFormulas: (call: FormulaCall) => Promise<unknown>
+      readWorkbookRange: (call: RangeCall) => Promise<unknown>
+    }
+    let rangeCalls = 0
+    desktop.readWorkbookFormulas = async () => ({
+      cells: [{ row: 0, column: 0, formula: '=B1+1', value: null }],
+      indexingComplete: true,
+      truncated: false,
+    })
+    desktop.readWorkbookRange = async (call: RangeCall) => {
+      rangeCalls += 1
+      // A structural edit lands between the analysis guard passing and this
+      // install read — the closure coordinates are now stale.
+      const ops = lazyState.editJournal.structuralOps.get('s1') ?? []
+      ops.push({ kind: 'insert-rows', index: 3, count: 2 })
+      lazyState.editJournal.structuralOps.set('s1', ops)
+      return {
+        cells: [{ row: 0, column: 0, formula: '=B1+1', value: 2 }],
+        rows: [],
+        merges: [],
+        hyperlinks: [],
+        conditionalRules: [],
+        dataValidations: [],
+        indexingComplete: true,
+        indexedThroughRow: call.range.endRow,
+      }
+    }
+
+    await activateFormulaClosure(runtime(), { current: lazyState }, () => {})
+
+    // The closure must have given up: status unavailable, nothing pinned,
+    // no patch installed at stale coordinates.
+    expect(lazyState.closure.status).toBe('unavailable')
+    expect(lazyState.closure.pinned.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** `activateFormulaClosure` now re-checks `state.editJournal.structuralOps.size > 0` after every `readWorkbookRange` await inside the install loop, not just once before it. A structural edit landing mid-install gives up cleanly (status → `'unavailable'`, nothing pinned) instead of installing file-space coordinates as screen-space.
- **Why is this change needed?** Fixes #136. The pre-analysis guard ran before the install loop's awaited reads, creating a window: a row/column insert landing between the guard passing and a later read completing meant every subsequent `patchWorksheetRange` call and pinned-map entry was written at shifted (wrong) coordinates. Unlike the preload path — which deliberately maps each block through the current op stream — the closure install had no mapping and no re-check, so the corruption persisted across every later eviction reinstall. Structural edits are explicitly allowed in every load mode (the BeforeCommandExecute gate comment in App.tsx), so this window was reachable by normal user actions during the multi-second install phase.

The fix is one guard line + comment, mirroring the exact rule the analysis phase already applies. When it fires, `giveUp()` sets status `'unavailable'` and the existing retry-on-next-open behavior takes over.

## Related issue

Fixes #136

## Validation

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — new `tests/closure-structural-recheck.test.ts`: drives `activateFormulaClosure` through fake IPC that injects a structural op at the first install read; asserts the closure gives up (`status: 'unavailable'`, empty pinned map) instead of installing at stale coordinates.

List any checks not run and explain why:

- `npm run lint` — the scoped ESLint run on `univer-sync.ts` (5,300+ lines) exceeds this machine's command timeout; CI covers it. The changed lines follow the file's existing conventions exactly.
- Sidecar-dependent tests cannot run locally (no MSVC toolchain); CI builds the sidecar first. No Rust code is touched.

## Screenshots or recordings

Not applicable — correctness fix visible as: inserting rows while the "Computing formula closure…" status is active no longer produces shifted/wrong cell contents after the closure activates.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: display-path only; the save side is untouched.
