### PR TITLE
fix(sheets): keep trailing newlines in clipboard TSV fields

### DIFF
--- a/apps/sheets/src/renderer/clipboard-tsv.ts
+++ b/apps/sheets/src/renderer/clipboard-tsv.ts
@@ -32,7 +32,9 @@ export function clipboardField(cell: ClipboardCell | null | undefined): string {
         // extractPureTextFromCell strips \r line breaks — keep string values
         // verbatim so embedded newlines survive to be quoted below
         (typeof cell.v === 'string' ? cell.v : extractPureTextFromCell(cell)))
-  const normalized = text.replace(/\r\n|\r+/g, '\n').replace(/\n+$/, '')
+  // Only normalize line endings: trailing newlines are significant cell
+  // content and must survive (quoted) instead of being stripped.
+  const normalized = text.replace(/\r\n|\r+/g, '\n')
   return /[\t\n"]/.test(normalized) ? `"${normalized.replace(/"/g, '""')}"` : normalized
 }
 

--- a/apps/sheets/tests/clipboard-tsv.test.ts
+++ b/apps/sheets/tests/clipboard-tsv.test.ts
@@ -20,6 +20,12 @@ describe('clipboard TSV serialization', () => {
     expect(clipboardField({ v: 'plain' })).toBe('plain')
   })
 
+  it('keeps significant trailing newlines (quoted) instead of stripping them', () => {
+    expect(clipboardField({ v: 'a\n' })).toBe('"a\n"')
+    expect(clipboardField({ v: 'a\r\n' })).toBe('"a\n"')
+    expect(clipboardField({ v: 'plain' })).toBe('plain')
+  })
+
   it('assembles rows with empty fields for missing cells (no column drift)', () => {
     const cells: Record<string, { v: string }> = { '0:0': { v: 'a' }, '0:2': { v: 'c' } }
     const plain = plainTextFromCells([0, 1], [0, 1, 2], (row, column) => cells[`${row}:${column}`])


### PR DESCRIPTION
## Summary
Copying a cell with a significant trailing newline (`"a\n"`) pasted back as `"a"` — `clipboardField` stripped trailing newlines before quoting, while the CSV export path preserves them. One-line fix: normalize line endings only, let the existing quoting carry the trailing newline.

## Related issue
Code-scan find (no open issue covers clipboard TSV).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI, including the new trailing-newline cases in `apps/sheets/tests/clipboard-tsv.test.ts` (existing `\r\r` collapsing expectation intentionally preserved)

## Screenshots
N/A — behavior: `"a\n"` copies as `"a\n"` (quoted) instead of `"a"`.

## Contributor checklist
- [x] Minimal one-line change, existing expectations untouched
- [x] Conventional Commits message (`fix(sheets): ...`)
- [x] Regression tests added
