### PR TITLE
fix(slides): serialize concurrent saves to prevent file corruption

### DIFF
--- a/apps/slides/src/renderer/file-actions.ts
+++ b/apps/slides/src/renderer/file-actions.ts
@@ -39,25 +39,45 @@ export function adoptSavedSlides(ctx: ActionCtx, next: RenderSlide[]): void {
   ctx.setSlides(next)
 }
 
+/**
+ * Serializes save passes: a call that arrives while a save is in flight waits
+ * for it instead of running concurrently. Two overlapping saves write the
+ * same file with two `createWriteStream` pipes — interleaved zip streams,
+ * truncated pptx, or EPERM/EBUSY on Windows. The queue is a simple promise
+ * chain: each caller awaits the previous tail, then runs its own pass.
+ */
+let saveTail: Promise<boolean> | null = null
+
 export async function save(ctx: ActionCtx, quiet = false): Promise<boolean> {
-  await flushActiveEdit(ctx)
-  await ctx.flushNotes()
-  const r = await window.slidesApi.save()
-  if (r.ok) {
-    if (r.slides) adoptSavedSlides(ctx, r.slides)
-    if (r.path) ctx.setPath(r.path)
-    ctx.setDirty(false)
-    const saved = t('appStatusSaved')
-    ctx.setStatus(saved)
-    if (!quiet) showToast(saved)
-  } else {
-    const failed = t('appStatusSaveFailed', { error: r.error ?? t('appErrorCanceled') })
-    ctx.setStatus(failed)
-    // quiet suppresses the success toast only — a failed save (incl. the 30s
-    // auto-save) must surface, or edits silently stop reaching disk
-    showToast(failed, 'error')
-  }
-  return r.ok
+  const prior = saveTail
+  const pass = (async () => {
+    if (prior) await prior.catch(() => false)
+    await flushActiveEdit(ctx)
+    await ctx.flushNotes()
+    const r = await window.slidesApi.save()
+    if (r.ok) {
+      if (r.slides) adoptSavedSlides(ctx, r.slides)
+      if (r.path) ctx.setPath(r.path)
+      ctx.setDirty(false)
+      const saved = t('appStatusSaved')
+      ctx.setStatus(saved)
+      if (!quiet) showToast(saved)
+    } else {
+      const failed = t('appStatusSaveFailed', { error: r.error ?? t('appErrorCanceled') })
+      ctx.setStatus(failed)
+      // quiet suppresses the success toast only — a failed save (incl. the 30s
+      // auto-save) must surface, or edits silently stop reaching disk
+      showToast(failed, 'error')
+    }
+    return r.ok
+  })()
+  saveTail = pass
+  pass
+    .catch(() => false)
+    .then(() => {
+      if (saveTail === pass) saveTail = null
+    })
+  return pass
 }
 
 export async function saveAs(ctx: ActionCtx): Promise<void> {

--- a/apps/slides/tests/save-serialization.test.ts
+++ b/apps/slides/tests/save-serialization.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { save } from '../src/renderer/file-actions'
+import type { ActionCtx } from '../src/renderer/action-context'
+
+function ctx(): ActionCtx {
+  return {
+    flushActiveEditRef: { current: () => Promise.resolve() },
+    editingActiveRef: { current: false },
+    flushNotes: () => Promise.resolve(),
+    slides: [],
+    current: 0,
+    setSlides: () => {},
+    setSelectedIds: () => {},
+    setEnteredGroupId: () => {},
+    setEditing: () => {},
+    setEditingCell: () => {},
+    setDirty: () => {},
+    setPath: () => {},
+    setStatus: () => {},
+    path: '/test/deck.pptx',
+  } as unknown as ActionCtx
+}
+
+describe('slides save serialization', () => {
+  it('queues concurrent saves so only one IPC write runs at a time', async () => {
+    let inFlight = 0
+    let maxConcurrent = 0
+    const mockSave = vi.fn(async () => {
+      inFlight += 1
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      // Simulate a slow write.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      inFlight -= 1
+      return { ok: true }
+    })
+    vi.stubGlobal('window', { slidesApi: { save: mockSave } })
+
+    // Fire three saves simultaneously — they must queue, not overlap.
+    const [a, b, c] = await Promise.all([save(ctx()), save(ctx(), true), save(ctx())])
+
+    expect(a).toBe(true)
+    expect(b).toBe(true)
+    expect(c).toBe(true)
+    expect(mockSave).toHaveBeenCalledTimes(3)
+    expect(maxConcurrent).toBe(1)
+
+    vi.unstubAllGlobals()
+  })
+
+  it('reports failure without blocking the queue for the next caller', async () => {
+    let calls = 0
+    const mockSave = vi.fn(async () => {
+      calls += 1
+      if (calls === 1) return { ok: false, error: 'disk full' }
+      return { ok: true }
+    })
+    vi.stubGlobal('window', { slidesApi: { save: mockSave } })
+
+    const first = save(ctx(), true)
+    const second = save(ctx(), true)
+    const [r1, r2] = await Promise.all([first, second])
+
+    expect(r1).toBe(false)
+    expect(r2).toBe(true)
+    expect(mockSave).toHaveBeenCalledTimes(2)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/apps/slides/tests/save-serialization.test.ts
+++ b/apps/slides/tests/save-serialization.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
+
+// file-actions pulls export-render → pptx-render → konva → native `canvas`
+// (missing in CI). Mock the UI-only modules so this unit test exercises
+// only the save-serialization queue.
+vi.mock('../src/renderer/export-render', () => ({ renderSlidesToPngBase64: vi.fn() }))
+vi.mock('../src/renderer/components/toast-bus', () => ({ showToast: vi.fn() }))
+vi.mock('../src/renderer/i18n/locale', () => ({ t: (k: string) => k }))
+
 import { save } from '../src/renderer/file-actions'
 import type { ActionCtx } from '../src/renderer/action-context'
 


### PR DESCRIPTION
## Summary

- **What changed?** `fileActions.save()` now queues concurrent calls behind a promise-chain tail — a second save arriving while one is in flight waits for it instead of running simultaneously. The queue is the same pattern the docs app uses (`save-until-persisted.ts`) and the markdown app received in #149.
- **Why is this change needed?** The `save()` function had no in-flight guard at any layer: the renderer autosave guards only its own local `saving` flag (which a user ⌘S or close-save bypasses), and the main-process `slides:save` handler accepts overlapping invocations without a busy check. The write itself is non-atomic — `createWriteStream` directly to the target path — so two concurrent calls interleave zip streams, truncate the pptx, or fail with EPERM/EBUSY on Windows, then both completions race on the dirty flags. Result: a corrupted deck on disk with the dirty state cleared — silent data loss.

Realistic triggers: double-tap Ctrl+S; the 30s autosave is still streaming a large deck when the user hits Ctrl+S; or the user closes the tab and picks "Save" in the close prompt while the autosave is in flight.

The fix is a 3-line promise chain at the renderer level (the single entry point all callers share). No changes to the main process or the pptx-engine write path.

## Related issue

No tracking issue — found by code inspection during a cross-app save-flow audit (docs has a serializer, markdown got one in #149, slides had none).

## Validation

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm test` — new `tests/save-serialization.test.ts` (2 cases): three concurrent saves queue with max concurrency 1; a failed first save doesn't block the second from succeeding. **Note:** the slides vitest worker (jsdom) times out on this Windows machine even on pristine `upstream/main` — CI on Ubuntu covers the actual run.

List any checks not run and explain why:

- The vitest worker for slides tests (jsdom) times out on this machine even on `upstream/main` with zero changes (reproduced by stashing and re-running). CI on Ubuntu covers the full suite.
- Sidecar-dependent tests cannot run locally (no MSVC toolchain); CI builds the sidecar first. No Rust code is touched.

## Screenshots or recordings

Not applicable — correctness fix; no visible change for single (non-concurrent) saves.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. — N/A: no new strings.
- [x] File open/save changes include an appropriate round-trip or fidelity test. — The serialization test proves saves queue correctly; the write path itself is unchanged.
