### PR TITLE
docs(contributing): document TAVILY_API_KEY in env var table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,16 +97,16 @@ or copy an existing `target/release/xlsx-sidecar.exe` to
 None are required — the apps run with all of these unset. They exist for
 testing and local overrides:
 
-| Variable                                                 | Effect                                                                 |
-| -------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `GENOFFICE_USER_DATA`                                    | Override the Electron userData directory (test isolation)              |
-| `GENOFFICE_LANG`                                         | Force the UI language instead of following the OS locale               |
-| `GENOFFICE_FAKE_UPDATE`                                  | Exercise the updater UI without a real release feed                    |
-| `GENOFFICE_CLOUD_SLIDE`, `GENOFFICE_CLOUD_SLIDE_TIER`    | Route slide generation through the cloud endpoint                      |
-| `GSK_API_KEY`, `GSK_CLI_PATH`                            | Genspark credentials / CLI location for the built-in AI provider       |
-| `AI_SEARCH_DISABLE_GSK`, `SERPER_API_KEY`                | Disable the gsk search backend / supply a Serper key instead           |
-| `XLSX_SIDECAR_PATH`, `XLSX_OPEN_PATH`, `XLSX_DEBUG_PORT` | Point at a locally built xlsx sidecar and its debug port               |
-| `*_DEV_PORT`, `*_RENDERER_URL`                           | Per-app Vite dev server ports and renderer URLs (set by `npm run dev`) |
+| Variable                                                    | Effect                                                                 |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `GENOFFICE_USER_DATA`                                       | Override the Electron userData directory (test isolation)              |
+| `GENOFFICE_LANG`                                            | Force the UI language instead of following the OS locale               |
+| `GENOFFICE_FAKE_UPDATE`                                     | Exercise the updater UI without a real release feed                    |
+| `GENOFFICE_CLOUD_SLIDE`, `GENOFFICE_CLOUD_SLIDE_TIER`       | Route slide generation through the cloud endpoint                      |
+| `GSK_API_KEY`, `GSK_CLI_PATH`                               | Genspark credentials / CLI location for the built-in AI provider       |
+| `AI_SEARCH_DISABLE_GSK`, `SERPER_API_KEY`, `TAVILY_API_KEY` | Disable the gsk search backend / supply a Serper or Tavily key         |
+| `XLSX_SIDECAR_PATH`, `XLSX_OPEN_PATH`, `XLSX_DEBUG_PORT`    | Point at a locally built xlsx sidecar and its debug port               |
+| `*_DEV_PORT`, `*_RENDERER_URL`                              | Per-app Vite dev server ports and renderer URLs (set by `npm run dev`) |
 
 AI features degrade rather than break without credentials: requests surface an
 inline sign-in prompt, and web search falls back to a keyless backend.


### PR DESCRIPTION
## Summary
Follows up #194 (Tavily web-search fallback): \CONTRIBUTING.md\'s environment-variable table listed \AI_SEARCH_DISABLE_GSK\ / \SERPER_API_KEY\ but not the new \TAVILY_API_KEY\, so contributors had no documented way to supply a Tavily key. This adds \TAVILY_API_KEY\ to that row and updates the effect text to \Disable the gsk search backend / supply a Serper or Tavily key\.

## Related issue
Related to #194 (Tavily fallback). No \Closes\ — docs follow-up, no behavior change.

## Validation
- [x] \ormat:check\ — no local \
ode_modules\, so verified equivalently: table rebuilt programmatically to Prettier column widths (Variable 59 / Effect 70, single-space borders, exact dash separators); diff is the minimal 10-line re-pad
- [ ] \lint\ — N/A (Markdown only, CI will confirm)
- [ ] \	ypecheck\ — N/A (Markdown only, CI will confirm)
- [ ] \
pm test\ — N/A (Markdown only, CI will confirm)

## Screenshots
N/A — docs table change:
\| AI_SEARCH_DISABLE_GSK, SERPER_API_KEY, TAVILY_API_KEY | Disable the gsk search backend / supply a Serper or Tavily key |\

## Contributor checklist
- [x] Change is scoped to the documented env var (no code touched)
- [x] Conventional Commits message (\docs(contributing): ...\)
- [x] Table kept Prettier-clean (uniform column widths)