### PR TITLE
fix(drop-open): route legacy .doc drops to the shell converter

### DIFF
--- a/apps/shell/tests/dropped-files.test.ts
+++ b/apps/shell/tests/dropped-files.test.ts
@@ -50,18 +50,26 @@ describe('handleDroppedFiles', () => {
 
   it('warns once with the combined extensions for known-unsupported drops', () => {
     const deps = fakeDeps()
-    handleDroppedFiles(['/tmp/old.doc', '/tmp/deck.pages', '/tmp/note.rtf'], deps)
+    handleDroppedFiles(['/tmp/old.odt', '/tmp/deck.pages', '/tmp/note.rtf'], deps)
     expect(deps.opened).toEqual([])
     expect(deps.revealed).not.toHaveBeenCalled()
-    expect(deps.warned).toEqual(['unsupported: doc, pages, rtf'])
+    expect(deps.warned).toEqual(['unsupported: odt, pages, rtf'])
+  })
+
+  it('opens legacy .doc alongside supported files with no warning', () => {
+    const deps = fakeDeps()
+    handleDroppedFiles(['/tmp/new.docx', '/tmp/old.doc'], deps)
+    expect(deps.opened).toEqual(['/tmp/new.docx', '/tmp/old.doc'])
+    expect(deps.revealed).toHaveBeenCalledOnce()
+    expect(deps.warned).toEqual([])
   })
 
   it('opens the supported files and warns about the rest in a mixed drop', () => {
     const deps = fakeDeps()
-    handleDroppedFiles(['/tmp/new.docx', '/tmp/old.doc'], deps)
+    handleDroppedFiles(['/tmp/new.docx', '/tmp/note.rtf'], deps)
     expect(deps.opened).toEqual(['/tmp/new.docx'])
     expect(deps.revealed).toHaveBeenCalledOnce()
-    expect(deps.warned).toEqual(['unsupported: doc'])
+    expect(deps.warned).toEqual(['unsupported: rtf'])
   })
 
   it('ignores junk payloads and unrecognized file types entirely', () => {

--- a/packages/electron-utils/src/drop-open.ts
+++ b/packages/electron-utils/src/drop-open.ts
@@ -15,13 +15,14 @@ import { ipcRenderer, webUtils } from 'electron'
 export const DROP_OPEN_CHANNEL = 'app:open-dropped-files'
 
 /** Extensions routed by apps/shell routeDocumentPath — keep in sync there and
- *  with OPEN_DIALOG_EXTENSIONS / OPEN_LOCAL_EXTENSIONS on the home screen. */
-export const OPENABLE_DOC_RE = /\.(docx|xlsx|xlsm|xls|csv|pptx|pdf|md|markdown)$/i
+ *  with OPEN_DIALOG_EXTENSIONS / OPEN_LOCAL_EXTENSIONS on the home screen.
+ *  Legacy .doc opens via the shell's extract-to-text converter. */
+export const OPENABLE_DOC_RE = /\.(docx|doc|xlsx|xlsm|xls|csv|pptx|pdf|md|markdown)$/i
 
 /** Recognized-but-unsupported formats: kept in the sent payload so the shell
  *  can show its "not supported" dialog instead of dropping them silently.
  *  Mirrors UNSUPPORTED_DOC_RE in apps/shell/src/main/index.ts. */
-export const KNOWN_UNSUPPORTED_DOC_RE = /\.(doc|rtf|odt|ppt|pps|odp|ods|xlsb|pages|key|numbers)$/i
+export const KNOWN_UNSUPPORTED_DOC_RE = /\.(rtf|odt|ppt|pps|odp|ods|xlsb|pages|key|numbers)$/i
 
 /** upper bound on how many files one drop may ask to open */
 const MAX_DROPPED_FILES = 20

--- a/packages/electron-utils/tests/drop-open.test.ts
+++ b/packages/electron-utils/tests/drop-open.test.ts
@@ -121,10 +121,10 @@ describe('partitionDropPayload', () => {
     expect(result.supported).toEqual(['REPORT.DOCX', 'data.CSV', 'notes.MarkDown'])
   })
 
-  it('collects known-unsupported extensions uniquely, first-seen order', () => {
+  it('routes legacy .doc to the shell converter instead of the unsupported warning', () => {
     const result = partitionDropPayload(['old.doc', 'x.pages', 'y.rtf', 'z.doc'])
-    expect(result.supported).toEqual([])
-    expect(result.unsupportedExts).toEqual(['doc', 'pages', 'rtf'])
+    expect(result.supported).toEqual(['old.doc', 'z.doc'])
+    expect(result.unsupportedExts).toEqual(['pages', 'rtf'])
   })
 
   it('caps the number of openable files at 20', () => {
@@ -252,10 +252,10 @@ describe('installDropOpenBridge', () => {
     electronMocks.getPathForFile.mockImplementation((f: { name: string }) => `/tmp/${f.name}`)
     const win = install()
     try {
-      const ev = fileDrag(['legacy.doc'])
+      const ev = fileDrag(['legacy.rtf'])
       win.fire('drop', ev)
       await vi.waitFor(() =>
-        expect(electronMocks.send).toHaveBeenCalledWith(DROP_OPEN_CHANNEL, ['/tmp/legacy.doc']),
+        expect(electronMocks.send).toHaveBeenCalledWith(DROP_OPEN_CHANNEL, ['/tmp/legacy.rtf']),
       )
     } finally {
       uninstall(win)


### PR DESCRIPTION
## Summary

- **What changed?** `OPENABLE_DOC_RE` in `packages/electron-utils/src/drop-open.ts` now includes legacy `.doc`, and `KNOWN_UNSUPPORTED_DOC_RE` drops it — matching the shell router change that opens `.doc` via text extraction. A dropped `.doc` now rides the `supported` path into `routeDocumentPath` (which converts it) instead of triggering the "not supported" warning.
- **Why is this change needed?** Follow-up to the `.doc` open support (#36): without this sync, drag-drop contradicted File > Open — dropping a `.doc` warned "not supported" while opening the same file from the dialog converted it. Both regexes document the keep-in-sync contract in comments.

## Related issue

Part of #36 (drag-drop parity for legacy `.doc` open support)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — updated `packages/electron-utils/tests/drop-open.test.ts`: `.doc` partitions to `supported`, `.rtf` still exercises the known-unsupported forward path

List any checks not run and explain why: none.

## Screenshots or recordings

Not applicable — drop-classification change. Before: dropping `legacy.doc` shows the unsupported warning. After: it opens via the text converter like File > Open.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (drop-open partition tests updated)
