### PR TITLE
feat(ai-provider): add OrcaRouter as a first-class BYOK provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ layer.
 - **PowerPoint-compatible presentations** — in-house `.pptx` engine with masters, layouts, smart guides, non-destructive crop.
 - **Markdown to Word, fully local** — the same OOXML engine, no Pandoc, no cloud.
 - **AI that edits documents** — block-level edits with snapshots and diffs, document-aware agents.
-- **Bring your own key (BYOK)** — run the AI on your own API key: Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, or any OpenAI-compatible endpoint — or sign in with Genspark and skip keys entirely.
+- **Bring your own key (BYOK)** — run the AI on your own API key: Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, OrcaRouter, or any OpenAI-compatible endpoint — or sign in with Genspark and skip keys entirely.
 - **Agent tools built in** — web/image search, image generation, media analysis.
 - **Light / dark / system themes.**
 - **macOS, Windows, Linux.**
@@ -101,8 +101,8 @@ apps sign in to a Genspark account through a device-code flow — no model API
 key to enter — and model calls route through the Genspark proxy (Claude,
 GPT, and Gemini families). Or bring your own key (BYOK) in the AI settings:
 Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-Mistral, and OpenRouter are built in, plus a custom provider slot for any
-OpenAI-compatible endpoint (base URL + key), local servers included. A
+Mistral, OpenRouter, and OrcaRouter are built in, plus a custom provider slot
+for any OpenAI-compatible endpoint (base URL + key), local servers included. A
 Genspark account also unlocks the Genspark ("gsk") tool endpoints the agents
 build on — web and image search, image generation and editing,
 image/audio/video analysis, and audio transcription — all reachable through
@@ -198,8 +198,8 @@ to editable text rather than a page image.
 **Can I use my own AI model or API key?**
 Yes. Besides the keyless Genspark sign-in, GenOffice supports bring your own
 key (BYOK) for Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao,
-MiniMax, Grok, Mistral, and OpenRouter, plus any OpenAI-compatible endpoint
-— including local model servers.
+MiniMax, Grok, Mistral, OpenRouter, and OrcaRouter, plus any OpenAI-compatible
+endpoint — including local model servers.
 
 **Does GenOffice collect any data?**
 Official packaged builds send limited usage analytics by default, and you can

--- a/apps/shell/src/renderer/src/provider-logos.tsx
+++ b/apps/shell/src/renderer/src/provider-logos.tsx
@@ -7,8 +7,8 @@ import type { AiProviderId } from '@genoffice/ai-provider'
 // hand-traced Genspark mark and a generic icon for the "custom" endpoint.
 // Brand-colored logos keep their official colors in both themes (brand
 // assets, not chrome — see CLAUDE.md theming rules); monochrome marks
-// (OpenAI, Kimi, Grok, OpenRouter, Genspark, Custom) use currentColor so
-// they stay legible in dark mode.
+// (OpenAI, Kimi, Grok, OpenRouter, OrcaRouter, Genspark, Custom) use
+// currentColor so they stay legible in dark mode.
 //
 // Gradient-filled marks (Gemini, Qwen, MiniMax) are components so useId can
 // namespace their <linearGradient> ids per mount: the dropdown renders the
@@ -191,6 +191,11 @@ const LOGOS: Record<AiProviderId, ReactNode> = {
   openrouter: (
     <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" aria-hidden="true">
       <path d="M18.654 3.87a5.087 5.087 0 110 10.174L23.7 19.09c.64.641.187 1.737-.72 1.737H8.48a8.479 8.479 0 010-16.958h10.175zM8.479 7.26a5.087 5.087 0 100 10.176 5.087 5.087 0 000-10.175z" />
+    </svg>
+  ),
+  orcarouter: (
+    <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" aria-hidden="true">
+      <path d="M12 1.5a10.5 10.5 0 100 21 10.5 10.5 0 000-21zM5.2 9.6a6.6 6.6 0 0111.4-2.3c.36-.24.78-.38 1.2-.4a.84.84 0 00.13-1.66A8.7 8.7 0 003.55 9.95a.84.84 0 001.65-.34zm11.7 1.35a6.6 6.6 0 01-9.9 4.95.84.84 0 10-.86 1.45 8.28 8.28 0 007.4-.22 8.28 8.28 0 004.95-7.5.84.84 0 10-1.68 0 6.6 6.6 0 01.09 1.32zm-4.9-1.62a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
     </svg>
   ),
   custom: (

--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -165,6 +165,24 @@ export const AI_PROVIDERS: AiProviderMeta[] = [
     keyPlaceholder: 'sk-or-...',
   },
   {
+    id: 'orcarouter',
+    label: 'OrcaRouter',
+    // vendor-prefixed slugs exactly as api.orcarouter.ai/v1/models lists them,
+    // mirroring OpenRouter; `orcarouter/auto` is the adaptive router default
+    models: [
+      'orcarouter/auto',
+      'orcarouter/fusion',
+      'orcarouter/fusion-flash',
+      'anthropic/claude-sonnet-5',
+      'anthropic/claude-fable-5',
+      'openai/gpt-5.6-sol',
+      'deepseek/deepseek-v4-flash',
+      'google/gemini-3.1-pro-preview',
+    ],
+    defaultModel: 'orcarouter/auto',
+    keyPlaceholder: 'ocr_...',
+  },
+  {
     id: 'custom',
     label: 'Custom',
     models: [],

--- a/packages/ai-provider/src/registry.ts
+++ b/packages/ai-provider/src/registry.ts
@@ -188,6 +188,11 @@ export const AI_PROVIDER_ADAPTERS: Record<AiProviderId, ProviderAdapter> = {
     capabilities: { auth: 'api-key', vision: true },
     resolveEndpoint: fixedEndpoint('openai-compatible', 'https://openrouter.ai/api/v1'),
   },
+  orcarouter: {
+    meta: metaOf('orcarouter'),
+    capabilities: { auth: 'api-key', vision: true },
+    resolveEndpoint: fixedEndpoint('openai-compatible', 'https://api.orcarouter.ai/v1'),
+  },
   custom: {
     meta: metaOf('custom'),
     capabilities: { auth: 'api-key', vision: true },

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -14,6 +14,7 @@ export type AiProviderId =
   | 'xai'
   | 'mistral'
   | 'openrouter'
+  | 'orcarouter'
   | 'custom'
 
 /** Genspark account status (gsk login state; the sole auth source for AI features) */

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -36,6 +36,14 @@ describe('provider model catalog', () => {
     expect(genspark.models).not.toContain('deep-seek-v4-flash')
     expect(genspark.models).not.toContain('deep-seek-v4-flash-vision-exp-openrouter')
   })
+
+  it('lists the orcarouter adaptive-router ids and defaults to orcarouter/auto', () => {
+    const orcarouter = AI_PROVIDERS.find((provider) => provider.id === 'orcarouter')!
+
+    expect(orcarouter.models).toContain('orcarouter/auto')
+    expect(orcarouter.models).toContain('anthropic/claude-sonnet-5')
+    expect(orcarouter.defaultModel).toBe('orcarouter/auto')
+  })
 })
 
 describe('resolveAiSettings', () => {

--- a/packages/ai-provider/tests/registry.test.ts
+++ b/packages/ai-provider/tests/registry.test.ts
@@ -81,6 +81,7 @@ describe('provider registry', () => {
       ['xai', 'grok-4.6', 'https://api.x.ai/v1'],
       ['mistral', 'mistral-large-latest', 'https://api.mistral.ai/v1'],
       ['openrouter', 'openrouter/auto', 'https://openrouter.ai/api/v1'],
+      ['orcarouter', 'orcarouter/auto', 'https://api.orcarouter.ai/v1'],
     ]
     for (const [id, model, baseUrl] of cases) {
       expect(AI_PROVIDER_ADAPTERS[id].resolveEndpoint(config(model))).toEqual({


### PR DESCRIPTION
## Summary

GenOffice is *"the world's first full-featured open-source AI Office suite"*, built around AI editing as a first-class workflow. For anyone who brings their own key in **AI Settings**, the suite already ships OpenRouter as a first-class provider — its models show up in the picker as `openrouter/*` slugs and traffic goes straight to `https://openrouter.ai/api/v1`, no "custom base URL" ceremony needed.

This PR adds **OrcaRouter** the same way. Users can now select **OrcaRouter** in the provider dropdown and pick from its vendor-prefixed model slugs (`orcarouter/auto` adaptive router, `orcarouter/fusion`, `anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`, …) exactly as they do with OpenRouter today.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means GenOffice users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- `packages/ai-provider/src/types.ts` — extend `AiProviderId` with `'orcarouter'`
- `packages/ai-provider/src/providers.ts` — provider catalog entry mirroring the OpenRouter entry: vendor-prefixed model slugs, `orcarouter/auto` as default model, `ocr_...` key placeholder
- `packages/ai-provider/src/registry.ts` — OpenAI-compatible adapter pinned to `https://api.orcarouter.ai/v1`
- `apps/shell/src/renderer/src/provider-logos.tsx` — brand mark for the provider picker
- `README.md` — OrcaRouter added to the BYOK provider lists
- tests — catalog + endpoint resolution coverage in `providers.test.ts` / `registry.test.ts`

## Related issue

N/A

## Validation

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; only pre-existing warnings in unrelated files)
- [x] `npm run typecheck`
- [x] `npm test` (JS suites green: 122 files / 1283 tests; the `@genoffice/sheets` Rust sidecar suite was not run — `cargo` is unavailable in this container and this change does not touch it)

Live connectivity was verified against the new endpoint: an OpenAI-compatible `chat/completions` request to `https://api.orcarouter.ai/v1` with the `orcarouter/auto` model returned HTTP 200 (`"OK"`), and the same with `anthropic/claude-sonnet-5`.

## Screenshots or recordings

Not applicable — no visible UI change beyond a new entry in the AI settings provider picker.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (Provider names are brand names rendered from the provider catalog, consistent with the existing OpenRouter/OpenAI entries.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A — provider registry change only.)

---
Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
