### PR TITLE
fix(sheets): trim spaces in whole-cell replace paths

### DIFF
--- a/apps/sheets/src/domain/workbook-dsl.ts
+++ b/apps/sheets/src/domain/workbook-dsl.ts
@@ -1505,6 +1505,9 @@ export function expandToPrimitiveOps(
         throw new Error('find_replace needs the current cell contents to plan against.')
       const matchCase = operation.matchCase ?? false
       const needle = matchCase ? operation.find : operation.find.toLowerCase()
+      // Spaces trimmed, line breaks kept — same convention as the find
+      // dialog (lazy-find.ts) so whole-cell matches agree everywhere.
+      const trimSpaces = (s: string): string => s.replace(/^ +/g, '').replace(/ +$/g, '')
       for (let row = bounds.startRow; row <= bounds.endRow; row += 1) {
         for (let column = bounds.startColumn; column <= bounds.endColumn; column += 1) {
           const address = formatAddress(row, column)
@@ -1517,7 +1520,10 @@ export function expandToPrimitiveOps(
           const haystack = matchCase ? content : content.toLowerCase()
           let next: string | null = null
           if (operation.wholeCell) {
-            if (haystack === needle) next = operation.replace
+            // Mirror the find dialog (lazy-find.ts matchesTheWholeCell):
+            // surrounding spaces are ignored so preview and AI apply agree
+            // on cells like "  total  ".
+            if (trimSpaces(haystack) === needle.trim()) next = operation.replace
           } else if (haystack.includes(needle)) {
             next = replaceOccurrences(content, operation.find, operation.replace, matchCase)
           }

--- a/apps/sheets/src/renderer/App.tsx
+++ b/apps/sheets/src/renderer/App.tsx
@@ -4009,6 +4009,9 @@ export function App(): React.JSX.Element {
           const targetSheet = sheetById(op.sheetId)
           const matchCase = op.matchCase ?? false
           const needle = matchCase ? op.find : op.find.toLowerCase()
+          // Spaces trimmed, line breaks kept — same convention as the find
+          // dialog (lazy-find.ts) so chunk replaces agree with per-cell ones.
+          const trimSpaces = (s: string): string => s.replace(/^ +/g, '').replace(/ +$/g, '')
           await applyRangeInLoadedChunks(
             runtime,
             lazyWorkbookRef,
@@ -4045,7 +4048,7 @@ export function App(): React.JSX.Element {
                   const haystack = matchCase ? value : value.toLowerCase()
                   let next: string | null = null
                   if (op.wholeCell) {
-                    if (haystack === needle) next = op.replace
+                    if (trimSpaces(haystack) === needle.trim()) next = op.replace
                   } else if (haystack.includes(needle)) {
                     next = replaceOccurrences(value, op.find, op.replace, matchCase)
                   }

--- a/apps/sheets/tests/workbook-dsl.test.ts
+++ b/apps/sheets/tests/workbook-dsl.test.ts
@@ -609,6 +609,23 @@ describe('find_replace expansion', () => {
     expect(wholeOps).toEqual([{ op: 'set_cell', sheetId: 's', address: 'A1', value: 'pear' }])
   })
 
+  it('wholeCell ignores surrounding spaces like the find dialog', () => {
+    const ops = expandToPrimitiveOps(
+      [
+        {
+          op: 'find_replace',
+          sheetId: 's',
+          range: 'A1:A2',
+          find: 'apple',
+          replace: 'pear',
+          wholeCell: true,
+        },
+      ],
+      reader({ A1: '  apple  ', A2: 'apple pie' }),
+    )
+    expect(ops).toEqual([{ op: 'set_cell', sheetId: 's', address: 'A1', value: 'pear' }])
+  })
+
   it('keeps a literal $ in the replacement and skips formula cells', () => {
     const ops = expandToPrimitiveOps(
       [


### PR DESCRIPTION
## Summary
Ctrl+F whole-cell find trims surrounding spaces, but the AI `find_replace` per-cell expansion and the large-range chunk applier compared raw — so `"  total  "` was found by the dialog yet missed by `find_replace wholeCell:true` (and vice versa for preview vs apply). Both replace paths now use the dialog convention (spaces trimmed, line breaks kept).

## Related issue
Code-scan find (no open issue covers whole-cell parity).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI, including the new `"  apple  "` case in `apps/sheets/tests/workbook-dsl.test.ts`

## Screenshots
N/A — behavior: whole-cell replace matches the find dialog on space-padded cells; substring path untouched.

## Contributor checklist
- [x] Scoped to the wholeCell branch in both replace paths (comment cites `lazy-find.ts`)
- [x] Conventional Commits message (`fix(sheets): ...`)
- [x] Regression test added
