### PR TITLE
feat(ai-search): add Tavily web search fallback via TAVILY_API_KEY

### DIFF
--- a/packages/ai-search/src/index.ts
+++ b/packages/ai-search/src/index.ts
@@ -72,9 +72,9 @@ export async function webSearch(
             : { results, method: 'serper' }
         }
       }
-      } catch {
-    /* fall back to Tavily/DuckDuckGo */
-  }
+    } catch {
+      /* fall back to Tavily/DuckDuckGo */
+    }
   }
   const tavilyKey = TAVILY_KEY()
   if (tavilyKey) {

--- a/packages/ai-search/src/index.ts
+++ b/packages/ai-search/src/index.ts
@@ -1,7 +1,8 @@
 /**
  * Search utilities (main process) — gsk (Genspark CLI) first, then Serper Google API,
- * with DuckDuckGo as the keyless last resort. Runs in the main process
- * (Node fetch / child process) to avoid renderer CORS; the Serper key reuses SERPER_API_KEY.
+ * then Tavily, with DuckDuckGo as the keyless last resort. Runs in the main process
+ * (Node fetch / child process) to avoid renderer CORS; the Serper key reuses SERPER_API_KEY,
+ * the Tavily key reuses TAVILY_API_KEY.
  * For gsk auth see ./gsk.ts (`gsk login` or GSK_API_KEY).
  */
 
@@ -19,6 +20,7 @@ export * from './gsk'
 export * from './genoffice-auth'
 
 const SERPER_KEY = () => process.env.SERPER_API_KEY ?? ''
+const TAVILY_KEY = () => process.env.TAVILY_API_KEY ?? ''
 
 // ── Web search ──────────────────────────────────────────────────────
 
@@ -38,7 +40,7 @@ export async function webSearch(
       const r = await gskWebSearch(query, maxResults)
       if (r.results.length) return { ...r, method: 'gsk' }
     } catch {
-      /* fall back to Serper/DuckDuckGo */
+      /* fall back to Serper/Tavily/DuckDuckGo */
     }
   }
   const key = SERPER_KEY()
@@ -68,6 +70,42 @@ export async function webSearch(
           return answer !== undefined
             ? { results, answer, method: 'serper' }
             : { results, method: 'serper' }
+        }
+      }
+      } catch {
+    /* fall back to Tavily/DuckDuckGo */
+  }
+  }
+  const tavilyKey = TAVILY_KEY()
+  if (tavilyKey) {
+    try {
+      const resp = await fetchWithTimeout('https://api.tavily.com/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: tavilyKey,
+          query,
+          max_results: maxResults,
+          include_answer: true,
+        }),
+      })
+      if (resp.ok) {
+        const data = asRecord(await resp.json())
+        const raw: unknown[] = Array.isArray(data.results) ? data.results : []
+        const results: WebSearchResult[] = raw.slice(0, maxResults).map((item) => {
+          const o = asRecord(item)
+          return {
+            title: String(o.title ?? ''),
+            url: String(o.url ?? ''),
+            snippet: String(o.content ?? ''),
+          }
+        })
+        const answerRaw = data.answer
+        const answer = typeof answerRaw === 'string' && answerRaw ? answerRaw : undefined
+        if (results.length) {
+          return answer !== undefined
+            ? { results, answer, method: 'tavily' }
+            : { results, method: 'tavily' }
         }
       }
     } catch {

--- a/packages/ai-search/tests/search.test.ts
+++ b/packages/ai-search/tests/search.test.ts
@@ -10,6 +10,7 @@ const realFetch = globalThis.fetch
 afterEach(() => {
   globalThis.fetch = realFetch
   delete process.env.SERPER_API_KEY
+  delete process.env.TAVILY_API_KEY
 })
 
 function mockFetch(
@@ -62,6 +63,56 @@ describe('webSearch (Serper)', () => {
     expect(r.method).toBe('duckduckgo')
     expect(r.results[0]?.url).toBe('https://x.com')
     expect(r.results[0]?.title).toBe('X Title')
+  })
+})
+
+describe('webSearch (Tavily)', () => {
+  it('parses results + answer when Serper is unconfigured', async () => {
+    process.env.TAVILY_API_KEY = 'test-key'
+    mockFetch((url, init) => {
+      expect(url).toBe('https://api.tavily.com/search')
+      expect(JSON.parse(String((init as any)?.body ?? '{}')).api_key).toBe('test-key')
+      return {
+        ok: true,
+        json: {
+          answer: '42',
+          results: [
+            { title: 'A', url: 'https://a.com', content: 'sa' },
+            { title: 'B', url: 'https://b.com', content: 'sb' },
+          ],
+        },
+      }
+    })
+    const r = await webSearch('meaning of life', 5)
+    expect(r.method).toBe('tavily')
+    expect(r.answer).toBe('42')
+    expect(r.results).toHaveLength(2)
+    expect(r.results[0]).toEqual({ title: 'A', url: 'https://a.com', snippet: 'sa' })
+  })
+
+  it('prefers Serper over Tavily when both keys are set', async () => {
+    process.env.SERPER_API_KEY = 'serper-key'
+    process.env.TAVILY_API_KEY = 'tavily-key'
+    mockFetch((url) => {
+      expect(url).toBe('https://google.serper.dev/search')
+      return { ok: true, json: { organic: [{ title: 'A', link: 'https://a.com' }] } }
+    })
+    const r = await webSearch('q', 3)
+    expect(r.method).toBe('serper')
+  })
+
+  it('falls back to DuckDuckGo when Tavily returns nothing usable', async () => {
+    process.env.TAVILY_API_KEY = 'test-key'
+    mockFetch((url) => {
+      if (url === 'https://api.tavily.com/search') return { ok: true, json: { results: [] } }
+      expect(url).toContain('duckduckgo.com')
+      return {
+        ok: true,
+        text: '<a class="result__a" href="/l/?uddg=https%3A%2F%2Fx.com">X Title</a>',
+      }
+    })
+    const r = await webSearch('q', 3)
+    expect(r.method).toBe('duckduckgo')
   })
 })
 


### PR DESCRIPTION
## Summary

- **What changed?** `webSearch` in `packages/ai-search/src/index.ts` now tries Tavily (`https://api.tavily.com/search` with `TAVILY_API_KEY`) between Serper and DuckDuckGo. Chain is now gsk → Serper → Tavily → DuckDuckGo → error. Response mapping mirrors Serper (`title`/`url`/`content` → `snippet`, plus optional `answer`), returning `method: 'tavily'`.
- **Why is this change needed?** Users with a Tavily subscription (part of #45's user-owned AI configuration ask) had no way to use it — only `SERPER_API_KEY` was honored, otherwise search fell straight to keyless DuckDuckGo scraping. Image search is unchanged (Tavily is text search; Serper → DuckDuckGo still applies there).

## Related issue

Part of #45 (user-owned AI configuration: Tavily search)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — extended `packages/ai-search/tests/search.test.ts` with 3 Tavily cases: parses results + answer, Serper preferred when both keys set, empty Tavily falls through to DuckDuckGo

List any checks not run and explain why: none. Live check needs a Tavily key; request/response shape follows Tavily's documented `/search` API.

## Screenshots or recordings

Not applicable — search-backend change. Before: `TAVILY_API_KEY` ignored. After: `method: 'tavily'` results with answer when the key is set.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A)
