### PR TITLE
fix(agent-core): discard stale compaction results after reset

### DIFF
--- a/packages/agent-core/src/loop.ts
+++ b/packages/agent-core/src/loop.ts
@@ -374,10 +374,14 @@ export class AgentLoop<TSnapshot = unknown> {
     if (historySize(this.history) <= maxBytes) return
     const cut = this.findCompactCut(keepRecentBytes)
     if (cut <= 0) return // no foldable prefix
+    const generation = this.generation
     const dropped = this.history.slice(0, cut)
     const opt = this.options.compaction === false ? undefined : this.options.compaction
     let summary: string | null = null
     if (!opt?.disableLlmSummary) summary = await this.summarizeViaLlm(dropped)
+    // A reset may have cleared history or started a new conversation while
+    // the summary was pending. Discard its result before touching that history.
+    if (generation !== this.generation) return
     if (!summary) summary = mechanicalDigest(dropped)
     this.history = [
       { role: 'user', text: `${COMPACT_SUMMARY_HEADER}\n${summary}` },

--- a/packages/agent-core/tests/compaction-reset.test.ts
+++ b/packages/agent-core/tests/compaction-reset.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AgentLoop,
+  type AgentSkill,
+  type AgentStreamCallbacks,
+  type AgentStreamRequest,
+  type AgentTransport,
+} from '../src'
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+function controlledTransport() {
+  const calls: Array<{
+    request: AgentStreamRequest
+    callbacks: AgentStreamCallbacks
+    cancel: ReturnType<typeof vi.fn>
+  }> = []
+  const transport: AgentTransport = {
+    stream(request, callbacks) {
+      // Like the Electron transport, cancellation completes asynchronously.
+      const cancel = vi.fn(() => queueMicrotask(() => callbacks.onDone()))
+      calls.push({ request, callbacks, cancel })
+      return { cancel }
+    },
+  }
+  return { transport, calls }
+}
+
+async function startCompaction() {
+  const { transport, calls } = controlledTransport()
+  const skill: AgentSkill = {
+    id: 'test',
+    systemPrompt: 'Test system prompt',
+    tools: [{ name: 'read', description: 'Read', inputSchema: { type: 'object' } }],
+    executeTool: () => ({ output: 'ok', summary: 'Read completed' }),
+  }
+  const onDone = vi.fn()
+  const loop = new AgentLoop({
+    transport,
+    skill,
+    events: { onDone },
+    compaction: { maxBytes: 500, keepRecentBytes: 100 },
+  })
+
+  // Build history through public calls. The long first reply exceeds the budget;
+  // a second user turn supplies a boundary at which that history can be folded.
+  loop.run('Old conversation instruction')
+  await flush()
+  calls[0]!.callbacks.onDelta('Old answer '.repeat(80))
+  calls[0]!.callbacks.onDone()
+  loop.run('Recent question')
+  await flush()
+  calls[1]!.callbacks.onDelta('Recent answer')
+  calls[1]!.callbacks.onDone()
+
+  onDone.mockClear()
+  loop.run('Continue the old conversation')
+  await flush()
+  expect(calls).toHaveLength(3)
+  expect(calls[2]!.request.tools).toEqual([])
+  expect(calls[2]!.request.messages).toContainEqual({
+    role: 'user',
+    text: 'Old conversation instruction',
+  })
+  expect(loop.busy).toBe(true)
+  return { loop, calls, onDone, summary: calls[2]! }
+}
+
+describe('AgentLoop reset during compaction', () => {
+  it('keeps history empty when reset cancels a pending summary', async () => {
+    const { loop, calls, onDone, summary } = await startCompaction()
+
+    loop.reset()
+    expect(summary.cancel).toHaveBeenCalledOnce()
+    expect(loop.messages).toEqual([])
+    await flush()
+
+    // Cancellation without summary text must not reintroduce a mechanical digest.
+    expect(loop.messages).toEqual([])
+    expect(loop.busy).toBe(false)
+    expect(calls).toHaveLength(3)
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('preserves a new conversation started immediately after reset', async () => {
+    const { loop, calls, onDone, summary } = await startCompaction()
+    summary.callbacks.onDelta('Summary belonging only to the old conversation')
+
+    loop.reset()
+    loop.run('Fresh conversation instruction')
+    await flush()
+    expect(calls).toHaveLength(4)
+    const freshTurn = calls[3]!
+    freshTurn.callbacks.onDelta('Fresh conversation answer')
+    freshTurn.callbacks.onDone()
+
+    expect(loop.messages).toEqual([
+      { role: 'user', text: 'Fresh conversation instruction' },
+      { role: 'assistant', text: 'Fresh conversation answer' },
+    ])
+    expect(freshTurn.request.messages).toEqual([
+      { role: 'user', text: 'Fresh conversation instruction' },
+    ])
+    expect(loop.busy).toBe(false)
+    expect(onDone).toHaveBeenCalledExactlyOnceWith({
+      text: 'Fresh conversation answer',
+      cancelled: false,
+      turnLimit: false,
+    })
+  })
+
+  it('retains the summary and recent messages when the conversation is not reset', async () => {
+    const { loop, calls, summary } = await startCompaction()
+    summary.callbacks.onDelta('Old conversation summary')
+    summary.callbacks.onDone()
+    await flush()
+
+    expect(calls).toHaveLength(4)
+    const continuation = calls[3]!
+    expect(continuation.request.messages[0]).toEqual({
+      role: 'user',
+      text: expect.stringContaining('Old conversation summary'),
+    })
+    expect(continuation.request.messages.slice(2)).toEqual([
+      { role: 'user', text: 'Recent question' },
+      { role: 'assistant', text: 'Recent answer' },
+      { role: 'user', text: 'Continue the old conversation' },
+    ])
+    continuation.callbacks.onDelta('Continued answer')
+    continuation.callbacks.onDone()
+    expect(loop.messages.at(-1)).toEqual({ role: 'assistant', text: 'Continued answer' })
+    expect(loop.busy).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Resetting chat during an in-flight history summary can restore old history or overwrite a newly started conversation when the old task finishes.

Capture the existing loop generation before summarization and check it before writing history, including the mechanical-digest fallback. The production change adds four lines, including two comment lines.

Add three regression tests through public AgentLoop calls:

* Reset while a summary is pending, with no summary text.
* Reset after partial summary text, followed immediately by a new conversation.
* Normal compaction without reset.

The first two tests fail on the baseline and pass with this fix.

## Related issue

Closes #176

## Validation

* [x] `npm run format:check`
* [x] `npm run lint` — 0 errors, 12 warnings, matching the baseline.
* [x] `npm run typecheck` — all 19 workspaces.
* [ ] `npm test` — full-suite limitations below.
* [x] `npm run licenses`
* [x] `npm run check:theme-colors`
* [x] `npm run check:english-comments`
* [x] Agent Core: 77 passed; baseline with the new tests: 75 passed, 2 failed.
* [x] AI Provider: 134 passed.

The root test command stopped at four remote-image failures; subsequent workspace scripts were run individually. Aggregate: 6,058 passed, 5 failed, 16 skipped, excluding Sheets tests that could not start.

The four remote-image failures also reproduce on the baseline due to DNS EAI_AGAIN. One Docs ProtectDialog test exceeded its internal wait during the broad run; its file passes 8/8 on both revisions when run separately. The full Docs suite was not rerun.

The fixture CLI wrapper hit EPERM creating a tsx IPC pipe. Running the same generator with `node --import tsx scripts/generate-fixtures.ts` from `packages/docx-engine` succeeded with no fixture diff.

Sheets native tests/build, compatibility checks and Rust license checks remain unverified because cargo is unavailable. Electron E2E and Windows desktop validation were not run. Local Node is 24.19.0; CI uses Node 22.


## Screenshots or recordings

Not applicable: no visual UI change.

Before/after evidence comes from regression tests and an additional check using the real AgentLoop and IPC transport with a simulated main process. No desktop GUI verification is claimed.

## Contributor checklist

* [x] Focused change; no unrelated formatting or refactoring.
* [x] No new user-facing strings requiring localization.
* [x] No file open/save changes; round-trip tests are not applicable.
* [x] Nothing under `ee/` is modified.
