### PR TITLE
fix(slides): clear answered clarifications on New chat

### DIFF
--- a/apps/slides/src/renderer/ai/AiPanel.tsx
+++ b/apps/slides/src/renderer/ai/AiPanel.tsx
@@ -1862,6 +1862,10 @@ export function AiPanel({
     loopRef.current?.reset()
     setBusy(false)
     setChat([])
+    // Answered clarifications are transcript too: they render under their
+    // original message index, so stale entries would re-attach to unrelated
+    // new messages after an index collision.
+    setClarifyAnswers([])
     sentAttachmentsRef.current = []
     readAttachmentPathsRef.current.clear()
     inputRef.current?.focus()


### PR DESCRIPTION
## Summary
Same transcript class as #195/#209, slides-only: answered clarification receipts (`clarifyAnswers`, rendered under their original message index) survived New chat, so stale entries re-attached under unrelated new messages after an index collision. One-line clear next to the `setHistoricChat` clearing.

## Related issue
Code-scan find (docs has no clarify-answers state; sheets passes history via parent props).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI
- Note: no dedicated component test — seeding an answered clarification requires driving a live loop run through the skill trigger chain (the mock loop in `ai-panel-run-lifecycle.test.ts` never calls back into it). Omission verified against the render mapping (`ai-clarify-answered` at AiPanel.tsx:2194) and the reset path; the sibling docs pattern is covered by `ai-new-chat-clears-history.test.ts`.

## Screenshots
N/A — behavior: New chat drops answered clarification receipts along with everything else.

## Contributor checklist
- [x] One-line, same-location fix as the #209 hunk
- [x] Conventional Commits message (`fix(slides): ...`)
