### PR TITLE
feat(ai-panels): RTL-aware chrome and auto-direction messages in slides/sheets/pdf/markdown (part of #13)

### DIFF
--- a/apps/markdown/src/renderer/ai/AiPanel.tsx
+++ b/apps/markdown/src/renderer/ai/AiPanel.tsx
@@ -669,7 +669,7 @@ export function AiPanel({
                   <div dir="auto">
                     <Markdown text={entry.text} nav={docNav} />
                   </div>
-                )}
+                )
               )}
               {hasTools && <ToolChipList tools={entry.tools!} />}
               {showToolbar && (

--- a/apps/markdown/src/renderer/ai/AiPanel.tsx
+++ b/apps/markdown/src/renderer/ai/AiPanel.tsx
@@ -561,6 +561,7 @@ export function AiPanel({
       ref={asideRef}
       className={`copilot${resizing ? ' ai-panel-resizing' : ''}`}
       style={{ width: '100%' }}
+      dir={lang === 'ar' || lang === 'he' ? 'rtl' : undefined}
     >
       <div
         className="ai-panel-resizer"
@@ -632,7 +633,7 @@ export function AiPanel({
           if (entry.role === 'user') {
             return (
               <div key={i} className="ai-msg ai-msg-user">
-                {entry.text}
+                <span dir="auto">{entry.text}</span>
                 {entry.undelivered && (
                   <div className="ai-msg-undelivered">
                     {t('aiUndelivered')}
@@ -664,7 +665,11 @@ export function AiPanel({
                   <AiTypingIndicator label={hasTools ? t('aiWorking') : t('aiThinking')} />
                 </span>
               ) : (
-                entry.text && <Markdown text={entry.text} nav={docNav} />
+                entry.text && (
+                  <div dir="auto">
+                    <Markdown text={entry.text} nav={docNav} />
+                  </div>
+                )}
               )}
               {hasTools && <ToolChipList tools={entry.tools!} />}
               {showToolbar && (

--- a/apps/pdf/src/renderer/ai/AiPanel.tsx
+++ b/apps/pdf/src/renderer/ai/AiPanel.tsx
@@ -532,6 +532,7 @@ export function AiPanel({
       ref={asideRef}
       className={`copilot${resizing ? ' ai-panel-resizing' : ''}`}
       style={{ width: '100%' }}
+      dir={lang === 'ar' || lang === 'he' ? 'rtl' : undefined}
     >
       <div
         className="ai-panel-resizer"
@@ -603,7 +604,7 @@ export function AiPanel({
           if (entry.role === 'user') {
             return (
               <div key={i} className="ai-msg ai-msg-user">
-                {entry.text}
+                <span dir="auto">{entry.text}</span>
                 {entry.undelivered && (
                   <div className="ai-msg-undelivered">
                     {t('aiUndelivered')}
@@ -625,7 +626,11 @@ export function AiPanel({
               className={`ai-msg ai-msg-assistant${entry.isError ? ' ai-msg-error' : ''}`}
             >
               {hasTools && <ToolChipList tools={entry.tools!} />}
-              {entry.text && <Markdown text={entry.text} nav={pdfNav} />}
+              {entry.text && (
+                <div dir="auto">
+                  <Markdown text={entry.text} nav={pdfNav} />
+                </div>
+              )}
             </div>
           )
         })}

--- a/apps/sheets/src/renderer/ai/AiChatPanel.tsx
+++ b/apps/sheets/src/renderer/ai/AiChatPanel.tsx
@@ -279,7 +279,9 @@ export function AiChatPanel({
   readonly onExpand: () => void
   readonly onCollapse: () => void
 }): React.JSX.Element {
-  const { t } = useI18n()
+  const { t, lang } = useI18n()
+  // Panel chrome follows the UI language; message text follows its own content (dir=auto below)
+  const isRtl = lang === 'ar' || lang === 'he'
   const chatRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const stickToBottomRef = useRef(true)
@@ -479,6 +481,7 @@ export function AiChatPanel({
     <aside
       ref={asideRef}
       className={`copilot${dragOver ? ' ai-panel-dragover' : ''}${resizing ? ' ai-panel-resizing' : ''}`}
+      dir={isRtl ? 'rtl' : undefined}
       onDragOver={(e) => {
         if (e.dataTransfer.types.includes('Files')) {
           e.preventDefault()
@@ -535,7 +538,11 @@ export function AiChatPanel({
                   <SentAttachments atts={entry.attachments} previews={attachmentPreviews} />
                 )}
                 {entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
-                {entry.text && <Markdown text={entry.text} nav={citationNav} />}
+                {entry.text && (
+                  <div dir="auto">
+                    <Markdown text={entry.text} nav={citationNav} />
+                  </div>
+                )}
               </div>
             ))}
             <div className="ai-history-sep">{t('aiHistorySep')}</div>
@@ -561,7 +568,7 @@ export function AiChatPanel({
                 {entry.attachments && entry.attachments.length > 0 && (
                   <SentAttachments atts={entry.attachments} previews={attachmentPreviews} />
                 )}
-                {entry.text}
+                <span dir="auto">{entry.text}</span>
                 {entry.undelivered && (
                   <div className="ai-msg-undelivered">
                     {t('aiUndelivered')}
@@ -580,7 +587,9 @@ export function AiChatPanel({
               <>
                 {entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
                 {entry.text ? (
-                  <Markdown text={entry.text} nav={citationNav} />
+                  <div dir="auto">
+                    <Markdown text={entry.text} nav={citationNav} />
+                  </div>
                 ) : (
                   entry.streaming && (
                     <span className="ai-typing-row">

--- a/apps/slides/src/renderer/ai/AiPanel.tsx
+++ b/apps/slides/src/renderer/ai/AiPanel.tsx
@@ -395,7 +395,9 @@ export function AiPanel({
   onQueueFocus,
   onQueueConsume,
 }: AiPanelProps) {
-  const { t } = useI18n()
+  const { t, lang } = useI18n()
+  // Panel chrome follows the UI language; message text follows its own content (dir=auto below)
+  const isRtl = lang === 'ar' || lang === 'he'
   const [input, setInput] = useState('')
   const [busy, setBusy] = useState(false)
   const [chat, setChat] = useState<ChatEntry[]>([])
@@ -1961,6 +1963,7 @@ export function AiPanel({
       ref={asideRef}
       style={{ width: '100%' }}
       className={`ai-panel${dragOver ? ' ai-panel-dragover' : ''}${resizing ? ' ai-panel-resizing' : ''}`}
+      dir={isRtl ? 'rtl' : undefined}
       onDragOver={(e) => {
         if (e.dataTransfer.types.includes('Files')) {
           e.preventDefault()
@@ -2019,7 +2022,11 @@ export function AiPanel({
                   <SentAttachments atts={entry.attachments} previews={attachmentPreviews} />
                 )}
                 {entry.tools && entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
-                {entry.text && <Markdown text={entry.text} />}
+                {entry.text && (
+                  <div dir="auto">
+                    <Markdown text={entry.text} />
+                  </div>
+                )}
               </div>
             ))}
             <div className="ai-history-sep">{t('aiHistorySep')}</div>
@@ -2087,9 +2094,11 @@ export function AiPanel({
                   />
                 </span>
               ) : entry.role === 'assistant' ? (
-                <Markdown text={entry.text} />
+                <div dir="auto">
+                  <Markdown text={entry.text} />
+                </div>
               ) : (
-                entry.text
+                <span dir="auto">{entry.text}</span>
               )}
               {entry.tools && entry.tools.length > 0 && <ToolChipList tools={entry.tools} />}
               {entry.error && (
@@ -2293,6 +2302,7 @@ export function AiPanel({
             <textarea
               ref={inputRef}
               value={input}
+              dir="auto"
               data-slides-ai-input="true"
               data-deck-undo-ready={!busy && !inputEditedSinceRunRef.current ? 'true' : 'false'}
               placeholder={t(deckEmpty ? 'aiInputPlaceholderGen' : 'aiInputPlaceholder')}


### PR DESCRIPTION
## Summary

- **What changed?** Extends the docs AI-panel RTL work to slides, sheets, pdf and markdown panels (same pattern): panel `<aside>` sets `dir="rtl"` for Arabic/Hebrew UI (flex chrome mirrors automatically, no CSS changes), message text resolves per content via `dir="auto"` wrappers (historic + current assistant Markdown, user text spans), and slides' own composer `<textarea>` gets `dir="auto"` (sheets/pdf/markdown share `@genoffice/ui` `AiComposer`, already covered).
- **Why is this change needed?** Same gap as the docs slice (part of #13 item 4): all four panels used physical LTR layout unconditionally, so Arabic input got an LTR cursor and Arabic responses rendered LTR. Document-engine bidi is untouched — AI sidebars only.

## Related issue

Part of #13 (item 4: AI sidebar RTL; docs slice shipped separately)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck` — `lang` from existing `useI18n()` destructuring (`ar`/`he` in `Lang`); `dir` props are standard JSX
- [x] `npm test` — existing per-app panel suites; manual: Arabic UI mirrors chrome in all four panels, Arabic/English messages align per content

List any checks not run and explain why: none.

## Screenshots or recordings

Not applicable — chrome mirroring. Before: LTR-only panels in every app. After: `rtl` chrome under ar/he UI locales, `auto` message/composer direction everywhere.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A)
