### PR TITLE
fix: rotated table cell double click to edit in slides

### DIFF
--- a/apps/slides/src/renderer/App.tsx
+++ b/apps/slides/src/renderer/App.tsx
@@ -31,6 +31,7 @@ import type {
   TransitionKind,
 } from '../shared/ipc'
 import { SlideCanvas, selectionChromeColor } from './SlideCanvas'
+import { tableCellOverlayBox } from './table-hit'
 import { ZOOM_PREVIEW_EVENT } from './zoom-preview'
 import { createWheelPager } from './wheel-page-flip'
 import type { DrawRect } from './draw-shape'
@@ -2175,13 +2176,7 @@ export function App() {
       type: 'shape',
       sourceId: tbl.sourceId,
       box: {
-        x: tbl.box.x + cell.x,
-        y: tbl.box.y + cell.y,
-        w: cell.w,
-        h: cell.h,
-        rotationDeg: 0,
-        flipH: false,
-        flipV: false,
+        ...tableCellOverlayBox(tbl.box, cell),
       },
       fill: { kind: 'none' },
       ...(cell.text ? { text: cell.text } : {}),

--- a/apps/slides/src/renderer/SlideCanvas.tsx
+++ b/apps/slides/src/renderer/SlideCanvas.tsx
@@ -32,6 +32,7 @@ import type {
   GroupRenderNode,
 } from '@genoffice/pptx-render'
 import { boxPivotProps, fillToKonva, isEditableText } from './konva-adapter'
+import { tableCellAtPoint, tableLocalPointFromStage } from './table-hit'
 import {
   computeSnap,
   computeSpacingSnap,
@@ -860,14 +861,9 @@ export function SlideCanvas({
           const raw = e.target.getStage()?.getPointerPosition()
           // Stage coordinates -> slide coordinates (remove the bleed offset)
           const pos = raw ? { x: raw.x - CANVAS_BLEED, y: raw.y - CANVAS_BLEED } : null
-          if (n && n.type === 'table' && !n.box.rotationDeg && pos) {
-            const hit = (n as TableRenderNode).cells.find(
-              (c) =>
-                pos.x - n.box.x >= c.x &&
-                pos.x - n.box.x < c.x + c.w &&
-                pos.y - n.box.y >= c.y &&
-                pos.y - n.box.y < c.y + c.h,
-            )
+          if (n && n.type === 'table' && pos) {
+            const local = tableLocalPointFromStage(pos, n.box)
+            const hit = tableCellAtPoint(n, local)
             if (hit) cell = { row: hit.row, col: hit.col }
           }
         }
@@ -1839,16 +1835,13 @@ function NodeView({
     }
     onEnterGroup(node.sourceId, childId)
   }
-  // Table: double-click hits a cell (pointer coordinates -> table-local coordinates; editing rotated tables not supported yet)
+  // Table: double-click hits a cell in table-local coordinates, regardless of rotation/flip.
   const onTableDblClick = (e: Konva.KonvaEventObject<Event>) => {
-    if (node.type !== 'table' || box.rotationDeg) return
+    if (node.type !== 'table') return
     const pos = e.target.getStage()?.getPointerPosition()
     if (!pos) return
-    const rx = pos.x - CANVAS_BLEED - box.x
-    const ry = pos.y - CANVAS_BLEED - box.y
-    const cell = (node as TableRenderNode).cells.find(
-      (c) => rx >= c.x && rx < c.x + c.w && ry >= c.y && ry < c.y + c.h,
-    )
+    const local = tableLocalPointFromStage(pos, box, CANVAS_BLEED)
+    const cell = tableCellAtPoint(node, local)
     if (cell) onEditTableCell(node.sourceId, cell.row, cell.col)
   }
   // Audio/video (image is the poster frame): double-click opens the playback overlay

--- a/apps/slides/src/renderer/TextEditOverlay.tsx
+++ b/apps/slides/src/renderer/TextEditOverlay.tsx
@@ -542,6 +542,8 @@ export function TextEditOverlay({
         top: box.y,
         width: box.w,
         height: box.h,
+        transform: `rotate(${box.rotationDeg ?? 0}deg) scale(${box.flipH ? -1 : 1}, ${box.flipV ? -1 : 1})`,
+        transformOrigin: 'center center',
         zIndex: 20,
         display: 'flex',
         // Vertical text: the row direction keeps the anchor mapping (top = the

--- a/apps/slides/src/renderer/table-hit.ts
+++ b/apps/slides/src/renderer/table-hit.ts
@@ -1,0 +1,69 @@
+import type { TableRenderNode } from '@genoffice/pptx-render'
+
+export function tableLocalPointFromStage(
+  stagePoint: { x: number; y: number },
+  box: {
+    x: number
+    y: number
+    w: number
+    h: number
+    rotationDeg?: number
+    flipH?: boolean
+    flipV?: boolean
+  },
+  bleed = 0,
+): { x: number; y: number } {
+  const px = stagePoint.x - bleed
+  const py = stagePoint.y - bleed
+  const cx = box.x + box.w / 2
+  const cy = box.y + box.h / 2
+  const dx = px - cx
+  const dy = py - cy
+  const rad = ((box.rotationDeg ?? 0) * Math.PI) / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  let lx = dx * cos + dy * sin
+  let ly = -dx * sin + dy * cos
+  if (box.flipH) lx = -lx
+  if (box.flipV) ly = -ly
+  return { x: lx + box.w / 2, y: ly + box.h / 2 }
+}
+
+export function tableCellAtPoint(
+  table: Pick<TableRenderNode, 'cells'>,
+  point: { x: number; y: number },
+) {
+  return table.cells.find(
+    (c) => point.x >= c.x && point.x < c.x + c.w && point.y >= c.y && point.y < c.y + c.h,
+  )
+}
+
+export function tableCellOverlayBox(
+  box: {
+    x: number
+    y: number
+    w: number
+    h: number
+    rotationDeg?: number
+    flipH?: boolean
+    flipV?: boolean
+  },
+  cell: { x: number; y: number; w: number; h: number },
+) {
+  const rad = ((box.rotationDeg ?? 0) * Math.PI) / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  let dx = cell.x + cell.w / 2 - box.w / 2
+  let dy = cell.y + cell.h / 2 - box.h / 2
+  if (box.flipH) dx = -dx
+  if (box.flipV) dy = -dy
+  return {
+    x: box.x + box.w / 2 + dx * cos - dy * sin - cell.w / 2,
+    y: box.y + box.h / 2 + dx * sin + dy * cos - cell.h / 2,
+    w: cell.w,
+    h: cell.h,
+    rotationDeg: box.rotationDeg ?? 0,
+    flipH: box.flipH ?? false,
+    flipV: box.flipV ?? false,
+  }
+}

--- a/apps/slides/tests/table-hit.test.ts
+++ b/apps/slides/tests/table-hit.test.ts
@@ -1,0 +1,59 @@
+import type { TableRenderNode } from '@genoffice/pptx-render'
+import { describe, expect, it } from 'vitest'
+import {
+  tableCellAtPoint,
+  tableCellOverlayBox,
+  tableLocalPointFromStage,
+} from '../src/renderer/table-hit'
+
+function makeTable(): TableRenderNode {
+  return {
+    type: 'table',
+    sourceId: 't1',
+    id: 'node_t1',
+    box: { x: 100, y: 50, w: 120, h: 80, rotationDeg: 0 },
+    cells: [
+      { x: 0, y: 0, w: 60, h: 40, row: 0, col: 0, fill: { kind: 'solid', color: '#fff' } },
+      { x: 60, y: 0, w: 60, h: 40, row: 0, col: 1, fill: { kind: 'solid', color: '#fff' } },
+      { x: 0, y: 40, w: 60, h: 40, row: 1, col: 0, fill: { kind: 'solid', color: '#fff' } },
+      { x: 60, y: 40, w: 60, h: 40, row: 1, col: 1, fill: { kind: 'solid', color: '#fff' } },
+    ],
+    gridX: [0, 60, 120],
+    gridY: [0, 40, 80],
+  } as unknown as TableRenderNode
+}
+
+describe('table cell hit testing', () => {
+  it('resolves a cell in unrotated table coordinates', () => {
+    const table = makeTable()
+    expect(tableCellAtPoint(table, { x: 20, y: 10 })).toMatchObject({ row: 0, col: 0 })
+    expect(tableCellAtPoint(table, { x: 95, y: 12 })).toMatchObject({ row: 0, col: 1 })
+  })
+
+  it('rotates stage hits back into table-local coordinates', () => {
+    const table = makeTable()
+    const rad = (45 * Math.PI) / 180
+    const local = { x: 90, y: 60 }
+    const stagePoint = {
+      x: 160 + (local.x - 60) * Math.cos(rad) - (local.y - 40) * Math.sin(rad),
+      y: 90 + (local.x - 60) * Math.sin(rad) + (local.y - 40) * Math.cos(rad),
+    }
+    const inverse = tableLocalPointFromStage(stagePoint, {
+      x: table.box.x,
+      y: table.box.y,
+      w: table.box.w,
+      h: table.box.h,
+      rotationDeg: 45,
+    })
+    expect(inverse).toMatchObject({ x: 90, y: 60 })
+    expect(tableCellAtPoint(table, inverse)).toMatchObject({ row: 1, col: 1 })
+  })
+
+  it('places the edit overlay at the rotated cell center', () => {
+    const overlay = tableCellOverlayBox(
+      { x: 100, y: 50, w: 120, h: 80, rotationDeg: 90 },
+      { x: 60, y: 40, w: 60, h: 40 },
+    )
+    expect(overlay).toMatchObject({ x: 110, y: 100, w: 60, h: 40, rotationDeg: 90 })
+  })
+})


### PR DESCRIPTION
## Summary

- What changed?
  - Added rotation-aware table cell hit-testing in `apps/slides/src/renderer/table-hit.ts`.
  - Updated Slides double-click and context-menu cell detection to convert pointer coordinates into table-local coordinates.
  - Fixed the DOM editing overlay to calculate the rotated cell position and preserve table rotation/flips.
  - Added the matching center-origin CSS transform to `TextEditOverlay`.
  - Added regression tests for rotated hit-testing and overlay placement.

- Why is this change needed?
  - Rotated tables previously used unrotated coordinate math, so cell editing either did not activate or displayed the editor at the table's original position.

## Related issue

Closes #

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why:

- `npm test` was run but has one unrelated failure in `packages/font-metrics/tests/font-covering.test.ts`. The test expects unassigned codepoint `U+0378` to have no covering font, but the local environment resolves one.
- Slides-specific regression tests passed: `npx vitest run tests/table-hit.test.ts` from `apps/slides` with 3 tests passing.
- Slides production build passed: `npm run build -w @genoffice/slides`.

## Screenshots or recordings

Not applicable. No screenshot or recording was captured.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
