### PR TITLE
fix(shell): harden Home rename validation

### DIFF
--- a/apps/shell/src/main/index.ts
+++ b/apps/shell/src/main/index.ts
@@ -189,6 +189,7 @@ import type { TabKind } from '../shared/tabs-api'
 import { TABS_CHANNELS } from '../shared/tabs-api'
 import { showErrorDialog } from './error-dialog'
 import { normalizeRecentQuery, pageRecentPaths, statPathEntries } from './recent-files'
+import { isCaseOnlyRename, isValidRenameName } from './rename-validation'
 import { TabManager } from './tab-manager'
 import { applyUpdateChannel, initAutoUpdater } from './updater'
 import { isUpdateChannel, type UpdateChannel } from '../shared/update-api'
@@ -2971,11 +2972,16 @@ function registerHomeIpc(): void {
       if (typeof path !== 'string' || typeof newName !== 'string')
         return { ok: false, error: tm('errBadArgs') }
       const name = newName.trim()
-      if (!name || /[\\/:]/.test(name)) return { ok: false, error: tm('errBadName') }
+      if (!isValidRenameName(name)) return { ok: false, error: tm('errBadName') }
       if (!existsSync(path)) return { ok: false, error: tm('errMissing') }
       const target = join(dirname(path), name)
       if (target === path) return { ok: true, path }
-      if (existsSync(target)) return { ok: false, error: tm('errExists') }
+      // A case-only rename (Report.pdf -> report.pdf) is the same file:
+      // existsSync sees the source itself on case-insensitive filesystems,
+      // so skip the gate and let the OS perform the case change.
+      if (!isCaseOnlyRename(path, target) && existsSync(target)) {
+        return { ok: false, error: tm('errExists') }
+      }
       try {
         renameSync(path, target)
       } catch (err) {

--- a/apps/shell/src/main/rename-validation.ts
+++ b/apps/shell/src/main/rename-validation.ts
@@ -4,6 +4,7 @@ import { basename, dirname } from 'node:path'
     auto-renamer set (apps/pdf/src/main/pdf-main.ts) — the Home rename gate
     must reject them with a localized error instead of letting renameSync
     throw a raw OS error. */
+// eslint-disable-next-line no-control-regex -- the C0 range IS the check: Windows forbids controls in names.
 export const RENAME_ILLEGAL_NAME_CHARS = /[\\/:*?"<>|\u0000-\u001f]/
 
 /** True when the trimmed name is usable as a file name. */

--- a/apps/shell/src/main/rename-validation.ts
+++ b/apps/shell/src/main/rename-validation.ts
@@ -1,0 +1,22 @@
+import { basename, dirname } from 'node:path'
+
+/** Name characters Windows forbids (plus controls). Mirrors the PDF
+    auto-renamer set (apps/pdf/src/main/pdf-main.ts) — the Home rename gate
+    must reject them with a localized error instead of letting renameSync
+    throw a raw OS error. */
+export const RENAME_ILLEGAL_NAME_CHARS = /[\\/:*?"<>|\u0000-\u001f]/
+
+/** True when the trimmed name is usable as a file name. */
+export function isValidRenameName(name: string): boolean {
+  return name.length > 0 && !RENAME_ILLEGAL_NAME_CHARS.test(name)
+}
+
+/** True when target names the same file with different letter case only
+    (same directory, case-insensitive-equal names). On case-insensitive
+    filesystems existsSync(target) sees the source itself, so callers must
+    skip the already-exists gate and attempt the rename directly. */
+export function isCaseOnlyRename(path: string, target: string): boolean {
+  if (target === path) return false
+  if (dirname(target) !== dirname(path)) return false
+  return basename(target).toLowerCase() === basename(path).toLowerCase()
+}

--- a/apps/shell/tests/home-rename-validation.test.ts
+++ b/apps/shell/tests/home-rename-validation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { isCaseOnlyRename, isValidRenameName } from '../src/main/rename-validation'
+
+describe('home rename validation', () => {
+  it('rejects every Windows-illegal name character with the localized gate', () => {
+    for (const bad of ['\\', '/', ':', '*', '?', '"', '<', '>', '|', 'a\0b', 'a\x01b']) {
+      expect(isValidRenameName(`report${bad}.pdf`)).toBe(false)
+    }
+    expect(isValidRenameName('')).toBe(false)
+    expect(isValidRenameName('quarterly report (final).pdf')).toBe(true)
+    expect(isValidRenameName('ski⛷report.pdf')).toBe(true)
+  })
+
+  it('recognizes case-only renames so the exists gate can be skipped', () => {
+    expect(isCaseOnlyRename('/d/Report.pdf', '/d/report.pdf')).toBe(true)
+    expect(isCaseOnlyRename('/d/report.pdf', '/d/report.pdf')).toBe(false)
+    expect(isCaseOnlyRename('/d/report.pdf', '/d/other.pdf')).toBe(false)
+    expect(isCaseOnlyRename('/d/report.pdf', '/e/report.pdf')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Two gaps in the Home rename gate: only `\ / :` were rejected while Windows also forbids `* ? " < > |` plus control characters (the PDF auto-renamer already strips that fuller set), so names like `rep"ort.pdf` fell through to a raw OS error; and a case-only rename (`Report.pdf` to `report.pdf`) was wrongly rejected with `errExists` because `existsSync` sees the source itself on case-insensitive filesystems.

## Related issue
Code-scan find (no open issue covers rename validation).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI
- [ ] `npm test` — CI, including the new `apps/shell/tests/home-rename-validation.test.ts` (illegal-char table incl. controls, unicode-safe names pass, case-only detection)

## Screenshots
N/A — behavior: illegal names get the localized `errBadName`; case-only renames proceed to the OS rename.

## Contributor checklist
- [x] Pure validation extracted to `rename-validation.ts` (index.ts stays electron-land, stays testable)
- [x] Character class mirrors the PDF auto-renamer set with a citing comment
- [x] Conventional Commits message (`fix(shell): ...`)
- [x] Regression tests added
