### PR TITLE
fix(slides): preserve agent runs across lifecycle boundaries

### DIFF
--- a/apps/slides/src/renderer/ai/AiPanel.tsx
+++ b/apps/slides/src/renderer/ai/AiPanel.tsx
@@ -1412,7 +1412,7 @@ export function AiPanel({
           })
           // Persist the assistant message (deckProgress not stored; tools store the whole run's full activity) —
           // side effects outside the updater (StrictMode double-invokes updaters, duplicating history writes)
-          if (finalText && !cancelled) {
+          if (!cancelled && (finalText || runToolsRef.current.length > 0)) {
             persistMessage('assistant', finalText, runToolsRef.current)
           }
           // A stop with nothing streamed is just the user changing their mind; a stop
@@ -1521,11 +1521,15 @@ export function AiPanel({
     const images: AgentImage[] = []
     const failures: string[] = []
     for (const att of imageAtts.slice(0, MAX_IMAGES_PER_MESSAGE)) {
-      const result = await window.desktop.readAttachmentImage(att.path)
-      if (result.ok && result.base64 && result.mime) {
-        images.push({ base64: result.base64, mime: result.mime })
-      } else {
-        failures.push(result.error ?? t('aiReadFailed', { name: att.name }))
+      try {
+        const result = await window.desktop.readAttachmentImage(att.path)
+        if (result.ok && result.base64 && result.mime) {
+          images.push({ base64: result.base64, mime: result.mime })
+        } else {
+          failures.push(result.error ?? t('aiReadFailed', { name: att.name }))
+        }
+      } catch {
+        failures.push(t('aiReadFailed', { name: att.name }))
       }
     }
     if (imageAtts.length > MAX_IMAGES_PER_MESSAGE) {

--- a/apps/slides/tests/ai-panel-run-lifecycle.test.ts
+++ b/apps/slides/tests/ai-panel-run-lifecycle.test.ts
@@ -17,9 +17,8 @@ const agentHarness = vi.hoisted(() => ({
 }))
 
 vi.mock('@genoffice/agent-core', async () => {
-  const actual = await vi.importActual<typeof import('@genoffice/agent-core')>(
-    '@genoffice/agent-core',
-  )
+  const actual =
+    await vi.importActual<typeof import('@genoffice/agent-core')>('@genoffice/agent-core')
   return {
     ...actual,
     AgentLoop: class MockAgentLoop {
@@ -74,10 +73,7 @@ import { AI_PROVIDERS, type AiSettings, type AttachmentMeta } from '../src/share
 const settings: AiSettings = {
   provider: 'anthropic',
   providers: Object.fromEntries(
-    AI_PROVIDERS.map((provider) => [
-      provider.id,
-      { apiKey: '', model: provider.defaultModel },
-    ]),
+    AI_PROVIDERS.map((provider) => [provider.id, { apiKey: '', model: provider.defaultModel }]),
   ) as AiSettings['providers'],
 }
 

--- a/apps/slides/tests/ai-panel-run-lifecycle.test.ts
+++ b/apps/slides/tests/ai-panel-run-lifecycle.test.ts
@@ -1,0 +1,235 @@
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const agentHarness = vi.hoisted(() => ({
+  events: null as null | {
+    onToolExecuted?: (event: {
+      call: { id: string; name: string; input: unknown }
+      execution: { summary: string; output?: string; isError?: boolean; mutated?: boolean }
+    }) => void
+    onDone?: (result: { text: string; cancelled: boolean; turnLimit: boolean }) => void
+  },
+  run: vi.fn(),
+  cancel: vi.fn(),
+  reset: vi.fn(),
+  restore: vi.fn(),
+}))
+
+vi.mock('@genoffice/agent-core', async () => {
+  const actual = await vi.importActual<typeof import('@genoffice/agent-core')>(
+    '@genoffice/agent-core',
+  )
+  return {
+    ...actual,
+    AgentLoop: class MockAgentLoop {
+      busy = false
+
+      constructor(options: { events?: typeof agentHarness.events }) {
+        agentHarness.events = options.events ?? null
+      }
+
+      run(...args: unknown[]) {
+        agentHarness.run(...args)
+      }
+
+      cancel() {
+        agentHarness.cancel()
+      }
+
+      reset() {
+        agentHarness.reset()
+      }
+
+      restore(...args: unknown[]) {
+        agentHarness.restore(...args)
+      }
+    },
+  }
+})
+
+// react-konva's node entry requires the native 'canvas' package; these tests do not draw.
+vi.mock('react-konva', () => {
+  const stub = () => null
+  return {
+    Stage: stub,
+    Layer: stub,
+    Rect: stub,
+    Group: stub,
+    Transformer: stub,
+    Line: stub,
+    Arrow: stub,
+    Text: stub,
+    Ellipse: stub,
+    Image: stub,
+    Path: stub,
+    Circle: stub,
+    Arc: stub,
+  }
+})
+
+import { AiPanel } from '../src/renderer/ai/AiPanel'
+import { AI_PROVIDERS, type AiSettings, type AttachmentMeta } from '../src/shared/ipc'
+
+const settings: AiSettings = {
+  provider: 'anthropic',
+  providers: Object.fromEntries(
+    AI_PROVIDERS.map((provider) => [
+      provider.id,
+      { apiKey: '', model: provider.defaultModel },
+    ]),
+  ) as AiSettings['providers'],
+}
+
+const mountedRoots: Array<{ root: Root; container: HTMLElement }> = []
+
+function mount(element: React.ReactElement): { root: Root; container: HTMLElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(element))
+  mountedRoots.push({ root, container })
+  return { root, container }
+}
+
+function panelProps(overrides: Record<string, unknown> = {}) {
+  return {
+    slides: [],
+    current: 0,
+    selectedIds: [],
+    images: new Map<string, HTMLImageElement>(),
+    applySlide: () => {},
+    applyDeck: () => {},
+    fitWidthPx: 960,
+    settings,
+    open: true,
+    onExpand: () => {},
+    onCollapse: () => {},
+    ...overrides,
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function installSlidesApi(): void {
+  Object.defineProperty(window, 'slidesApi', {
+    configurable: true,
+    value: {
+      aiGskStatus: vi.fn(async () => ({ loggedIn: true })),
+      beginHistoryBatch: vi.fn(async () => false),
+      endHistoryBatch: vi.fn(async () => null),
+      aiLogRunFailure: vi.fn(async () => undefined),
+    },
+  })
+}
+
+beforeAll(() => {
+  Element.prototype.scrollTo ??= () => {}
+})
+
+beforeEach(() => {
+  agentHarness.events = null
+  agentHarness.run.mockReset()
+  agentHarness.cancel.mockReset()
+  agentHarness.reset.mockReset()
+  agentHarness.restore.mockReset()
+  installSlidesApi()
+  Object.defineProperty(window, 'projectApi', { configurable: true, value: undefined })
+  Object.defineProperty(window, 'desktop', {
+    configurable: true,
+    value: { readAttachmentImage: vi.fn(async () => ({ ok: false })) },
+  })
+})
+
+afterEach(() => {
+  for (const { root, container } of mountedRoots.splice(0)) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  vi.restoreAllMocks()
+})
+
+describe('AiPanel agent run lifecycle (slides)', () => {
+  it('persists a successful tool-only run so reopening can restore the completed turn', async () => {
+    const appendChat = vi.fn(async () => undefined)
+    Object.defineProperty(window, 'projectApi', {
+      configurable: true,
+      value: {
+        resolveChat: vi.fn(async () => ({ projectId: 'default', chatId: 'deck-chat' })),
+        loadChat: vi.fn(async () => []),
+        appendChat,
+        rebindChat: vi.fn(async () => ({ projectId: 'default', chatId: 'deck-chat' })),
+      },
+    })
+
+    mount(createElement(AiPanel, panelProps({ currentFilePath: '/tmp/deck.pptx' })))
+    await flushEffects()
+    appendChat.mockClear()
+
+    expect(agentHarness.events).not.toBeNull()
+    act(() => {
+      agentHarness.events!.onToolExecuted?.({
+        call: { id: 'tool-1', name: 'apply_ops', input: { op: 'set_fill' } },
+        execution: { summary: 'Changed the title fill', output: 'ok', mutated: true },
+      })
+      agentHarness.events!.onDone?.({ text: '', cancelled: false, turnLimit: false })
+    })
+    await flushEffects()
+
+    expect(appendChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'default',
+        chatId: 'deck-chat',
+        role: 'assistant',
+        text: '',
+        tools: [
+          expect.objectContaining({
+            name: 'apply_ops',
+            summary: 'Changed the title fill',
+            output: 'ok',
+          }),
+        ],
+      }),
+    )
+  })
+
+  it('continues the agent run without images when attachment reading rejects', async () => {
+    const readAttachmentImage = vi.fn(async () => {
+      throw new Error('attachment bridge unavailable')
+    })
+    Object.defineProperty(window, 'desktop', {
+      configurable: true,
+      value: { readAttachmentImage },
+    })
+    const attachment: AttachmentMeta = {
+      path: '/tmp/reference.png',
+      name: 'reference.png',
+      ext: 'png',
+      sizeBytes: 128,
+    }
+
+    mount(
+      createElement(
+        AiPanel,
+        panelProps({
+          preset: {
+            text: 'Polish this slide',
+            nonce: 1,
+            autoRun: true,
+            attachments: [attachment],
+          },
+        }),
+      ),
+    )
+    await flushEffects()
+
+    expect(readAttachmentImage).toHaveBeenCalled()
+    expect(agentHarness.run).toHaveBeenCalledWith('Polish this slide', [])
+  })
+})

--- a/apps/slides/tests/ai-panel-run-lifecycle.test.ts
+++ b/apps/slides/tests/ai-panel-run-lifecycle.test.ts
@@ -199,20 +199,19 @@ describe('AiPanel agent run lifecycle (slides)', () => {
     )
   })
 
-  it('continues the agent run without images when attachment reading rejects', async () => {
-    const readAttachmentImage = vi.fn(async () => {
+  it('keeps readable images and continues the run when another attachment read rejects', async () => {
+    const readAttachmentImage = vi.fn(async (path: string) => {
+      if (path.endsWith('good.png')) return { ok: true, base64: 'AAAA', mime: 'image/png' }
       throw new Error('attachment bridge unavailable')
     })
     Object.defineProperty(window, 'desktop', {
       configurable: true,
       value: { readAttachmentImage },
     })
-    const attachment: AttachmentMeta = {
-      path: '/tmp/reference.png',
-      name: 'reference.png',
-      ext: 'png',
-      sizeBytes: 128,
-    }
+    const attachments: AttachmentMeta[] = [
+      { path: '/tmp/good.png', name: 'good.png', ext: 'png', sizeBytes: 128 },
+      { path: '/tmp/bad.png', name: 'bad.png', ext: 'png', sizeBytes: 128 },
+    ]
 
     mount(
       createElement(
@@ -222,14 +221,17 @@ describe('AiPanel agent run lifecycle (slides)', () => {
             text: 'Polish this slide',
             nonce: 1,
             autoRun: true,
-            attachments: [attachment],
+            attachments,
           },
         }),
       ),
     )
     await flushEffects()
 
-    expect(readAttachmentImage).toHaveBeenCalled()
-    expect(agentHarness.run).toHaveBeenCalledWith('Polish this slide', [])
+    expect(readAttachmentImage).toHaveBeenCalledWith('/tmp/good.png')
+    expect(readAttachmentImage).toHaveBeenCalledWith('/tmp/bad.png')
+    expect(agentHarness.run).toHaveBeenCalledWith('Polish this slide', [
+      { base64: 'AAAA', mime: 'image/png' },
+    ])
   })
 })


### PR DESCRIPTION
## Summary

* **What changed?** Slides now persists successful tool-only assistant turns together with their executed tool metadata, even when the model finishes without a text reply. Attachment image reads are also isolated per attachment, so one rejected read no longer aborts the submitted Agent run or discards other images that were read successfully.
* **Why is this change needed?** A successful Slides Agent run can legitimately finish with an empty closing text after tools have already edited the deck. The UI already treats that as a completed tool-heavy run, but chat persistence previously skipped the assistant turn because `finalText` was empty. After reopening the file, the durable transcript could therefore contain only the preceding user message, which `AgentLoop.restore()` correctly treats as unanswered and filters from model history.

  Attachment preflight had a similar lifecycle gap at run startup: `collectImageAttachments()` handled `{ ok: false }` results but not a rejected `readAttachmentImage()` promise. One IPC rejection rejected the whole collection before `loop.run()` was reached, even though the user message had already been submitted. The new per-attachment handling preserves readable images, reports failed ones through the existing localized warning path, and allows the run to continue.

The changes are limited to the Slides Agent lifecycle; Agent Core, provider behavior, and slide editing operations are unchanged.

## Related issue

No tracking issue — found while auditing Slides Agent run lifecycle and session persistence behavior.

## Validation

* [x] Regression test reproduces both failures before the production fix:

  * successful tool-only completion does not append the assistant transcript entry
  * one rejected attachment read prevents the Agent run from starting
* [x] `npm test -w @genoffice/slides -- ai-panel-run-lifecycle.test.ts` — 2 passed
* [x] `npm run typecheck -w @genoffice/slides`
* [x] `npm test -w @genoffice/slides` — 634 passed, 12 skipped
* [x] Repository CI on the final candidate commit — formatting, licenses, lint, typecheck, fixtures, full test suite, Sheets compatibility gate, and Electron E2E passed

## Screenshots or recordings

Not applicable — lifecycle/session reliability fix with no intended visual change.

## Contributor checklist

* [x] The change is focused and does not include unrelated reformatting or refactoring.
* [x] User-facing strings use the existing i18n resources. No new strings are introduced.
* [x] Regression coverage exercises both the successful tool-only completion path and partial attachment-read failure path.
