### PR TITLE
fix(markdown): wait for in-flight saves during close instead of silently failing

### DIFF
--- a/apps/markdown/src/renderer/App.tsx
+++ b/apps/markdown/src/renderer/App.tsx
@@ -393,7 +393,22 @@ export default function App() {
       (mode) => void doSave(mode).then((ok) => window.markdownApi.sendSaveRequestAck(ok)),
     )
     const offClose = window.markdownApi.onCloseSaveRequest(() => {
-      void doSave('save').then((ok) => window.markdownApi.sendCloseSaveResult(ok))
+      void (async () => {
+        // A close-save arriving during an in-flight autosave must wait for it
+        // instead of failing (the old immediate `false` from `savingRef` made
+        // "Save and close" silently give up during a blur autosave — the same
+        // bug the docs app fixed with its save serializer).
+        while (savingRef.current) {
+          await new Promise((resolve) => setTimeout(resolve, 50))
+        }
+        // The in-flight save may have already persisted everything.
+        if (!dirtyRef.current) {
+          window.markdownApi.sendCloseSaveResult(true)
+          return
+        }
+        const ok = await doSave('save')
+        window.markdownApi.sendCloseSaveResult(ok)
+      })()
     })
     const offRenamed = window.markdownApi.onFileRenamed((newPath) => setFilePath(newPath))
     const onKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Summary

- **What changed?** The Markdown app's close-save handler now waits for any in-flight autosave to finish before deciding whether to run its own save. Previously it called `doSave('save')` which returned `false` immediately when `savingRef.current` was set, so clicking "Save" in the close dialog silently canceled the close with zero feedback.
- **Why is this change needed?** An explicit save action silently no-ops exactly when work is being saved — users can believe their document state is lost or the app is broken. Both sibling apps fixed this precise bug: the docs app shipped `save-until-persisted.ts` with the comment *"the old immediate `false` made 'Save and close' silently give up during a blur autosave"*, and the PDF app queues concurrent saves. Markdown was the only editor without the fix.

The fix follows the simplest correct pattern: poll `savingRef` until the in-flight save completes, skip the retry when the document is already clean (the in-flight save may have persisted everything), then run the explicit save and report the real outcome. No new module, no architecture change — a 16-line focused patch inside the existing close handler.

## Related issue

No tracking issue — found by code inspection during a cross-app save-flow audit (the docs and pdf apps already had the fix; markdown was the gap).

## Validation

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — existing markdown suites pass (`doc-text`: 14, `teardown`: 8)

List any checks not run and explain why:

- No new unit test: the fix lives inside the App.tsx close-save callback (renderer-only UI tweak — per CONTRIBUTING, "renderer-only UI tweaks generally don't" need tests). The pattern is identical to the docs app's `save-until-persisted.ts`, which has 6 passing tests covering the same queueing semantics.
- Sidecar-dependent tests cannot run locally (no MSVC toolchain); CI builds the sidecar first.

## Screenshots or recordings

Not applicable — behavior change: clicking "Save" in the close dialog during an in-flight autosave now waits and saves, instead of silently canceling the close.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: save-flow fix, no format change.
