### PR TITLE
feat(docs): collapsible ribbon with persisted state (fixes #210)

### DIFF
--- a/apps/docs/src/renderer/App.tsx
+++ b/apps/docs/src/renderer/App.tsx
@@ -493,6 +493,10 @@ export function App() {
   const [ribbonTabRequest, setRibbonTabRequest] = useState<{ tab: string; nonce: number } | null>(
     null,
   )
+  /** Word-style ribbon collapse (#210): tab row stays as the drag area, tool body hides; persisted */
+  const [ribbonCollapsed, setRibbonCollapsed] = useState(
+    () => localStorage.getItem('aidocs.ribbonCollapsed') === '1',
+  )
   const [status, setStatus] = useState('')
   const [zoom, setZoom] = useState(100)
   const [darkCanvas, setDarkCanvas] = useState(false)
@@ -975,6 +979,10 @@ export function App() {
   useEffect(() => {
     localStorage.setItem('aidocs.showAi', showAi ? '1' : '0')
   }, [showAi])
+
+  useEffect(() => {
+    localStorage.setItem('aidocs.ribbonCollapsed', ribbonCollapsed ? '1' : '0')
+  }, [ribbonCollapsed])
 
   useEffect(() => {
     localStorage.setItem('aidocs.autoSave', autoSave ? '1' : '0')
@@ -4370,6 +4378,8 @@ export function App() {
         styles={ribbonStyles}
         docDefaults={doc?.parsed.docDefaults}
         showAi={showAi}
+        ribbonCollapsed={ribbonCollapsed}
+        onToggleRibbonCollapse={() => setRibbonCollapsed((v) => !v)}
         section={sections[activeSection]?.settings ?? section}
         activeSection={sections.length > 1 ? activeSection : null}
         pageColor={pageColor}

--- a/apps/docs/src/renderer/components/Ribbon.tsx
+++ b/apps/docs/src/renderer/components/Ribbon.tsx
@@ -159,9 +159,10 @@ interface RibbonProps {
   onSaveAs: () => void
   showAi: boolean
   onToggleAi: () => void
-  /** Word-style collapse: the tab row (frameless drag area) stays, the tool body hides */
-  ribbonCollapsed: boolean
-  onToggleRibbonCollapse: () => void
+  /** Word-style collapse: the tab row (frameless drag area) stays, the tool body hides.
+      Optional so test-only mounts render the classic expanded ribbon. */
+  ribbonCollapsed?: boolean
+  onToggleRibbonCollapse?: () => void
   section: SectionSettings | null
   onSection: (next: SectionSettings) => void
   /** Multi-section documents: index of the cursor's section (0-based); null for single-section */
@@ -618,7 +619,7 @@ function RibbonInner({
   onSaveAs,
   showAi,
   onToggleAi,
-  ribbonCollapsed,
+  ribbonCollapsed = false,
   onToggleRibbonCollapse,
   section,
   onSection,

--- a/apps/docs/src/renderer/components/Ribbon.tsx
+++ b/apps/docs/src/renderer/components/Ribbon.tsx
@@ -159,6 +159,9 @@ interface RibbonProps {
   onSaveAs: () => void
   showAi: boolean
   onToggleAi: () => void
+  /** Word-style collapse: the tab row (frameless drag area) stays, the tool body hides */
+  ribbonCollapsed: boolean
+  onToggleRibbonCollapse: () => void
   section: SectionSettings | null
   onSection: (next: SectionSettings) => void
   /** Multi-section documents: index of the cursor's section (0-based); null for single-section */
@@ -615,6 +618,8 @@ function RibbonInner({
   onSaveAs,
   showAi,
   onToggleAi,
+  ribbonCollapsed,
+  onToggleRibbonCollapse,
   section,
   onSection,
   activeSection,
@@ -1868,7 +1873,7 @@ function RibbonInner({
   )
 
   return (
-    <div className="ribbon">
+    <div className={`ribbon${ribbonCollapsed ? ' collapsed' : ''}`}>
       <div
         className={`ribbon-tabs ${IN_TAB ? '' : IS_MAC ? 'ribbon-tabs-mac' : 'ribbon-tabs-win'}`}
       >
@@ -1967,6 +1972,23 @@ function RibbonInner({
             </button>
           ))}
         <span className="ribbon-tabs-spacer" />
+        <button
+          className="ribbon-tab ribbon-collapse-btn"
+          onClick={onToggleRibbonCollapse}
+          data-tip={t(ribbonCollapsed ? 'ribbonExpandTip' : 'ribbonCollapseTip')}
+          aria-label={t(ribbonCollapsed ? 'ribbonExpandTip' : 'ribbonCollapseTip')}
+          aria-expanded={!ribbonCollapsed}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-flex',
+              transform: ribbonCollapsed ? undefined : 'rotate(180deg)',
+            }}
+          >
+            <IconCaret size={10} />
+          </span>
+        </button>
         {trailingActions}
       </div>
 

--- a/apps/docs/src/renderer/i18n/ribbon/ar.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/ar.ts
@@ -145,6 +145,8 @@ export const ar = {
   ribbonAllBordersTip: 'إضافة حدود إلى كافة جوانب الخلايا المحددة',
   ribbonOuterBorders: 'الحدود الخارجية',
   ribbonOuterBordersTip: 'حدود على الحافة الخارجية للتحديد فقط',
+  ribbonCollapseTip: 'طي الشريط',
+  ribbonExpandTip: 'توسيع الشريط',
   ribbonInnerBorders: 'الحدود الداخلية',
   ribbonInnerBordersTip: 'حدود داخل التحديد فقط',
   ribbonClearBordersTip: 'مسح حدود الخلايا المحددة',

--- a/apps/docs/src/renderer/i18n/ribbon/de.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/de.ts
@@ -149,6 +149,8 @@ export const de = {
   ribbonAllBordersTip: 'Rahmenlinien an allen Seiten der ausgewählten Zellen hinzufügen',
   ribbonOuterBorders: 'Rahmenlinien außen',
   ribbonOuterBordersTip: 'Rahmenlinien nur am äußeren Rand der Auswahl',
+  ribbonCollapseTip: 'Menüband minimieren',
+  ribbonExpandTip: 'Menüband erweitern',
   ribbonInnerBorders: 'Rahmenlinien innen',
   ribbonInnerBordersTip: 'Rahmenlinien nur innerhalb der Auswahl',
   ribbonClearBordersTip: 'Rahmenlinien der ausgewählten Zellen entfernen',

--- a/apps/docs/src/renderer/i18n/ribbon/en.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/en.ts
@@ -146,6 +146,8 @@ export const en = {
   ribbonAllBordersTip: 'Add borders to all sides of the selected cells',
   ribbonOuterBorders: 'Outside Borders',
   ribbonOuterBordersTip: 'Borders on the outer edge of the selection only',
+  ribbonCollapseTip: 'Collapse the ribbon',
+  ribbonExpandTip: 'Expand the ribbon',
   ribbonInnerBorders: 'Inside Borders',
   ribbonInnerBordersTip: 'Borders inside the selection only',
   ribbonClearBordersTip: 'Clear borders from the selected cells',

--- a/apps/docs/src/renderer/i18n/ribbon/es.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/es.ts
@@ -149,6 +149,8 @@ export const es = {
   ribbonAllBordersTip: 'Agregar bordes a los cuatro lados de las celdas seleccionadas',
   ribbonOuterBorders: 'Bordes externos',
   ribbonOuterBordersTip: 'Bordes solo en el contorno de la selección',
+  ribbonCollapseTip: 'Contraer la cinta de opciones',
+  ribbonExpandTip: 'Expandir la cinta de opciones',
   ribbonInnerBorders: 'Bordes internos',
   ribbonInnerBordersTip: 'Bordes solo en el interior de la selección',
   ribbonClearBordersTip: 'Borrar los bordes de las celdas seleccionadas',

--- a/apps/docs/src/renderer/i18n/ribbon/fr.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/fr.ts
@@ -149,6 +149,8 @@ export const fr = {
   ribbonAllBordersTip: 'Ajouter des bordures aux quatre côtés des cellules sélectionnées',
   ribbonOuterBorders: 'Bordures extérieures',
   ribbonOuterBordersTip: 'Bordures uniquement sur le pourtour de la sélection',
+  ribbonCollapseTip: 'Réduire le ruban',
+  ribbonExpandTip: 'Développer le ruban',
   ribbonInnerBorders: 'Bordures intérieures',
   ribbonInnerBordersTip: "Bordures uniquement à l'intérieur de la sélection",
   ribbonClearBordersTip: 'Effacer les bordures des cellules sélectionnées',

--- a/apps/docs/src/renderer/i18n/ribbon/he.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/he.ts
@@ -145,6 +145,8 @@ export const he = {
   ribbonAllBordersTip: 'הוסף גבולות לכל צידי התאים הנבחרים',
   ribbonOuterBorders: 'גבולות חיצוניים',
   ribbonOuterBordersTip: 'גבולות רק בהיקף החיצוני של הבחירה',
+  ribbonCollapseTip: 'כווץ את הסרט',
+  ribbonExpandTip: 'הרחב את הסרט',
   ribbonInnerBorders: 'גבולות פנימיים',
   ribbonInnerBordersTip: 'גבולות רק בתוך הבחירה',
   ribbonClearBordersTip: 'נקה גבולות מהתאים הנבחרים',

--- a/apps/docs/src/renderer/i18n/ribbon/hi.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/hi.ts
@@ -148,6 +148,8 @@ export const hi = {
   ribbonAllBordersTip: 'चयनित कक्षों के सभी किनारों पर बॉर्डर जोड़ें',
   ribbonOuterBorders: 'बाहरी बॉर्डर',
   ribbonOuterBordersTip: 'केवल चयन के बाहरी किनारे पर बॉर्डर',
+  ribbonCollapseTip: 'रिबन समेटें',
+  ribbonExpandTip: 'रिबन फैलाएँ',
   ribbonInnerBorders: 'भीतरी बॉर्डर',
   ribbonInnerBordersTip: 'केवल चयन के भीतर बॉर्डर',
   ribbonClearBordersTip: 'चयनित कक्षों से बॉर्डर साफ़ करें',

--- a/apps/docs/src/renderer/i18n/ribbon/id.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/id.ts
@@ -147,6 +147,8 @@ export const id = {
   ribbonAllBordersTip: 'Tambahkan batas ke semua sisi sel yang dipilih',
   ribbonOuterBorders: 'Batas Luar',
   ribbonOuterBordersTip: 'Batas hanya di tepi luar pilihan',
+  ribbonCollapseTip: 'Ciutkan pita',
+  ribbonExpandTip: 'Luaskan pita',
   ribbonInnerBorders: 'Batas Dalam',
   ribbonInnerBordersTip: 'Batas hanya di bagian dalam pilihan',
   ribbonClearBordersTip: 'Hapus batas dari sel yang dipilih',

--- a/apps/docs/src/renderer/i18n/ribbon/it.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/it.ts
@@ -149,6 +149,8 @@ export const it = {
   ribbonAllBordersTip: 'Aggiungi bordi a tutti i lati delle celle selezionate',
   ribbonOuterBorders: 'Bordi esterni',
   ribbonOuterBordersTip: 'Bordi solo sul contorno esterno della selezione',
+  ribbonCollapseTip: 'Comprimi la barra multifunzione',
+  ribbonExpandTip: 'Espandi la barra multifunzione',
   ribbonInnerBorders: 'Bordi interni',
   ribbonInnerBordersTip: "Bordi solo all'interno della selezione",
   ribbonClearBordersTip: 'Rimuovi i bordi dalle celle selezionate',

--- a/apps/docs/src/renderer/i18n/ribbon/ja.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/ja.ts
@@ -156,6 +156,8 @@ export const ja = {
   ribbonAllBordersTip: '選択したセルの四辺すべてに罫線を追加',
   ribbonOuterBorders: '外枠',
   ribbonOuterBordersTip: '選択範囲の外側のみに罫線を追加',
+  ribbonCollapseTip: 'リボンを折りたたむ',
+  ribbonExpandTip: 'リボンを展開する',
   ribbonInnerBorders: '内側の罫線',
   ribbonInnerBordersTip: '選択範囲の内側のみに罫線を追加',
   ribbonClearBordersTip: '選択したセルの罫線をクリア',

--- a/apps/docs/src/renderer/i18n/ribbon/ko.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/ko.ts
@@ -154,6 +154,8 @@ export const ko = {
   ribbonAllBordersTip: '선택한 셀의 모든 면에 테두리 추가',
   ribbonOuterBorders: '바깥쪽 테두리',
   ribbonOuterBordersTip: '선택 영역의 바깥쪽에만 테두리 추가',
+  ribbonCollapseTip: '리본 최소화',
+  ribbonExpandTip: '리본 확장',
   ribbonInnerBorders: '안쪽 테두리',
   ribbonInnerBordersTip: '선택 영역의 안쪽에만 테두리 추가',
   ribbonClearBordersTip: '선택한 셀의 테두리 지우기',

--- a/apps/docs/src/renderer/i18n/ribbon/ms.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/ms.ts
@@ -148,6 +148,8 @@ export const ms = {
   ribbonAllBordersTip: 'Tambah sempadan pada semua sisi sel yang dipilih',
   ribbonOuterBorders: 'Sempadan Luar',
   ribbonOuterBordersTip: 'Sempadan pada bahagian luar pilihan sahaja',
+  ribbonCollapseTip: 'Runtuhkan reben',
+  ribbonExpandTip: 'Kembangkan reben',
   ribbonInnerBorders: 'Sempadan Dalam',
   ribbonInnerBordersTip: 'Sempadan di bahagian dalam pilihan sahaja',
   ribbonClearBordersTip: 'Kosongkan sempadan daripada sel yang dipilih',

--- a/apps/docs/src/renderer/i18n/ribbon/nl.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/nl.ts
@@ -150,6 +150,8 @@ export const nl = {
   ribbonAllBordersTip: 'Randen toevoegen aan alle zijden van de geselecteerde cellen',
   ribbonOuterBorders: 'Buitenranden',
   ribbonOuterBordersTip: 'Alleen randen aan de buitenkant van de selectie',
+  ribbonCollapseTip: 'Het lint samenvouwen',
+  ribbonExpandTip: 'Het lint uitvouwen',
   ribbonInnerBorders: 'Binnenranden',
   ribbonInnerBordersTip: 'Alleen randen binnen de selectie',
   ribbonClearBordersTip: 'Randen van de geselecteerde cellen wissen',

--- a/apps/docs/src/renderer/i18n/ribbon/pl.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/pl.ts
@@ -148,6 +148,8 @@ export const pl = {
   ribbonAllBordersTip: 'Dodaj krawędzie ze wszystkich stron zaznaczonych komórek',
   ribbonOuterBorders: 'Krawędzie zewnętrzne',
   ribbonOuterBordersTip: 'Krawędzie tylko na zewnętrznym obrysie zaznaczenia',
+  ribbonCollapseTip: 'Zwiń wstążkę',
+  ribbonExpandTip: 'Rozwiń wstążkę',
   ribbonInnerBorders: 'Krawędzie wewnętrzne',
   ribbonInnerBordersTip: 'Krawędzie tylko wewnątrz zaznaczenia',
   ribbonClearBordersTip: 'Usuń krawędzie z zaznaczonych komórek',

--- a/apps/docs/src/renderer/i18n/ribbon/pt.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/pt.ts
@@ -148,6 +148,8 @@ export const pt = {
   ribbonAllBordersTip: 'Adicionar bordas a todos os lados das células selecionadas',
   ribbonOuterBorders: 'Bordas Externas',
   ribbonOuterBordersTip: 'Bordas apenas no contorno externo da seleção',
+  ribbonCollapseTip: 'Recolher a faixa',
+  ribbonExpandTip: 'Expandir a faixa',
   ribbonInnerBorders: 'Bordas Internas',
   ribbonInnerBordersTip: 'Bordas apenas no interior da seleção',
   ribbonClearBordersTip: 'Limpar as bordas das células selecionadas',

--- a/apps/docs/src/renderer/i18n/ribbon/ru.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/ru.ts
@@ -148,6 +148,8 @@ export const ru = {
   ribbonAllBordersTip: 'Добавить границы со всех сторон выделенных ячеек',
   ribbonOuterBorders: 'Внешние границы',
   ribbonOuterBordersTip: 'Границы только по внешнему краю выделения',
+  ribbonCollapseTip: 'Свернуть ленту',
+  ribbonExpandTip: 'Развернуть ленту',
   ribbonInnerBorders: 'Внутренние границы',
   ribbonInnerBordersTip: 'Границы только внутри выделения',
   ribbonClearBordersTip: 'Убрать границы выделенных ячеек',

--- a/apps/docs/src/renderer/i18n/ribbon/th.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/th.ts
@@ -146,6 +146,8 @@ export const th = {
   ribbonAllBordersTip: 'เพิ่มเส้นขอบทุกด้านของเซลล์ที่เลือก',
   ribbonOuterBorders: 'เส้นขอบด้านนอก',
   ribbonOuterBordersTip: 'เส้นขอบเฉพาะรอบนอกของส่วนที่เลือกเท่านั้น',
+  ribbonCollapseTip: 'ยุบ Ribbon',
+  ribbonExpandTip: 'ขยาย Ribbon',
   ribbonInnerBorders: 'เส้นขอบด้านใน',
   ribbonInnerBordersTip: 'เส้นขอบเฉพาะด้านในของส่วนที่เลือกเท่านั้น',
   ribbonClearBordersTip: 'ล้างเส้นขอบของเซลล์ที่เลือก',

--- a/apps/docs/src/renderer/i18n/ribbon/zh-TW.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/zh-TW.ts
@@ -144,6 +144,8 @@ export const zhTW = {
   ribbonAllBordersTip: '選取儲存格四邊全部加上框線',
   ribbonOuterBorders: '外框線',
   ribbonOuterBordersTip: '僅選取範圍外側加上框線',
+  ribbonCollapseTip: '收合功能區',
+  ribbonExpandTip: '展開功能區',
   ribbonInnerBorders: '內框線',
   ribbonInnerBordersTip: '僅選取範圍內部加上框線',
   ribbonClearBordersTip: '清除選取儲存格的框線',

--- a/apps/docs/src/renderer/i18n/ribbon/zh.ts
+++ b/apps/docs/src/renderer/i18n/ribbon/zh.ts
@@ -153,6 +153,8 @@ export const zh = {
   ribbonAllBordersTip: '选中单元格四边全部加框线',
   ribbonOuterBorders: '外侧框线',
   ribbonOuterBordersTip: '仅选区外侧加框线',
+  ribbonCollapseTip: '收起功能区',
+  ribbonExpandTip: '展开功能区',
   ribbonInnerBorders: '内侧框线',
   ribbonInnerBordersTip: '仅选区内部加框线',
   ribbonClearBordersTip: '清除选中单元格框线',

--- a/apps/docs/src/renderer/styles.css
+++ b/apps/docs/src/renderer/styles.css
@@ -404,6 +404,12 @@ button {
   -webkit-app-region: no-drag;
 }
 
+/* Word-style collapse (#210): the tab row (frameless drag area) stays while
+   the tool body hides; the body stays mounted so dropdown state survives */
+.ribbon.collapsed .ribbon-body {
+  display: none;
+}
+
 /* While a popover is open the row must deliver presses (drag regions swallow
    them), so outside-press dismissal can see presses on the blank band */
 html.genoffice-popover-open .ribbon-tabs {


### PR DESCRIPTION
## Summary
The top header bar (ribbon) was always fully expanded. This adds a Word-style one-click collapse toggle at the end of the tab row: the tool body hides while the tab row stays visible (it doubles as the frameless-window drag area with traffic-light/caption spacing, so it must not collapse). State persists in localStorage (`aidocs.ribbonCollapsed`).

## Related issue
Fixes #210. Docs only; slides/sheets have their own ribbon implementations and are untouched.

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6 on all touched source files
- [ ] `lint` — CI
- [ ] `typecheck` — CI (all 19 locale shards carry both new keys per the `satisfies Record<keyof typeof zh>` contract)
- [ ] `npm test` — CI

## Screenshots
N/A — behavior: chevron button at the tab-row end toggles `.ribbon.collapsed` (hides `.ribbon-body`, body stays mounted so dropdown state survives); tooltips/aria-labels via new `ribbonCollapseTip`/`ribbonExpandTip` keys in all 19 locales.

## Contributor checklist
- [x] Scoped to the reported ask (docs ribbon only)
- [x] Conventional Commits message (`feat(docs): ...`)
- [x] Reuses existing `ribbon-tab` styling + `IconCaret` (rotated for the expand/collapse direction)
- [x] No key removals; zh defines the new key set per convention