### PR TITLE
feat ai settings for the per-turn output token cap

### DIFF
--- a/apps/docs/src/main/docs-main.ts
+++ b/apps/docs/src/main/docs-main.ts
@@ -58,6 +58,7 @@ import {
   activeProvider,
   cloudToolsEnabled,
   resolveAiSettings,
+  maxOutputTokensOf,
   setRescueFetch,
   streamForProvider,
   type AiChatRequest,
@@ -2661,7 +2662,7 @@ export function registerAiIpc(): void {
   ipcMain.handle('ai:stream', async (event, request: AiStreamRequest) => {
     const { requestId, settings, system, messages } = request
     const tools = request.tools ?? []
-    const maxTokens = request.maxTokens ?? 8192
+    const maxTokens = request.maxTokens ?? maxOutputTokensOf(settings)
     const provider = settings.provider
     let config = settings.providers?.[provider]
     // the genspark key never enters the settings file; requests take it from the gsk login state

--- a/apps/sheets/src/main/sheets-main.ts
+++ b/apps/sheets/src/main/sheets-main.ts
@@ -62,6 +62,7 @@ import {
   defaultAiSettings,
   activeProvider,
   cloudToolsEnabled,
+  maxOutputTokensOf,
   resolveAiSettings,
   setRescueFetch,
   streamForProvider,
@@ -3094,7 +3095,7 @@ export function registerSheetsAiIpc(): void {
     const request = aiStreamRequestSchema.parse(input)
     const { requestId, system, messages } = request
     const tools = request.tools ?? []
-    const maxTokens = request.maxTokens ?? 8192
+    const maxTokens = request.maxTokens ?? maxOutputTokensOf(request.settings)
     const provider = request.settings.provider as AiProviderId
     let config = request.settings.providers[provider]
     // Genspark's key never enters the settings file; it is read from the gsk

--- a/apps/sheets/src/shared/desktop-api.ts
+++ b/apps/sheets/src/shared/desktop-api.ts
@@ -2383,6 +2383,10 @@ export const aiSettingsInputSchema = z
     provider: z.string().min(1),
     providers: z.record(z.string(), aiProviderConfigSchema),
     gskToolsEnabled: z.boolean().optional(),
+    // bounds are enforced by clampMaxOutputTokens on read; the schema only
+    // rejects nonsense (this object is .strict(), so an omitted key here would
+    // make the whole settings save fail)
+    maxOutputTokens: z.number().int().positive().optional(),
   })
   .strict()
 

--- a/apps/shell/src/renderer/src/SettingsModal.tsx
+++ b/apps/shell/src/renderer/src/SettingsModal.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { Dropdown } from '@genoffice/ui'
+import {
+  DEFAULT_MAX_OUTPUT_TOKENS,
+  MAX_MAX_OUTPUT_TOKENS,
+  MIN_MAX_OUTPUT_TOKENS,
+  clampMaxOutputTokens,
+} from '@genoffice/ai-provider'
 import type { AiSettings } from '@genoffice/ai-provider'
 import { useI18n } from './locale'
 import type { StringKey, TFunc } from './locale'
@@ -153,6 +159,8 @@ function AiModelPane({ t }: { t: TFunc }) {
   const [saved, setSaved] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; error?: string } | null>(null)
+  /** free-typed value of the output-cap field; committed (and clamped) on blur */
+  const [maxTokensDraft, setMaxTokensDraft] = useState<string | null>(null)
 
   useEffect(() => {
     let alive = true
@@ -192,6 +200,15 @@ function AiModelPane({ t }: { t: TFunc }) {
       ...settings,
       providers: { ...settings.providers, [provider]: { ...config, ...patch } },
     })
+    touch()
+  }
+  /** Commit the output-cap input: clamp what was typed and drop a no-op edit */
+  const commitMaxTokens = () => {
+    if (maxTokensDraft === null) return
+    setMaxTokensDraft(null)
+    const next = clampMaxOutputTokens(Number.parseInt(maxTokensDraft, 10))
+    if (next === (settings.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS)) return
+    setSettings({ ...settings, maxOutputTokens: next })
     touch()
   }
   const selectProvider = (id: AiSettings['provider']) => {
@@ -322,6 +339,27 @@ function AiModelPane({ t }: { t: TFunc }) {
           </div>
         </>
       )}
+      <div className="set-field">
+        <div className="set-field-text">
+          <div className="set-field-stack">
+            <label className="set-field-label" htmlFor="set-ai-max-tokens">
+              {t('setAiMaxTokens')}
+            </label>
+            <div className="set-field-desc">{t('setAiMaxTokensDesc')}</div>
+          </div>
+        </div>
+        <input
+          id="set-ai-max-tokens"
+          className="set-input"
+          type="number"
+          min={MIN_MAX_OUTPUT_TOKENS}
+          max={MAX_MAX_OUTPUT_TOKENS}
+          step={1024}
+          value={maxTokensDraft ?? String(settings.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS)}
+          onChange={(e) => setMaxTokensDraft(e.target.value)}
+          onBlur={commitMaxTokens}
+        />
+      </div>
       <div className="set-field">
         <div className="set-field-text">
           <div className="set-field-stack">

--- a/apps/shell/src/renderer/src/strings.ts
+++ b/apps/shell/src/renderer/src/strings.ts
@@ -158,6 +158,9 @@ export const strings = {
     setAiTesting: '测试中…',
     setAiTestOk: '连接成功',
     setAiTestFail: '连接失败',
+    setAiMaxTokens: '单次输出上限（tokens）',
+    setAiMaxTokensDesc:
+      '一次回合的输出预算。推理模型会先消耗预算用于思考，预算用完时回复可能变成空白，遇到这种情况请调大此项。',
     setAiGskTools: 'Genspark 云工具',
     setAiGskToolsDesc:
       '网页搜索、AI 生图、媒体分析经 Genspark 云端并消耗积分；关闭后生图与媒体分析不可用，搜索改用免费来源。',
@@ -354,6 +357,9 @@ export const strings = {
     setAiTesting: 'Testing…',
     setAiTestOk: 'Connection OK',
     setAiTestFail: 'Connection failed',
+    setAiMaxTokens: 'Max output tokens',
+    setAiMaxTokensDesc:
+      'Output budget for one turn. Reasoning models spend part of it thinking, so an answer can come back empty once the budget runs out; raise this value if that happens.',
     setAiGskTools: 'Genspark cloud tools',
     setAiGskToolsDesc:
       'Web search, AI image generation and media analysis run through Genspark and use credits; when off, image tools are unavailable and search uses free sources.',
@@ -565,6 +571,9 @@ export const strings = {
     setAiTesting: 'テスト中…',
     setAiTestOk: '接続に成功しました',
     setAiTestFail: '接続に失敗しました',
+    setAiMaxTokens: '1 回あたりの出力トークン上限',
+    setAiMaxTokensDesc:
+      '1 ターンの出力予算です。推論モデルは思考に消費するため、耗尽すると返信が空になります。その場合は値を大きくしてください。',
     setAiGskTools: 'Genspark クラウドツール',
     setAiGskToolsDesc:
       'ウェブ検索・AI 画像生成・メディア分析は Genspark クラウド経由でクレジットを消費します。オフにすると画像ツールは使えず、検索は無料ソースを使用します。',
@@ -773,6 +782,9 @@ export const strings = {
     setAiTesting: '테스트 중…',
     setAiTestOk: '연결 성공',
     setAiTestFail: '연결 실패',
+    setAiMaxTokens: '턴당 출력 토큰 상한',
+    setAiMaxTokensDesc:
+      '한 턴의 출력 예산입니다. 추론 모델은 생각하는 데 소모하므로 예산이 떨어지면 응답이 비어 올 수 있습니다. 그럴 때 값을 키우세요.',
     setAiGskTools: 'Genspark 클라우드 도구',
     setAiGskToolsDesc:
       '웹 검색·AI 이미지 생성·미디어 분석은 Genspark 클라우드를 거치며 크레딧을 사용합니다. 끄면 이미지 도구를 사용할 수 없고 검색은 무료 소스를 사용합니다.',
@@ -986,6 +998,9 @@ export const strings = {
     setAiTesting: 'Test en cours…',
     setAiTestOk: 'Connexion réussie',
     setAiTestFail: 'Échec de la connexion',
+    setAiMaxTokens: 'Jetons de sortie max.',
+    setAiMaxTokensDesc:
+      'Budget de sortie pour un tour. Les modèles à raisonnement le dépensent en réflexion ; quand il est épuisé, la réponse arrive vide : augmentez cette valeur.',
     setAiGskTools: 'Outils cloud Genspark',
     setAiGskToolsDesc:
       "Recherche web, génération d'images et analyse de médias passent par Genspark et consomment des crédits ; désactivé, les outils d'image sont indisponibles et la recherche utilise des sources gratuites.",
@@ -1201,6 +1216,9 @@ export const strings = {
     setAiTesting: 'Wird getestet…',
     setAiTestOk: 'Verbindung erfolgreich',
     setAiTestFail: 'Verbindung fehlgeschlagen',
+    setAiMaxTokens: 'Max. Ausgabe-Tokens',
+    setAiMaxTokensDesc:
+      'Ausgabe-Budget pro Durchlauf. Denk-Modelle verbrauchen es beim Reasoning; ist es erschöpft, kommt eine leere Antwort zurück — dann diesen Wert erhöhen.',
     setAiGskTools: 'Genspark-Cloud-Tools',
     setAiGskToolsDesc:
       'Websuche, KI-Bilderzeugung und Medienanalyse laufen über Genspark und verbrauchen Guthaben; ausgeschaltet sind Bildtools nicht verfügbar und die Suche nutzt freie Quellen.',
@@ -1415,6 +1433,9 @@ export const strings = {
     setAiTesting: 'Probando…',
     setAiTestOk: 'Conexión correcta',
     setAiTestFail: 'Error de conexión',
+    setAiMaxTokens: 'Tokens de salida máx.',
+    setAiMaxTokensDesc:
+      'Presupuesto de salida por turno. Los modelos de razonamiento lo gastan en pensar; si se agota, la respuesta llega vacía: suba este valor.',
     setAiGskTools: 'Herramientas en la nube de Genspark',
     setAiGskToolsDesc:
       'La búsqueda web, la generación de imágenes y el análisis de medios pasan por Genspark y consumen créditos; desactivado, las herramientas de imagen no están disponibles y la búsqueda usa fuentes gratuitas.',
@@ -1623,6 +1644,9 @@ export const strings = {
     setAiTesting: 'กำลังทดสอบ…',
     setAiTestOk: 'เชื่อมต่อสำเร็จ',
     setAiTestFail: 'การเชื่อมต่อล้มเหลว',
+    setAiMaxTokens: 'จำนวนโทเคนขาออกสูงสุด',
+    setAiMaxTokensDesc:
+      'งบผลลัพท์ต่อหนึ่งรอบ โมเดลท่ีไตร่ตรองจะใช้ส่วนหนึ่่งไปกบการคิด หากงบหมด คำตอบจะกลบมาเปลา ให้เพิ่มคา่นี',
     setAiGskTools: 'เครื่องมือคลาวด์ Genspark',
     setAiGskToolsDesc:
       'ค้นเว็บ สร้างภาพ AI และวิเคราะห์สื่อผ่านคลาวด์ Genspark และใช้เครดิต ปิดแล้วเครื่องมือภาพจะใช้ไม่ได้ และการค้นหาใช้แหล่งฟรี',
@@ -1832,6 +1856,9 @@ export const strings = {
     setAiTesting: 'Menguji…',
     setAiTestOk: 'Koneksi berhasil',
     setAiTestFail: 'Koneksi gagal',
+    setAiMaxTokens: 'Token keluaran maks.',
+    setAiMaxTokensDesc:
+      'Anggaran keluaran untuk satu giliran. Model penalaran memakainya untuk berpikir; jika habis, balasan datang kosong — naikkan nilai ini.',
     setAiGskTools: 'Alat cloud Genspark',
     setAiGskToolsDesc:
       'Pencarian web, pembuatan gambar AI, dan analisis media berjalan lewat Genspark dan memakai kredit; jika dimatikan, alat gambar tidak tersedia dan pencarian memakai sumber gratis.',
@@ -2042,6 +2069,9 @@ export const strings = {
     setAiTesting: 'Проверка…',
     setAiTestOk: 'Подключение успешно',
     setAiTestFail: 'Ошибка подключения',
+    setAiMaxTokens: 'Макс. токенов на ответ',
+    setAiMaxTokensDesc:
+      'Бюджет вывода за один ход. Модели рассуждений тратят его на размышления: если бюджет иссякнет, ответ придёт пустым — увеличьте значение.',
     setAiGskTools: 'Облачные инструменты Genspark',
     setAiGskToolsDesc:
       'Веб-поиск, генерация изображений и анализ медиа идут через Genspark и расходуют кредиты; при отключении инструменты изображений недоступны, а поиск использует бесплатные источники.',
@@ -2250,6 +2280,9 @@ export const strings = {
     setAiTesting: 'جارٍ الاختبار…',
     setAiTestOk: 'نجح الاتصال',
     setAiTestFail: 'فشل الاتصال',
+    setAiMaxTokens: 'الحد الأقصى لرموز المخرجات',
+    setAiMaxTokensDesc:
+      'ميزانية الإخراج في الدورة الواحدة. نماذج الاستدلال تصرفها على التفكير، فإذا نفدت جاء الرد فارغًا؛ ارفع هذه القيمة عندئذ.',
     setAiGskTools: 'أدوات Genspark السحابية',
     setAiGskToolsDesc:
       'يمر بحث الويب وتوليد الصور وتحليل الوسائط عبر سحابة Genspark ويستهلك الرصيد؛ عند الإيقاف تصبح أدوات الصور غير متاحة ويستخدم البحث مصادر مجانية.',
@@ -2452,6 +2485,9 @@ export const strings = {
     setAiTesting: 'Testando…',
     setAiTestOk: 'Conexão bem-sucedida',
     setAiTestFail: 'Falha na conexão',
+    setAiMaxTokens: 'Máx. de tokens de saída',
+    setAiMaxTokensDesc:
+      'Orçamento de saída por turno. Modelos de raciocínio gastam-no pensando; se esgotar, a resposta vem vazia — aumente este valor.',
     setAiGskTools: 'Ferramentas na nuvem Genspark',
     setAiGskToolsDesc:
       'Busca na web, geração de imagens e análise de mídia passam pela Genspark e consomem créditos; desligado, as ferramentas de imagem ficam indisponíveis e a busca usa fontes gratuitas.',
@@ -2653,6 +2689,9 @@ export const strings = {
     setAiTesting: 'Test in corso…',
     setAiTestOk: 'Connessione riuscita',
     setAiTestFail: 'Connessione non riuscita',
+    setAiMaxTokens: 'Token di output massimi',
+    setAiMaxTokensDesc:
+      'Budget di uscita per singolo turno. I modelli di ragionamento lo consumano pensando: se si esaurisce, la risposta arriva vuota; aumentalo.',
     setAiGskTools: 'Strumenti cloud Genspark',
     setAiGskToolsDesc:
       'Ricerca web, generazione di immagini e analisi dei media passano da Genspark e consumano crediti; se disattivato, gli strumenti immagine non sono disponibili e la ricerca usa fonti gratuite.',
@@ -2853,6 +2892,9 @@ export const strings = {
     setAiTesting: 'Testowanie…',
     setAiTestOk: 'Połączenie działa',
     setAiTestFail: 'Połączenie nie powiodło się',
+    setAiMaxTokens: 'Maks. tokeny wyjścia',
+    setAiMaxTokensDesc:
+      'Budżet wyjścia na jedną turę. Modele rozumowania zużywają go na myślenie; gdy się wyczerpie, odpowiedź przychodzi pusta — zwiększ tę wartość.',
     setAiGskTools: 'Narzędzia chmurowe Genspark',
     setAiGskToolsDesc:
       'Wyszukiwanie w sieci, generowanie obrazów AI i analiza mediów przechodzą przez Genspark i zużywają kredyty; po wyłączeniu narzędzia obrazów są niedostępne, a wyszukiwanie korzysta z darmowych źródeł.',
@@ -3054,6 +3096,9 @@ export const strings = {
     setAiTesting: 'Testen…',
     setAiTestOk: 'Verbinding geslaagd',
     setAiTestFail: 'Verbinding mislukt',
+    setAiMaxTokens: 'Max. outputtokens',
+    setAiMaxTokensDesc:
+      'Uitvoerbudget voor één beurt. Redeneermodellen geven dit uit aan denken; is het op, dan komt een leeg antwoord terug — verhoog deze waarde.',
     setAiGskTools: 'Genspark-cloudtools',
     setAiGskToolsDesc:
       'Webzoeken, AI-beeldgeneratie en media-analyse lopen via Genspark en verbruiken tegoed; uitgeschakeld zijn beeldtools niet beschikbaar en gebruikt zoeken gratis bronnen.',
@@ -3254,6 +3299,9 @@ export const strings = {
     setAiTesting: 'Menguji…',
     setAiTestOk: 'Sambungan berjaya',
     setAiTestFail: 'Sambungan gagal',
+    setAiMaxTokens: 'Token output maks.',
+    setAiMaxTokensDesc:
+      'Belanjawan output untuk satu pusingan. Model penaakulan menghabiskannya untuk berfikir; jika habis, balasan datang kosong — tingkatkan nilai ini.',
     setAiGskTools: 'Alat awan Genspark',
     setAiGskToolsDesc:
       'Carian web, penjanaan imej AI dan analisis media melalui awan Genspark dan menggunakan kredit; jika dimatikan, alat imej tidak tersedia dan carian menggunakan sumber percuma.',
@@ -3451,6 +3499,9 @@ export const strings = {
     setAiTesting: 'בודק…',
     setAiTestOk: 'החיבור תקין',
     setAiTestFail: 'החיבור נכשל',
+    setAiMaxTokens: 'מקסימום טוקנים לתשובה',
+    setAiMaxTokensDesc:
+      'תקן פלט לסיבוב אחד. מודלי נימוק מבזבזים אותו על מחשבה, ואם הוא נגמר התשובה חוזרת ריקה — העלו את הערך.',
     setAiGskTools: 'כלי הענן של Genspark',
     setAiGskToolsDesc:
       'חיפוש ברשת, יצירת תמונות וניתוח מדיה עוברים דרך Genspark וצורכים קרדיטים; בכיבוי, כלי התמונות אינם זמינים והחיפוש משתמש במקורות חינמיים.',
@@ -3650,6 +3701,9 @@ export const strings = {
     setAiTesting: 'परख रहे हैं…',
     setAiTestOk: 'कनेक्शन सफल',
     setAiTestFail: 'कनेक्शन विफल',
+    setAiMaxTokens: 'अधिकतम आउटपुट टोकन',
+    setAiMaxTokensDesc:
+      'एक मोड़ का आउटपुट बजट। तरक मॉडल इसमें से क्छ हिस्सा सोचने पर खरच करते हैं; बजट खत्म होने पर उत्तर खाली आ सकता है — ज़रूरत पर इसे बढ़ाएँ।',
     setAiGskTools: 'Genspark क्लाउड टूल',
     setAiGskToolsDesc:
       'वेब खोज, AI छवि निर्माण और मीडिया विश्लेषण Genspark क्लाउड से होते हैं और क्रेडिट खर्च करते हैं; बंद करने पर छवि टूल अनुपलब्ध होंगे और खोज मुफ्त स्रोतों का उपयोग करेगी।',
@@ -3844,6 +3898,9 @@ export const strings = {
     setAiTesting: '測試中…',
     setAiTestOk: '連線成功',
     setAiTestFail: '連線失敗',
+    setAiMaxTokens: '單次輸出上限（tokens）',
+    setAiMaxTokensDesc:
+      '一次回合的輸出預算。推理模型會先消耗預算用於思考，預算用畢時回覆可能變成空白，遇到此情況請調高本項。',
     setAiGskTools: 'Genspark 雲端工具',
     setAiGskToolsDesc:
       '網頁搜尋、AI 生圖、媒體分析經 Genspark 雲端並消耗點數；關閉後生圖與媒體分析不可用，搜尋改用免費來源。',

--- a/apps/slides/src/main/ai-ipc.ts
+++ b/apps/slides/src/main/ai-ipc.ts
@@ -24,6 +24,7 @@ import {
   defaultAiSettings,
   activeProvider,
   cloudToolsEnabled,
+  maxOutputTokensOf,
   resolveAiSettings,
   setRescueFetch,
   streamForProvider,
@@ -142,7 +143,7 @@ export function registerAiIpc(): void {
   ipcMain.handle('ai:stream', async (event, request: AiStreamRequest) => {
     const { requestId, settings, system, messages } = request
     const tools = request.tools ?? []
-    const maxTokens = request.maxTokens ?? 8192
+    const maxTokens = request.maxTokens ?? maxOutputTokensOf(settings)
     const provider = settings.provider
     let config = settings.providers?.[provider]
     // The genspark key never enters the settings file; it is fetched from the gsk login state per request

--- a/packages/ai-provider/src/index.ts
+++ b/packages/ai-provider/src/index.ts
@@ -12,10 +12,15 @@ export type {
 } from './types'
 export {
   AI_PROVIDERS,
+  DEFAULT_MAX_OUTPUT_TOKENS,
   GENSPARK_LLM_BASE_URLS,
+  MAX_MAX_OUTPUT_TOKENS,
+  MIN_MAX_OUTPUT_TOKENS,
   activeProvider,
+  clampMaxOutputTokens,
   cloudToolsEnabled,
   defaultAiSettings,
+  maxOutputTokensOf,
   resolveAiSettings,
 } from './providers'
 export { AI_PROVIDER_ADAPTERS, getProviderAdapter, modelLacksVision } from './registry'

--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -237,6 +237,33 @@ const RETIRED_MODELS: Partial<Record<AiProviderId, Record<string, string>>> = {
   },
 }
 
+/**
+ * Per-turn output cap applied when the settings carry none. Every app's AI IPC
+ * handler used to hardcode this 8192 with no user-facing way to raise it, which
+ * is exactly the budget a reasoning model burns on thinking before it writes any
+ * prose (see AiSettings.maxOutputTokens).
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 8192
+/** bounds accepted for AiSettings.maxOutputTokens: below the first a short answer cannot even finish, above the second one turn risks the whole context window */
+export const MIN_MAX_OUTPUT_TOKENS = 1024
+export const MAX_MAX_OUTPUT_TOKENS = 131072
+
+/** Out-of-range or non-finite input falls back to a bound / the default (a mistyped settings field must not kill AI features) */
+export function clampMaxOutputTokens(value: unknown): number {
+  const n = typeof value === 'number' ? Math.floor(value) : Number.NaN
+  if (!Number.isFinite(n)) return DEFAULT_MAX_OUTPUT_TOKENS
+  return Math.min(MAX_MAX_OUTPUT_TOKENS, Math.max(MIN_MAX_OUTPUT_TOKENS, n))
+}
+
+/** The effective per-turn output cap of a settings object (clamped; absent → default) */
+export function maxOutputTokensOf(
+  settings: Pick<AiSettings, 'maxOutputTokens'> | null | undefined,
+): number {
+  return settings?.maxOutputTokens === undefined
+    ? DEFAULT_MAX_OUTPUT_TOKENS
+    : clampMaxOutputTokens(settings.maxOutputTokens)
+}
+
 /** pasted keys/URLs often carry stray whitespace, which turns into a 401 with a valid key */
 function trimConfigs(providers: AiSettings['providers']): AiSettings['providers'] {
   const trimmed = { ...providers }
@@ -284,5 +311,12 @@ export function resolveAiSettings(
     provider: stored.provider ?? defaults.provider,
     providers: trimConfigs(migrateRetiredModels({ ...defaults.providers, ...stored.providers })),
     gskToolsEnabled: stored.gskToolsEnabled ?? defaults.gskToolsEnabled ?? true,
+    // clamped on read: a hand-edited settings file with an absurd cap must not be
+    // forwarded to the endpoint verbatim
+    ...(stored.maxOutputTokens !== undefined || defaults.maxOutputTokens !== undefined
+      ? {
+          maxOutputTokens: clampMaxOutputTokens(stored.maxOutputTokens ?? defaults.maxOutputTokens),
+        }
+      : {}),
   }
 }

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -49,6 +49,14 @@ export interface AiSettings {
    * unavailable regardless.
    */
   gskToolsEnabled?: boolean
+  /**
+   * Output-token cap for ONE model turn of agent runs (default
+   * DEFAULT_MAX_OUTPUT_TOKENS). Reasoning models bill their thinking against
+   * this same budget, so a heavy edit turn can consume all of it and close with
+   * finish_reason=length and no prose at all — raising it is the user's lever
+   * (absent = the default, so pre-existing settings files keep working).
+   */
+  maxOutputTokens?: number | undefined
 }
 
 /** pre-provider settings shape (single OpenAI-compatible endpoint); migrated into "custom" */

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
   AI_PROVIDERS,
+  DEFAULT_MAX_OUTPUT_TOKENS,
+  MAX_MAX_OUTPUT_TOKENS,
+  MIN_MAX_OUTPUT_TOKENS,
   activeProvider,
+  clampMaxOutputTokens,
   cloudToolsEnabled,
   defaultAiSettings,
+  maxOutputTokensOf,
   resolveAiSettings,
 } from '../src/providers'
 import type { AiProviderId } from '../src/types'
@@ -152,6 +157,50 @@ describe('resolveAiSettings', () => {
     )
     expect(resolved.providers.custom.apiKey).toBe('legacy-key')
     expect(resolved.providers.custom.baseUrl).toBe('https://legacy.example.com/v1')
+  })
+
+  it('carries a stored output cap and clamps a hand-edited one', () => {
+    // a multi-provider file (the legacy single-endpoint shape returns defaults wholesale)
+    const stored = { providers: {} as never }
+    expect(
+      resolveAiSettings({ ...stored, maxOutputTokens: 32768 }, defaultAiSettings()).maxOutputTokens,
+    ).toBe(32768)
+    // a settings file edited by hand must not forward an absurd budget to the endpoint
+    expect(
+      resolveAiSettings({ ...stored, maxOutputTokens: 1 }, defaultAiSettings()).maxOutputTokens,
+    ).toBe(MIN_MAX_OUTPUT_TOKENS)
+    expect(
+      resolveAiSettings({ ...stored, maxOutputTokens: 1e9 }, defaultAiSettings()).maxOutputTokens,
+    ).toBe(MAX_MAX_OUTPUT_TOKENS)
+    // absent stays absent: pre-existing settings files keep the default behaviour
+    expect('maxOutputTokens' in resolveAiSettings(stored, defaultAiSettings())).toBe(false)
+  })
+})
+
+describe('maxOutputTokensOf', () => {
+  it('falls back to the default when the setting is absent or unusable', () => {
+    expect(maxOutputTokensOf({})).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+    expect(maxOutputTokensOf(undefined)).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+    expect(maxOutputTokensOf({ maxOutputTokens: Number.NaN })).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+    expect(maxOutputTokensOf({ maxOutputTokens: '8192' as unknown as number })).toBe(
+      DEFAULT_MAX_OUTPUT_TOKENS,
+    )
+  })
+
+  it('honors a stored cap inside the bounds', () => {
+    expect(maxOutputTokensOf({ maxOutputTokens: 16384 })).toBe(16384)
+    expect(maxOutputTokensOf({ maxOutputTokens: 3.7 })).toBe(MIN_MAX_OUTPUT_TOKENS)
+    expect(maxOutputTokensOf({ maxOutputTokens: 20000 })).toBe(20000)
+  })
+})
+
+describe('clampMaxOutputTokens', () => {
+  it('floors, bounds and defaults whatever the settings field or the input box held', () => {
+    expect(clampMaxOutputTokens(16384.9)).toBe(16384)
+    expect(clampMaxOutputTokens(0)).toBe(MIN_MAX_OUTPUT_TOKENS)
+    expect(clampMaxOutputTokens(5e6)).toBe(MAX_MAX_OUTPUT_TOKENS)
+    expect(clampMaxOutputTokens(Number.POSITIVE_INFINITY)).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+    expect(clampMaxOutputTokens(undefined)).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
   })
 })
 


### PR DESCRIPTION
Follow-up to #184 (same root cause, the fix side).

## Why

Every app's AI IPC handler computed

```ts
const maxTokens = request.maxTokens ?? 8192   // docs-main / sheets-main / slides ai-ipc
```

and **no renderer ever sends `maxTokens`** (`git grep maxTokens -- apps/*/src/renderer` is
empty apart from slides' own one-off LLM calls). So the per-turn output budget was a
hardcoded 8192 that no user could change.

For a reasoning model that budget is *shared with thinking*. Probing the reporter's
endpoint (`api.deepseek.com/v1`, `deepseek-v4-flash`, synthetic prompts only):

| probe | result |
| --- | --- |
| `max_tokens=50`, problem needing thought | `finish_reason=length`, **0 content characters**, `completion_tokens=50 / reasoning_tokens=50` |
| `max_tokens=3000`, proof request | 23.2 s, `finish_reason=length`, **0 content characters**, `completion_tokens=3000 / reasoning_tokens=3000` (≈129 tok/s) |
| + `thinking:{type:"disabled"}` | `finish_reason=stop`, no reasoning, normal prose |

Reasoning tokens are billed against `max_tokens`, and 8192 at ≈129 tok/s is ~63 s —
the reporter's four dead turns took 59.7 / 60.7 / 65.4 / 73.1 s. #184 makes that
outcome legible; this PR gives the user the lever.

**Why not just disable thinking?** `registry.ts` pins the *direct* DeepSeek endpoint to
`DEEPSEEK_NON_THINKING` precisely because the OpenAI-compatible transcript could not
carry reasoning back, while `modelEchoesReasoning()` documents that "DeepSeek V4
rejects tool turns without it". So for the model family in question thinking is not a
free opt-out — the budget is the honest knob.

## What changed

- `AiSettings.maxOutputTokens?: number | undefined` (absent = default, so existing
  settings files behave exactly as before).
- `DEFAULT_MAX_OUTPUT_TOKENS` / `MIN_MAX_OUTPUT_TOKENS` (1024) /
  `MAX_MAX_OUTPUT_TOKENS` (131072) + `clampMaxOutputTokens()` + `maxOutputTokensOf()`
  in `@genoffice/ai-provider`. Clamped **both** on read (`resolveAiSettings`) and on
  commit (the settings box): a hand-edited or mistyped value can never be forwarded to
  an endpoint verbatim, and never kills AI features.
- `docs-main.ts` / `sheets-main.ts` / `slides/ai-ipc.ts` resolve the cap through
  `maxOutputTokensOf(settings)`. Markdown and PDF ride docs-main's shared `ai:stream`
  channel, so one setting covers all six apps with no renderer plumbing (the value
  travels inside `settings`, which the transport already sends).
- Settings ▸ AI model: numeric field, clamped on blur (typing is free-form until
  commit), label + explanation in all 19 locales of `apps/shell/.../strings.ts`.
- `apps/sheets/src/shared/desktop-api.ts`: `aiSettingsInputSchema` is `.strict()`, so
  the key had to be added there or saving settings from a sheets window would have
  started failing.

`max_tokens` itself is unchanged for every non-agent call site (slides' per-page LLM
helpers pass their own explicit value).

## Checks

```
npm run test -w @genoffice/ai-provider → 138 passed (new: resolveAiSettings carry/clamp/absent,
                                        maxOutputTokensOf, clampMaxOutputTokens)
npm run test -w @genoffice/shell       → 219 passed (incl. tests/strings.test.ts locale parity)
npm run test -w @genoffice/sheets      → 2262 passed | 1 skipped
npm run test -w @genoffice/slides      → 629 passed | 12 skipped
npm run test -w @genoffice/docs        → 1501 passed | 1 failed (*)
npm run test -w @genoffice/markdown    → 143 passed | 2 skipped
npm run test -w @genoffice/pdf         → 574 passed | 1 failed (*)
npm run typecheck -w {ai-provider,shell,docs,sheets,slides,markdown,pdf} → clean
npx eslint <changed files> → clean; prettier --check; check:english-comments; check-theme-colors
```

(*) Both failures are **pre-existing and unrelated**, reproduced on a clean `main`
checkout with the tree stashed: `docs` `tests/protect-dialog.test.ts` exceeds its 10 s
timeout when the whole suite runs concurrently (passes in isolation), and `pdf`
`tests/generated-output.test.ts` asserts POSIX path joining (`/save/a_b_.pdf`) but gets
`\save\b_.pdf` on win32.
