### PR TITLE
fix(shell): include legacy .doc under the recents docx filter (part of #36)

### DIFF
--- a/apps/shell/src/main/recent-files.ts
+++ b/apps/shell/src/main/recent-files.ts
@@ -53,7 +53,12 @@ export function normalizeRecentQuery(
 }
 
 /** sidebar filter keys that stand for a family of extensions, not one exact ext */
-const EXT_FAMILY: Record<string, readonly string[]> = { xlsx: ['xlsx', 'xlsm'] }
+const EXT_FAMILY: Record<string, readonly string[]> = {
+  xlsx: ['xlsx', 'xlsm'],
+  // legacy .doc opens via the shell's extract-to-text converter, so it belongs
+  // under the Word filter with .docx
+  docx: ['docx', 'doc'],
+}
 
 /** Page over the recents paths, preserving the source's newest-first order (unavailable paths stay, flagged missing). */
 export function pageRecentPaths(

--- a/apps/shell/tests/recent-files.test.ts
+++ b/apps/shell/tests/recent-files.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { pageRecentPaths } from '../src/main/recent-files'
+
+const NONE = new Set<string>()
+const PATHS = ['/d/new.docx', '/d/legacy.doc', '/d/book.xlsx', '/d/macro.xlsm', '/d/deck.pptx']
+
+describe('pageRecentPaths ext families', () => {
+  it('includes legacy .doc under the docx filter', () => {
+    const page = pageRecentPaths(PATHS, { ext: 'docx', limit: 50 }, NONE)
+    expect(page.entries.map((e) => e.path)).toEqual(['/d/new.docx', '/d/legacy.doc'])
+    expect(page.total).toBe(2)
+    expect(page.totalAll).toBe(PATHS.length)
+  })
+
+  it('keeps the xlsx family as-is', () => {
+    const page = pageRecentPaths(PATHS, { ext: 'xlsx', limit: 50 }, NONE)
+    expect(page.entries.map((e) => e.path)).toEqual(['/d/book.xlsx', '/d/macro.xlsm'])
+  })
+
+  it('matches unknown extensions exactly', () => {
+    const page = pageRecentPaths(PATHS, { ext: 'pptx', limit: 50 }, NONE)
+    expect(page.entries.map((e) => e.path)).toEqual(['/d/deck.pptx'])
+  })
+})


### PR DESCRIPTION
## Summary

- **What changed?** The recents sidebar `docx` filter family now includes legacy `.doc` (`EXT_FAMILY.docx = ['docx', 'doc']` in `apps/shell/src/main/recent-files.ts`), mirroring the existing `xlsx → xlsm` precedent.
- **Why is this change needed?** Follow-up to legacy `.doc` open support (#36): converted `.doc` files are recorded in recents, but filtering the sidebar by Word showed only `.docx` — opened `.doc` files vanished from the filtered list.

## Related issue

Part of #36 (recents parity for legacy `.doc` open support)

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — new `apps/shell/tests/recent-files.test.ts` (docx family includes doc, xlsx family unchanged, unknown ext exact-match)

List any checks not run and explain why: none.

## Screenshots or recordings

Not applicable — filter behavior. Before: Word filter hides opened `.doc` files. After: `.docx` + `.doc` both listed.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (no new strings)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (recents filter tests added)
