### PR TITLE
fix(slides): route saveAs through the save queue

### DIFF
--- a/apps/slides/src/renderer/file-actions.ts
+++ b/apps/slides/src/renderer/file-actions.ts
@@ -46,12 +46,37 @@ export function adoptSavedSlides(ctx: ActionCtx, next: RenderSlide[]): void {
  * truncated pptx, or EPERM/EBUSY on Windows. The queue is a simple promise
  * chain: each caller awaits the previous tail, then runs its own pass.
  */
-let saveTail: Promise<boolean> | null = null
+let saveTail: Promise<unknown> | null = null
+
+/**
+ * Runs `pass` after the in-flight save (if any) finishes, and becomes the
+ * tail subsequent saves wait on. A pass that throws still releases the
+ * queue; the error propagates to its own caller only.
+ */
+async function runSerialized<T>(pass: () => Promise<T>): Promise<T> {
+  const prior = saveTail
+  const current = (async (): Promise<T> => {
+    if (prior) await prior.catch(() => undefined)
+    return pass()
+  })()
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  )
+  saveTail = tail
+  void current.then(
+    () => {
+      if (saveTail === tail) saveTail = null
+    },
+    () => {
+      if (saveTail === tail) saveTail = null
+    },
+  )
+  return current
+}
 
 export async function save(ctx: ActionCtx, quiet = false): Promise<boolean> {
-  const prior = saveTail
-  const pass = (async () => {
-    if (prior) await prior.catch(() => false)
+  return runSerialized(async () => {
     await flushActiveEdit(ctx)
     await ctx.flushNotes()
     const r = await window.slidesApi.save()
@@ -70,35 +95,32 @@ export async function save(ctx: ActionCtx, quiet = false): Promise<boolean> {
       showToast(failed, 'error')
     }
     return r.ok
-  })()
-  saveTail = pass
-  pass
-    .catch(() => false)
-    .then(() => {
-      if (saveTail === pass) saveTail = null
-    })
-  return pass
+  })
 }
 
 export async function saveAs(ctx: ActionCtx): Promise<void> {
-  await flushActiveEdit(ctx)
-  await ctx.flushNotes()
-  const name = ctx.path?.split('/').pop() ?? 'presentation.pptx'
-  const r = await window.slidesApi.saveAs(name)
-  if (r.ok) {
-    if (r.slides) adoptSavedSlides(ctx, r.slides)
-    ctx.setPath(r.path ?? ctx.path)
-    ctx.setDirty(false)
-    const saved = t('appStatusSavedAs')
-    ctx.setStatus(saved)
-    showToast(saved)
-  } else if (r.error) {
-    // a canceled dialog returns ok:false without error — only real write
-    // failures surface, matching the docs/sheets save-as feedback
-    const failed = t('appStatusSaveFailed', { error: r.error })
-    ctx.setStatus(failed)
-    showToast(failed, 'error')
-  }
+  // Same queue as save(): Save + Save As (or double Save As) write through
+  // the same main-process pipe and would interleave without it.
+  await runSerialized(async () => {
+    await flushActiveEdit(ctx)
+    await ctx.flushNotes()
+    const name = ctx.path?.split('/').pop() ?? 'presentation.pptx'
+    const r = await window.slidesApi.saveAs(name)
+    if (r.ok) {
+      if (r.slides) adoptSavedSlides(ctx, r.slides)
+      ctx.setPath(r.path ?? ctx.path)
+      ctx.setDirty(false)
+      const saved = t('appStatusSavedAs')
+      ctx.setStatus(saved)
+      showToast(saved)
+    } else if (r.error) {
+      // a canceled dialog returns ok:false without error — only real write
+      // failures surface, matching the docs/sheets save-as feedback
+      const failed = t('appStatusSaveFailed', { error: r.error })
+      ctx.setStatus(failed)
+      showToast(failed, 'error')
+    }
+  })
 }
 
 /** Export base name: file name without the .pptx extension */

--- a/apps/slides/tests/save-serialization.test.ts
+++ b/apps/slides/tests/save-serialization.test.ts
@@ -7,7 +7,7 @@ vi.mock('../src/renderer/export-render', () => ({ renderSlidesToPngBase64: vi.fn
 vi.mock('../src/renderer/components/toast-bus', () => ({ showToast: vi.fn() }))
 vi.mock('../src/renderer/i18n/locale', () => ({ t: (k: string) => k }))
 
-import { save } from '../src/renderer/file-actions'
+import { save, saveAs } from '../src/renderer/file-actions'
 import type { ActionCtx } from '../src/renderer/action-context'
 
 function ctx(): ActionCtx {
@@ -50,6 +50,32 @@ describe('slides save serialization', () => {
     expect(b).toBe(true)
     expect(c).toBe(true)
     expect(mockSave).toHaveBeenCalledTimes(3)
+    expect(maxConcurrent).toBe(1)
+
+    vi.unstubAllGlobals()
+  })
+
+  it('serializes save against saveAs so their IPC writes never overlap', async () => {
+    let inFlight = 0
+    let maxConcurrent = 0
+    const track = async () => {
+      inFlight += 1
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      // Simulate a slow write.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      inFlight -= 1
+      return { ok: true }
+    }
+    const mockSave = vi.fn(track)
+    const mockSaveAs = vi.fn(track)
+    vi.stubGlobal('window', { slidesApi: { save: mockSave, saveAs: mockSaveAs } })
+
+    // A manual save racing Save As (or close-save) must queue behind it.
+    const [saved, _] = await Promise.all([save(ctx(), true), saveAs(ctx())])
+
+    expect(saved).toBe(true)
+    expect(mockSave).toHaveBeenCalledTimes(1)
+    expect(mockSaveAs).toHaveBeenCalledTimes(1)
     expect(maxConcurrent).toBe(1)
 
     vi.unstubAllGlobals()


### PR DESCRIPTION
## Summary
Follow-up to #155 (merged): `save()` runs through the `saveTail` promise chain, but `saveAs()` still wrote directly — a manual save racing Save As (or double Save As, or close-save) interleaves writes through the same main-process pipe. This extracts the chain into `runSerialized` and routes both through it, with identical error propagation.

## Related issue
Code-scan find (extends #155 to the sibling write path).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI, including the new save/saveAs overlap case in `apps/slides/tests/save-serialization.test.ts` (asserts max 1 concurrent IPC write)

## Screenshots
N/A — behavior: overlapping Save + Save As serialize; failure still releases the queue for the next caller.

## Contributor checklist
- [x] `runSerialized` preserves the exact prior semantics (prior failure tolerated, tail cleared only by its owner, caller sees its own rejection)
- [x] Conventional Commits message (`fix(slides): ...`)
- [x] Regression test added
