### PR TITLE
fix(ai-provider): release SSE reader when the consumer abandons the stream mid-flight

### DIFF
--- a/packages/ai-provider/src/protocols/shared.ts
+++ b/packages/ai-provider/src/protocols/shared.ts
@@ -10,16 +10,25 @@ export async function* sseLines(
   let buffer = ''
   const stream = body as ReadableStream<Uint8Array>
   const reader = stream.getReader()
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    onBytes?.()
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split('\n')
-    buffer = lines.pop() ?? ''
-    for (const line of lines) yield line
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      onBytes?.()
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+      for (const line of lines) yield line
+    }
+    if (buffer) yield buffer
+  } finally {
+    // The consumer may abandon this generator mid-stream (an in-band gateway
+    // error thrown inside the for-await loop calls .return()). Without this
+    // cleanup the reader stays locked and the underlying socket is not
+    // returned to the pool until GC nondeterministically finalizes it.
+    await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
   }
-  if (buffer) yield buffer
 }
 
 export interface StreamCallbacks {

--- a/packages/ai-provider/tests/sse-lines.test.ts
+++ b/packages/ai-provider/tests/sse-lines.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { sseLines } from '../src/protocols/shared'
+
+function sseBody(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line + '\n'))
+      controller.close()
+    },
+  })
+}
+
+function hangingBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('data: first\n\n'))
+      // Never closes — the stream stays open.
+    },
+  })
+}
+
+describe('sseLines', () => {
+  it('yields SSE lines from a completing stream', async () => {
+    const lines: string[] = []
+    for await (const line of sseLines(sseBody(['data: a', 'data: b', '']))) {
+      lines.push(line)
+    }
+    expect(lines).toEqual(['data: a', 'data: b', ''])
+  })
+
+  it('releases the reader when the consumer abandons mid-stream', async () => {
+    const body = hangingBody()
+    const reader = body.getReader()
+    reader.releaseLock() // give the lock back so sseLines can acquire it
+    const gen = sseLines(body)
+    const first = await gen.next()
+    expect(first.value).toBe('data: first')
+    // Abandon: .return() triggers the finally block, which must cancel and
+    // release the reader so the underlying socket can be reused.
+    await gen.return(undefined)
+    // If the lock was not released this would throw.
+    expect(() => body.getReader()).not.toThrow()
+  })
+
+  it('propagates consumer exceptions and still releases the reader', async () => {
+    const body = hangingBody()
+    const reader = body.getReader()
+    reader.releaseLock()
+    const gen = sseLines(body)
+    await gen.next()
+    // The consumer throws inside the for-await loop — JS calls gen.return(),
+    // which runs the finally block.
+    await expect(gen.throw(new Error('gateway error'))).rejects.toThrow('gateway error')
+    expect(() => body.getReader()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** The `sseLines` async generator (shared by all three AI protocol adapters — Anthropic, Gemini, OpenAI-compatible) now wraps its read loop in `try/finally` that cancels the reader and releases the lock when the generator is abandoned mid-stream.
- **Why is this change needed?** Every in-band gateway error (quota, moderation, upstream — documented as real at `shared.ts:70-75`) causes the consumer to throw inside its `for await` loop. JS then calls the generator's `.return()`, but without a `finally` block the reader was simply dropped: the response body stayed locked and the underlying HTTPS socket was not returned to the pool until GC nondeterministically finalized it. Repeated AI runs against flaky gateways accumulated dangling readers/sockets in the long-lived Electron main process, degrading or eventually exhausting connections.

The fix is the standard async-generator cleanup pattern — `try/finally { reader.cancel(); reader.releaseLock() }` — with the cancel error swallowed (best-effort cleanup).

## Related issue

No tracking issue — found by code inspection during a resource-leak audit of the AI provider packages.

## Validation

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — new `packages/ai-provider/tests/sse-lines.test.ts` (3 cases): normal SSE line splitting works; abandoning the generator mid-stream (`.return()`) releases the reader lock; a consumer exception (`gen.throw()`) propagates correctly and still releases the lock.

List any checks not run and explain why:

- `npm run lint` — the repo-wide lint exceeds this machine's timeout; the scoped ESLint run over both changed files passes with 0 errors.
- Sidecar-dependent tests cannot run locally (no MSVC toolchain); CI builds the sidecar first.

## Screenshots or recordings

Not applicable — resource-leak fix; no visible behavior change.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — N/A: network-stream cleanup only.
