### PR TITLE
feat(docs): RTL-aware AI panel chrome and auto-direction messages (part of #13)

### DIFF
--- a/apps/docs/src/renderer/ai/AiPanel.tsx
+++ b/apps/docs/src/renderer/ai/AiPanel.tsx
@@ -305,7 +305,9 @@ export function AiPanel({
   commentsAccess,
   hfAccess,
 }: AiPanelProps) {
-  const { t } = useI18n()
+  const { t, lang } = useI18n()
+  // Panel chrome follows the UI language; message text follows its own content (dir=auto below)
+  const isRtl = lang === 'ar' || lang === 'he'
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
   /** Wall-clock start of the current run, drives the elapsed badge */
@@ -996,6 +998,7 @@ export function AiPanel({
     <aside
       ref={asideRef}
       style={{ width: '100%' }}
+      dir={isRtl ? 'rtl' : undefined}
       className={`ai-panel${dragOver ? ' ai-panel-dragover' : ''}${resizing ? ' ai-panel-resizing' : ''}`}
       onDragOver={(e) => {
         if (e.dataTransfer.types.includes('Files')) {
@@ -1055,7 +1058,11 @@ export function AiPanel({
                   <SentAttachments atts={entry.attachments} previews={attachmentPreviews} />
                 )}
                 {entry.tools && entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
-                {entry.text && <Markdown text={entry.text} nav={docNav} />}
+                {entry.text && (
+                  <div dir="auto">
+                    <Markdown text={entry.text} nav={docNav} />
+                  </div>
+                )}
               </div>
             ))}
             <div className="ai-history-sep">{t('aiHistorySep')}</div>
@@ -1123,9 +1130,11 @@ export function AiPanel({
                   />
                 </span>
               ) : entry.role === 'assistant' ? (
-                <Markdown text={entry.text} nav={docNav} />
+                <div dir="auto">
+                  <Markdown text={entry.text} nav={docNav} />
+                </div>
               ) : (
-                entry.text
+                <span dir="auto">{entry.text}</span>
               )}
               {entry.tools && entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
               {entry.error && (

--- a/packages/ui/src/AiComposer.tsx
+++ b/packages/ui/src/AiComposer.tsx
@@ -86,6 +86,7 @@ export function AiComposer({
         placeholder={placeholder}
         aria-label={ariaLabel}
         rows={1}
+        dir="auto"
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {


### PR DESCRIPTION
## Summary

- **What changed?** The docs AI panel now adapts to right-to-left UI languages (part of #13 item 4): the panel `<aside>` sets `dir="rtl"` when the UI language is Arabic or Hebrew (flex header/actions mirror automatically, no CSS changes needed), message text resolves direction per content via `dir="auto"` wrappers (historic + current assistant Markdown, current user text), and the shared `AiComposer` textarea in `@genoffice/ui` gets `dir="auto"` (also fixes sheets, which shares the composer) so the cursor and alignment follow the typed script.
- **Why is this change needed?** The panel chrome used physical LTR layout unconditionally and never derived direction from locale or content, so Arabic input got an LTR cursor/alignment and Arabic responses rendered LTR. Document-engine bidi (lists, tables, headers) is untouched — this slice is AI-sidebar only.

## Related issue

Part of #13 (item 4: AI sidebar RTL)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` — `lang` comes from `useI18n(): I18n` (`ar`/`he` in `Lang`); `dir` props are standard JSX
- [x] `npm test` — existing `ai-panel-collapse.test.ts` suite; manual: switch UI to Arabic, panel chrome mirrors, Arabic prompt/response align right, English content unaffected

List any checks not run and explain why: none.

## Screenshots or recordings

Not applicable — chrome mirroring. Before: Arabic UI still LTR panel, Arabic messages LTR-aligned. After: `rtl` panel chrome, `auto` message/composer direction.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A)
