### PR TITLE
fix docs per-section page margins and pct table widths

### DIFF
--- a/apps/docs/src/renderer/editor/extensions.ts
+++ b/apps/docs/src/renderer/editor/extensions.ts
@@ -1804,8 +1804,13 @@ export const DocTable = Node.create({
     const styles: string[] = []
     let centerMargin: string | null = null
     if (displayAutoFit === 'contents') styles.push('width:auto')
-    else if (displayAutoFit === 'window') styles.push('width:100%')
-    else if (node.attrs.widthPct) styles.push(`width:${Number(node.attrs.widthPct)}%`)
+    // 'window' (w:tblLayout autofit with a full-width grid) and w:tblW type="pct"
+    // are both percentages of the section's TEXT COLUMN, not of the canvas' padding
+    // box: sections that disagree on margins/page width pad differently, so resolve
+    // through --doc-content-w (set per block by sectionWidthSpecs; unset → the old %)
+    else if (displayAutoFit === 'window') styles.push('width:var(--doc-content-w,100%)')
+    else if (node.attrs.widthPct)
+      styles.push(`width:calc(var(--doc-content-w,100%) * ${Number(node.attrs.widthPct) / 100})`)
     // Over-wide grids may spill into the page margins like Word/LO (clamping
     // them to the content box narrowed every column, wrapped cell text onto extra
     // lines and inflated PDF-converted documents by pages), but never past the paper:

--- a/apps/docs/src/renderer/editor/pagination-gaps.ts
+++ b/apps/docs/src/renderer/editor/pagination-gaps.ts
@@ -217,6 +217,11 @@ export function makeGapEl(m: GapMetrics, kind: GapKind, cols?: number): HTMLElem
         : 'page-gap'
   gap.style.marginLeft = `-${m.marginLeft}px`
   gap.style.marginRight = `-${m.marginRight}px`
+  // the next page's own side margins: a section whose margins differ from the
+  // canvas' first section gets its header/footer strips placed on ITS text
+  // column (alignGapHfStrips), not the cover's margin-less one
+  gap.style.setProperty('--gap-ml', `${m.marginLeft}px`)
+  gap.style.setProperty('--gap-mr', `${m.marginRight}px`)
   // inline-block (not block-level): avoids block-in-inline anonymous-box splitting,
   // which would re-apply text-indent/alignment on continuation lines and drift line
   // breaks; negative margins don't widen an inline-block, so width explicitly adds the bleed
@@ -744,8 +749,15 @@ export function clampCellBoxTops(pm: HTMLElement, paperTop: number, factor: numb
  * setPageGaps while the widgets' rects are final).
  */
 export function alignGapHfStrips(pm: HTMLElement, bodyLeftPx: number, factor: number): void {
-  const target = pm.getBoundingClientRect().left + bodyLeftPx * factor
+  const pmLeft = pm.getBoundingClientRect().left
+  const canvasTarget = pmLeft + bodyLeftPx * factor
   for (const el of Array.from(pm.querySelectorAll<HTMLElement>('.page-gap-hf'))) {
+    // prefer the gap's own section inset (--gap-ml, makeGapEl): mixed-margin
+    // documents must not pin every strip to the first section's column; table
+    // gaps carry no inset and keep the canvas target
+    const own = el.closest<HTMLElement>('.page-gap')?.style.getPropertyValue('--gap-ml')
+    const ownPx = own ? parseFloat(own) : NaN
+    const target = Number.isFinite(ownPx) ? pmLeft + ownPx * factor : canvasTarget
     // widget DOM reused from an equal-width era still carries the stylesheet
     // centering (left:50% + translateX(-50%)): pin it before measuring, or the
     // increment is applied against the wrong base

--- a/apps/docs/src/renderer/editor/protected-render.ts
+++ b/apps/docs/src/renderer/editor/protected-render.ts
@@ -1370,7 +1370,15 @@ export function renderTableSpec(model: TableModel, nested = false): DomSpec {
   if (model.bidiVisual) tableAttrs.dir = 'rtl'
   const tableStyles: string[] = []
   let centerMargin: string | null = null
-  if (model.widthPct) tableStyles.push(`width:${model.widthPct}%`)
+  if (model.widthPct)
+    // 'pct' table widths are a share of the section's TEXT COLUMN (see
+    // DocTable.renderHTML): differing-margin/width sections resolve through the
+    // per-block --doc-content-w; nested tables stay relative to their cell
+    tableStyles.push(
+      nested
+        ? `width:${model.widthPct}%`
+        : `width:calc(var(--doc-content-w,100%) * ${Number(model.widthPct) / 100})`,
+    )
   else if (colPx) {
     // nested tables are capped by their cell; top-level ones spill into the page
     // margins like Word (centered: both sides via negative-margin centering,

--- a/apps/docs/src/renderer/pagination.ts
+++ b/apps/docs/src/renderer/pagination.ts
@@ -1505,10 +1505,14 @@ const isTableBlock = (el: HTMLElement) =>
   el.tagName === 'TABLE' || el.getAttribute('data-doc-protected') === 'table'
 
 /**
- * Per-block wrap widths for documents whose sections disagree on content width,
- * e.g. a landscape section in a portrait document. The canvas lays the whole flow
- * on one page width; these placements make each section's blocks wrap at their
- * own content width. Every block gets an explicit width (not just the differing
+ * Per-block wrap widths and horizontal placement for documents whose sections
+ * disagree on content width or side margins, e.g. a landscape section in a
+ * portrait document, or a full-bleed cover section (w:pgMar left="0") ahead of
+ * body sections with real margins. The canvas lays the whole flow on one page
+ * width and pads it by the FIRST section's margins (--page-pad), so a section
+ * that disagrees needs both its own wrap width and an x offset back onto its
+ * own left margin — otherwise every later page keeps the cover's margin-less
+ * text column. Every block gets an explicit width (not just the differing
  * sections'): preview clones render into per-section wrap widths, so any
  * container-relative block would reflow there. Tables keep their inline min()
  * width and get the section geometry via --doc-content-w / --doc-margin-* instead.
@@ -1519,11 +1523,19 @@ export function sectionWidthSpecs(
   geoms: SectionGeom[],
 ): ColumnBlockPlacement[] {
   const canvasW = geoms[0]?.contentWidth
-  if (
-    canvasW === undefined ||
-    !geoms.some((g) => g.contentWidth !== undefined && Math.abs(g.contentWidth - canvasW) > 0.5)
-  )
-    return []
+  // the canvas pads by sections[0] (App.tsx's canvasSection): placement offsets
+  // are relative to that inset, and the first section sits on it unshifted
+  const canvasInsetLeftPx = sections[0]?.settings ? twipsToPx(sections[0].settings.marginLeft) : 0
+  const differsAt = (i: number): boolean => {
+    const g = geoms[i]
+    const set = sections[i]?.settings
+    if (!g || !set) return false
+    const widthDiffers =
+      g.contentWidth !== undefined && Math.abs(g.contentWidth - (canvasW ?? 0)) > 0.5
+    const insetDiffers = Math.abs(twipsToPx(set.marginLeft) - canvasInsetLeftPx) > 0.5
+    return widthDiffers || insetDiffers
+  }
+  if (canvasW === undefined || !geoms.some((_, i) => differsAt(i))) return []
   const specs: ColumnBlockPlacement[] = []
   for (const b of blocks) {
     if (!b.el || b.floated) continue
@@ -1533,7 +1545,9 @@ export function sectionWidthSpecs(
     const set = sections[si]?.settings
     const spec: ColumnBlockPlacement = {
       el: b.el,
-      dx: 0,
+      // shift the block from the canvas' (first section's) text column onto its
+      // own section's left margin; dx composes with column/vAlign translates
+      dx: (set ? twipsToPx(set.marginLeft) : 0) - canvasInsetLeftPx,
       dy: 0,
       contentWPx: w,
       marginLeftPx: set ? twipsToPx(set.marginLeft) : 0,

--- a/apps/docs/tests/native-table.test.ts
+++ b/apps/docs/tests/native-table.test.ts
@@ -259,6 +259,56 @@ describe('native editable tables', () => {
     editor.destroy()
   })
 
+  it('resolves a pct table width against its own section column', async () => {
+    // w:tblW type="pct" is a share of the section's TEXT COLUMN. The canvas pads by
+    // the first section's margins, so a bare 100% made every table of a document
+    // with a full-bleed cover section (w:pgMar w:left="0") span the whole paper and
+    // hang off its right edge once the section's own left inset is applied.
+    const { editor } = await openTable()
+    const table = editor.state.doc.firstChild!
+    editor.view.dispatch(
+      editor.state.tr.setNodeMarkup(0, undefined, {
+        ...table.attrs,
+        tblAutoFit: 'fixed',
+        widthPx: null,
+        widthPct: 100,
+      }),
+    )
+    const spec = editor.schema.nodes.docTable.spec.toDOM!(editor.state.doc.firstChild!) as [
+      string,
+      Record<string, string>,
+    ]
+    expect(spec[1].style).toContain('width:calc(var(--doc-content-w,100%) * 1)')
+    expect(spec[1].style).not.toContain('width:100%')
+    editor.destroy()
+  })
+
+  it('resolves an AutoFit-to-Window table against its own section column', async () => {
+    // the imported shape the bug came in on: <w:tblLayout w:type="autofit"/> +
+    // <w:tblW w:w="5000" w:type="pct"/> parses as AutoFit to Window
+    const pctTable =
+      '<w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/>' +
+      '<w:tblW w:w="5000" w:type="pct"/><w:tblLayout w:type="autofit"/></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+      '<w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>' +
+      '<w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'
+    const source = await buildDocx({ bodyXml: pctTable })
+    const parsed = await parseDocx(source)
+    expect(parsed.blocks[0].table?.autoFit).toBe('window')
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: editorExtensions,
+      content: blocksToPmDoc(parsed.blocks) as never,
+    })
+    const spec = editor.schema.nodes.docTable.spec.toDOM!(editor.state.doc.firstChild!) as [
+      string,
+      Record<string, string>,
+    ]
+    expect(spec[1].style).toContain('width:var(--doc-content-w,100%)')
+    expect(spec[1].style).not.toContain('width:100%')
+    editor.destroy()
+  })
+
   it('takes a positive table indent out of the right-margin spill allowance', async () => {
     const { editor } = await openTable()
     const table = editor.state.doc.firstChild!

--- a/apps/docs/tests/pagination.test.ts
+++ b/apps/docs/tests/pagination.test.ts
@@ -626,6 +626,44 @@ describe('sectionWidthSpecs — differing-width sections wrap at their own conte
     expect(specs[2].contentWPx).toBeCloseTo(landscapeW, 1)
     expect(specs[3].widthPx).toBeCloseTo(portraitW, 1)
   })
+
+  it('blocks are placed at their own section’s left margin (full-bleed cover section)', () => {
+    // A cover section with w:pgMar w:left="0" must not strip the body sections'
+    // margins: the canvas pads by the first section, so every other section also
+    // needs a horizontal placement offset (dx), not just its own wrap width.
+    const cover = sec({ marginTop: 0, marginRight: 0, marginBottom: 0, marginLeft: 0 })
+    const body = sec({ marginLeft: 1701, marginRight: 1417 })
+    const secsList = [cover, body]
+    const blocks = [
+      block(0, 100, { section: 0, el: el() }),
+      block(100, 100, { section: 1, el: el() }),
+    ]
+    const specs = sectionWidthSpecs(blocks, secsList, sectionGeoms(secsList))
+    expect(specs).toHaveLength(2)
+    // the canvas section sits on the page padding: no offset
+    expect(specs[0].dx).toBe(0)
+    expect(specs[1].dx).toBeCloseTo((1701 / 1440) * 96, 1)
+    // width is the section's own content width, so the shifted block's right edge
+    // lands on its right margin (1701 + 8788 + 1417 = 11906)
+    expect(specs[1].widthPx).toBeCloseTo(((11906 - 1701 - 1417) / 1440) * 96, 1)
+  })
+
+  it('side-margin-only differences still get placement specs', () => {
+    // Mirrored margins keep the content width identical: nothing would be emitted
+    // on the width comparison alone, but the text column must move right.
+    const a = sec({ marginLeft: 720, marginRight: 2160 })
+    const b = sec({ marginLeft: 2160, marginRight: 720 })
+    const secsList = [a, b]
+    const blocks = [
+      block(0, 100, { section: 0, el: el() }),
+      block(100, 100, { section: 1, el: el() }),
+    ]
+    const specs = sectionWidthSpecs(blocks, secsList, sectionGeoms(secsList))
+    expect(specs).toHaveLength(2)
+    expect(specs[0].dx).toBe(0)
+    expect(specs[1].dx).toBeCloseTo(((2160 - 720) / 1440) * 96, 1)
+    expect(specs[1].widthPx).toBeCloseTo(((11906 - 2160 - 720) / 1440) * 96, 1)
+  })
 })
 
 describe('computeSectionedSlicesF2 — line-level pagination', () => {

--- a/apps/docs/tests/table-overflow-clamp.test.ts
+++ b/apps/docs/tests/table-overflow-clamp.test.ts
@@ -314,6 +314,11 @@ describe('renderTableSpec width budget', () => {
       colWidthsPct: [50, 50],
       widthPct: 80,
     }
-    expect((renderTableSpec(pct) as Spec)[1].style).toContain('width:80%')
+    // a top-level 'pct' table is a share of its SECTION column (differing-margin
+    // sections resolve through --doc-content-w); nested tables stay cell-relative
+    const pctStyle = (renderTableSpec(pct) as Spec)[1].style
+    expect(pctStyle).toContain('width:calc(var(--doc-content-w,100%) * 0.8)')
+    expect(pctStyle).not.toContain('width:80%')
+    expect((renderTableSpec(pct, true) as Spec)[1].style).toContain('width:80%')
   })
 })


### PR DESCRIPTION
## Why

Opening a docx whose **first section is full-bleed** (a cover page with
`<w:pgMar w:top="0" w:right="0" w:bottom="0" w:left="0"/>`, ahead of body sections
with real margins) rendered every following page with its side margins gone: body
text hugged the paper's left edge and a dead band opened up on the right, and any
100 %-width table spilled past the right edge of the sheet.

Reproducer (reporter's document, Word renders it correctly):

```xml
<w:sectPr>… <w:pgMar w:top="0"    w:right="0"    w:bottom="0"    w:left="0"/>    </w:sectPr>  <!-- cover  -->
<w:sectPr>… <w:pgMar w:top="1440" w:right="1417" w:bottom="1440" w:left="1701"/> </w:sectPr>  <!-- TOC    -->
<w:sectPr>… <w:pgMar w:top="1440" w:right="1417" w:bottom="1440" w:left="1701"/> </w:sectPr>  <!-- body   -->
```

The editor lays the whole flow in one continuous `.doc-page` and pads it by
**`sections[0]`'s** margins (`canvasSection` → `--page-pad`, App.tsx:3984/4027).
Vertical margins are already per-page (the gap bands carry each page's own section
top/bottom), which is why only the horizontal offset leaked. `sectionWidthSpecs()`
— the pass that handles sections disagreeing on content width (landscape sections)
— already knew each block's own `marginLeftPx`, but emitted `dx: 0`, so differing
sections got their wrap width and never their x position.

## What changed

**1. `sectionWidthSpecs` emits a real horizontal placement (apps/docs/src/renderer/pagination.ts)**

`dx = section marginLeft − canvas (sections[0]) marginLeft`. It rides the existing
visual-translate channel (`.doc-col-block { transform: translate(--col-dx,--col-dy) }`),
so:

- line breaking / page slicing is untouched (widths are explicit, and the
  `.measuring-columns` state already neutralizes the transforms);
- it composes with the mixed-column and `w:vAlign` translates (App.tsx merges with
  `dx: prev.dx + s.dx`);
- page-relative-X anchored boxes keep their paper-relative X thanks to the existing
  `translateX(calc(-1 * var(--col-dx)))` rule;
- `dx ≥ −canvasML`, so a block can never be pushed off the paper.

The trigger now also fires when sections agree on content width but differ on the
left margin (mirrored margin pairs).

**2. Gap header/footer strips follow their own section (apps/docs/src/renderer/editor/pagination-gaps.ts)**

`makeGapEl` records the next page's side margins as `--gap-ml/--gap-mr`;
`alignGapHfStrips` prefers that inset over the single canvas-wide target, so
footers on the body pages no longer sit on the cover's margin-less column. Table
gaps carry no inset and keep the previous behaviour.

**3. `pct` / AutoFit-to-Window table widths resolve against the section column (extensions.ts, protected-render.ts)**

`w:tblW type="pct"` and AutoFit-to-Window mean "a share of the section's TEXT
COLUMN" in Word, but rendered as a bare `width:100%` — resolved against the canvas
padding box, i.e. the whole paper whenever the first section has no side margins.
Both now go through the per-block `--doc-content-w` that `sectionWidthSpecs`
already delivers; nested tables stay cell-relative (they inherit the outer table's
`--doc-content-w`).

For single-section / equal-margin documents every expression degenerates to what it
was before (`var(--doc-content-w,100%)` unset → `100%`, `calc(100% * 1)` ≡ `100%`),
so the rendered CSS is unchanged; `widthPct > 100` on a protected table additionally
now gets the paper-edge cap the `w:tblW dxa` branch has always had.

## Tests

New unit tests:

- `apps/docs/tests/pagination.test.ts` — the reported 0 / 1701-twip cover+body
  combination (cover blocks `dx === 0`, body blocks `dx === 113.4px`, right edge
  lands on the body's own right margin), plus the mirrored-margin pair that agrees
  on content width.
- `apps/docs/tests/native-table.test.ts` — an imported
  `<w:tblLayout autofit/> + <w:tblW 5000 pct/>` table (parses as AutoFit to Window)
  and a `pct` table both resolve through `--doc-content-w`; `width:100%` asserted
  absent.

Checks run locally:

```
npm run test -w @genoffice/docs   → 1331 passed / 1 failed
                                    (tests/protect-dialog.test.ts "setting a modify
                                    password…" times out at 10s under full-suite load;
                                    it fails identically on a clean main checkout and
                                    passes in isolation — pre-existing, unrelated)
npm run typecheck -w @genoffice/docs → clean
npx eslint <changed files>           → clean
prettier --check / check:english-comments / check-theme-colors → clean
```

Not a docx read/write change (rendering only), so no round-trip fixture was added.
The Word-fidelity scripts need macOS + Word, so they were not run.

## Manual verification

`npm run dev:docs` on the reporter's document: TOC and body pages now inset 30 mm /
25 mm with the leaders ending on the body's right text edge, body tables align with
the paragraph column instead of crossing the paper edge, and the cover page stays
full-bleed as in Word.
