### PR TITLE
fix(shell): advertise legacy .doc on the home open-local card (part of #36)

### DIFF
--- a/apps/shell/src/renderer/src/Home.tsx
+++ b/apps/shell/src/renderer/src/Home.tsx
@@ -54,7 +54,7 @@ const FILE_ICONS: Record<string, string> = {
 /* Formats the open-local card advertises. Too long for the card at any window
    width, so it ellipsizes and a hover ScreenTip carries the full list. Keep in
    sync with the main-process open-dialog filter (OPEN_DIALOG_EXTENSIONS). */
-const OPEN_LOCAL_EXTENSIONS = '.docx / .xlsx / .xlsm / .xls / .csv / .pptx / .pdf / .md'
+const OPEN_LOCAL_EXTENSIONS = '.docx / .doc / .xlsx / .xlsm / .xls / .csv / .pptx / .pdf / .md'
 
 function FileBadge({ ext, size }: { ext: string; size: number }) {
   const icon = FILE_ICONS[ext]


### PR DESCRIPTION
## Summary

- **What changed?** One line: the home screen open-local card now advertises `.doc` alongside the other openable formats.
- **Why is this change needed?** Follow-up to legacy `.doc` open support (#36): the dialog filter, router, and drop bridge all accept `.doc`, but the home card still listed only the old set — its own comment demands sync with `OPEN_DIALOG_EXTENSIONS`. Files dropped onto the home card without an icon fall back to the letter badge (`D`), so no icon asset is needed.

## Related issue

Part of #36 (home-screen parity for legacy `.doc` open support)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: none.

## Screenshots or recordings

Not applicable — one-line advertised-formats string. Before: `.docx / .xlsx / …`. After: `.docx / .doc / .xlsx / …`.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings — display list only)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A)
