### PR TITLE
fix(sheets): reject out-of-grid Go To refs at validation

### DIFF
--- a/apps/sheets/src/renderer/goto.ts
+++ b/apps/sheets/src/renderer/goto.ts
@@ -5,6 +5,8 @@
 /// tolerates `$` markers and `Sheet1!` prefixes but silently yields NaN rows
 /// for garbage, so validity is decided here, not by try/catch alone.
 
+import { columnIndex } from '../domain/cell-address'
+
 export interface GoToNameEntry {
   readonly name: string
   readonly ref: string
@@ -22,12 +24,52 @@ function splitSheetPrefix(ref: string): { readonly sheet: string; readonly body:
   return { sheet: ref.slice(0, bang), body: ref.slice(bang + 1) }
 }
 
+/// Excel grid limits: rows 1..1048576, columns A..XFD.
+const MAX_ROW_NUMBER = 1048576
+const MAX_COLUMN_INDEX = 16383 // XFD
+
+const CELL_PART = /^\$?([A-Za-z]{1,3})\$?(\d+)$/
+
+function columnInBounds(letters: string): boolean {
+  try {
+    return columnIndex(letters.toUpperCase()) <= MAX_COLUMN_INDEX
+  } catch {
+    return false
+  }
+}
+
+function rowInBounds(digits: string): boolean {
+  const row = Number(digits)
+  return Number.isInteger(row) && row >= 1 && row <= MAX_ROW_NUMBER
+}
+
+/// True when every cell endpoint in the shape-validated body also sits
+/// inside the grid. Without this, `A0` / `ZZZ1` / `A1048577` / `0:5`
+/// pass the shape regexes and leak into getRange as NaN/out-of-bounds,
+/// surfacing as a generic failure instead of an unresolvable reference.
+function endpointsInBounds(body: string): boolean {
+  return body.split(':').every((part) => {
+    const cell = CELL_PART.exec(part)
+    if (cell?.[1] !== undefined && cell[2] !== undefined) {
+      return columnInBounds(cell[1]) && rowInBounds(cell[2])
+    }
+    const lettersOnly = /^\$?([A-Za-z]{1,3})$/.exec(part)
+    if (lettersOnly?.[1] !== undefined) return columnInBounds(lettersOnly[1])
+    const digitsOnly = /^\$?(\d+)$/.exec(part)
+    if (digitsOnly?.[1] !== undefined) return rowInBounds(digitsOnly[1])
+    return false
+  })
+}
+
 /// True when the reference (after any sheet prefix) is a cell, a range, a
 /// whole-column span, or a whole-row span in A1 notation.
 export function isA1Reference(ref: string): boolean {
   const { sheet, body } = splitSheetPrefix(ref)
   if (ref.includes('!') && sheet === '') return false
-  return CELL_OR_RANGE.test(body) || COLUMN_SPAN.test(body) || ROW_SPAN.test(body)
+  if (!CELL_OR_RANGE.test(body) && !COLUMN_SPAN.test(body) && !ROW_SPAN.test(body)) {
+    return false
+  }
+  return endpointsInBounds(body)
 }
 
 /// Resolves Name Box / Go To input to the A1 reference to jump to, or null

--- a/apps/sheets/tests/goto.test.ts
+++ b/apps/sheets/tests/goto.test.ts
@@ -27,6 +27,24 @@ describe('isA1Reference', () => {
     expect(isA1Reference('A1,B2')).toBe(false)
     expect(isA1Reference('')).toBe(false)
   })
+
+  it('rejects shape-valid refs outside the grid', () => {
+    // Row 0, over-long columns, and over-max rows/cols used to pass the
+    // shape regexes and leak into getRange as NaN/out-of-bounds.
+    expect(isA1Reference('A0')).toBe(false)
+    expect(isA1Reference('0:5')).toBe(false)
+    expect(isA1Reference('ZZZ1')).toBe(false)
+    expect(isA1Reference('A1048577')).toBe(false)
+    expect(isA1Reference('A1:ZZZ2')).toBe(false)
+    expect(isA1Reference('Sheet1!A0')).toBe(false)
+  })
+
+  it('accepts grid-boundary refs', () => {
+    expect(isA1Reference('XFD1048576')).toBe(true)
+    expect(isA1Reference('$XFD$1048576')).toBe(true)
+    expect(isA1Reference('A:A')).toBe(true)
+    expect(isA1Reference('1048576:1048576')).toBe(true)
+  })
 })
 
 describe('resolveGoToRef', () => {


### PR DESCRIPTION
## Summary
The Name Box / Go To validator accepted shape-valid but out-of-grid references (`A0`, `ZZZ1`, `A1048577`, `0:5`). Those leaked into `getRange` as NaN/out-of-bounds and surfaced as a generic failure instead of an unresolvable reference.

## Related issue
Code-scan find (no open issue covers Go To validation).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI, including the new boundary cases in `apps/sheets/tests/goto.test.ts`

## Screenshots
N/A — behavior: `A0`/`ZZZ1`/`A1048577`/`0:5` now resolve to null (unresolvable); `XFD1048576` still accepted.

## Contributor checklist
- [x] Scoped to the validator (reuses `columnIndex` from `domain/cell-address`, same import direction as sibling modules)
- [x] Conventional Commits message (`fix(sheets): ...`)
- [x] Regression tests added (reject + boundary-accept cases)
