### PR TITLE
fix(pdf): let fit-to-width zoom below the 50% manual-zoom floor

### DIFF
--- a/apps/pdf/src/renderer/App.tsx
+++ b/apps/pdf/src/renderer/App.tsx
@@ -128,6 +128,8 @@ import {
   SCROLL_PAD,
   SIDEBAR_W_KEY,
   SIDEBAR_CHROME,
+  clampScale,
+  clampScaleFit,
   clampSidebarW,
   loadSidebarW,
   DOC_OPTS,
@@ -1128,8 +1130,6 @@ export default function App() {
     }
   }, [activeFormWidgetId, formCatalog])
 
-  const clampScale = (s: number) => Math.min(MAX_SCALE, Math.max(MIN_SCALE, s))
-
   /** Overall size of a row (in spread mode widths add up, including the page gap) */
   const rowSize = useCallback(
     (row: number[]): PageSize => {
@@ -1209,8 +1209,8 @@ export default function App() {
     const availW = el.clientWidth - SCROLL_PAD * 2 - (noteMarginOn ? NOTE_MARGIN_W + PAGE_GAP : 0)
     const next =
       mode === 'width'
-        ? clampScale(availW / maxW)
-        : clampScale(
+        ? clampScaleFit(availW / maxW)
+        : clampScaleFit(
             Math.min(
               availW / maxW,
               (el.clientHeight - PAGE_GAP * 2) / Math.max(...dims.map((s) => s.height)),

--- a/apps/pdf/src/renderer/view-config.ts
+++ b/apps/pdf/src/renderer/view-config.ts
@@ -4,6 +4,12 @@ export const ASSET_BASE = new URL('pdfjs/', document.baseURI).href
 export const ZOOM_STEPS = [0.5, 0.67, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4]
 export const MIN_SCALE = ZOOM_STEPS[0]
 export const MAX_SCALE = ZOOM_STEPS[ZOOM_STEPS.length - 1]
+
+/// Manual-zoom clamp: keeps the scale between the zoom-step endpoints.
+export const clampScale = (s: number): number => Math.min(MAX_SCALE, Math.max(MIN_SCALE, s))
+/// Fit-derived clamp: skips the manual-zoom floor so a large page whose true
+/// fit-width is 22% opens at 22%, not at the 50% manual-zoom minimum (#142).
+export const clampScaleFit = (s: number): number => Math.min(MAX_SCALE, s)
 export const PAGE_GAP = 16
 export const SCROLL_PAD = 24
 // ── Sidebar (thumbnails / outline) width: drag the divider to resize; persisted ──

--- a/apps/pdf/tests/zoom-clamp.test.ts
+++ b/apps/pdf/tests/zoom-clamp.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { clampScale, clampScaleFit, MAX_SCALE, MIN_SCALE } from '../src/renderer/view-config'
+
+describe('clampScale (manual zoom)', () => {
+  it('floors at MIN_SCALE and caps at MAX_SCALE', () => {
+    expect(clampScale(0.3)).toBe(MIN_SCALE)
+    expect(clampScale(0.5)).toBe(0.5)
+    expect(clampScale(1)).toBe(1)
+    expect(clampScale(4)).toBe(MAX_SCALE)
+    expect(clampScale(10)).toBe(MAX_SCALE)
+  })
+})
+
+describe('clampScaleFit (fit-derived zoom)', () => {
+  it('caps at MAX_SCALE but skips the MIN_SCALE floor', () => {
+    // A scanned page whose true fit-width is 22% opens at 22%, not 50% (#142).
+    expect(clampScaleFit(0.22)).toBe(0.22)
+    expect(clampScaleFit(0.1)).toBe(0.1)
+    expect(clampScaleFit(0.01)).toBe(0.01)
+  })
+
+  it('still caps at MAX_SCALE', () => {
+    expect(clampScaleFit(10)).toBe(MAX_SCALE)
+    expect(clampScaleFit(MAX_SCALE)).toBe(MAX_SCALE)
+  })
+
+  it('passes through normal fit scales unchanged', () => {
+    expect(clampScaleFit(0.67)).toBe(0.67)
+    expect(clampScaleFit(1)).toBe(1)
+    expect(clampScaleFit(1.5)).toBe(1.5)
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** The PDF app's fit-to-width and fit-to-page calculations no longer clamp through `MIN_SCALE` (50%). A new `clampScaleFit` helper caps only at `MAX_SCALE`, so a scanned page whose true fit-width is 22% opens at 22% instead of being forced to 50%. Manual zoom (slider, buttons, Ctrl+wheel) keeps the existing 50%–400% range via the unchanged `clampScale`.
- **Why is this change needed?** Fixes #142. Image-based PDFs with large page sizes compute a true fit-width well below 50% (the issue reporter measured ~22%), but `recomputeFit` clamped through `MIN_SCALE`, forcing the initial view to 50% — far too large for scanned documents. Every other PDF viewer fits the page width on open.

Implementation notes:

- Both clamping helpers now live in `view-config.ts` alongside the zoom constants they use, exported for testability; `App.tsx` imports them instead of defining a local closure.
- The saved-view restore path still uses `clampScale` (with the floor) because it's restoring a user-chosen zoom, not computing a fit.
- The zoom slider's `min` attribute still shows `MIN_SCALE * 100` — manual zoom-out stops at 50% as before; only the initial/fit-recalculation path is affected.

## Related issue

Fixes #142

## Validation

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — new `tests/zoom-clamp.test.ts` (4 cases): `clampScale` floors at MIN_SCALE and caps at MAX_SCALE; `clampScaleFit` passes sub-MIN scales through (0.22, 0.1, 0.01); `clampScaleFit` still caps at MAX_SCALE; normal fit scales pass through unchanged. Existing `view-state.test.ts` passes alongside.

List any checks not run and explain why:

- `npm run lint` — the scoped ESLint run on `App.tsx` (8,400+ lines) exceeds this machine's command timeout; CI covers it. The changed lines follow the file's existing conventions exactly.
- Sidecar-dependent tests cannot run locally (no MSVC toolchain); CI builds the sidecar first. No Rust code is touched.

## Screenshots or recordings

Not applicable — visual change: opening a large image-based PDF now fits the page width instead of showing a zoomed-in view at 50%.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: display-only zoom change.
