### PR TITLE
feat(markdown): localize zoom control labels

### DIFF
--- a/apps/markdown/src/renderer/App.tsx
+++ b/apps/markdown/src/renderer/App.tsx
@@ -651,7 +651,7 @@ export default function App() {
               <button
                 type="button"
                 className="zoom-btn"
-                aria-label="Zoom out"
+                aria-label={t('zoomOut')}
                 onClick={zoomOut}
                 disabled={zoom <= MIN_ZOOM}
               >
@@ -664,13 +664,13 @@ export default function App() {
                 max={MAX_ZOOM}
                 step={ZOOM_STEP}
                 value={Math.round(zoom)}
-                aria-label="Zoom"
+                aria-label={t('zoom')}
                 onChange={(event) => setZoom(Number(event.target.value))}
               />
               <button
                 type="button"
                 className="zoom-btn"
-                aria-label="Zoom in"
+                aria-label={t('zoomIn')}
                 onClick={zoomIn}
                 disabled={zoom >= MAX_ZOOM}
               >

--- a/apps/markdown/src/renderer/i18n/strings.ts
+++ b/apps/markdown/src/renderer/i18n/strings.ts
@@ -156,6 +156,9 @@ export const strings = {
     aiToolReplaceDone: '已改写 {n} 个块',
     aiToolWebSearch: '联网搜索',
     aiToolWebSearchDone: '搜索"{query}" · {count} 条结果',
+    zoom: '缩放',
+    zoomIn: '放大',
+    zoomOut: '缩小',
   },
   en: {
     aiToolReadFm: 'Read document properties',
@@ -319,6 +322,9 @@ export const strings = {
     aiToolReplaceDone: 'Rewrote {n} block(s)',
     aiToolWebSearch: 'Web search',
     aiToolWebSearchDone: 'Searched "{query}" · {count} results',
+    zoom: 'Zoom',
+    zoomIn: 'Zoom in',
+    zoomOut: 'Zoom out',
   },
   ja: {
     aiToolReadFm: 'ドキュメントのプロパティを読み取り',
@@ -480,6 +486,9 @@ export const strings = {
     aiToolReplaceDone: '{n} 個のブロックを書き換え',
     aiToolWebSearch: 'ウェブ検索',
     aiToolWebSearchDone: '「{query}」を検索 · {count} 件',
+    zoom: 'ズーム',
+    zoomIn: '拡大',
+    zoomOut: '縮小',
   },
   ko: {
     aiToolReadFm: '문서 속성 읽기',
@@ -642,6 +651,9 @@ export const strings = {
     aiToolReplaceDone: '블록 {n}개 다시 씀',
     aiToolWebSearch: '웹 검색',
     aiToolWebSearchDone: '"{query}" 검색 · 결과 {count}개',
+    zoom: '줌',
+    zoomIn: '확대',
+    zoomOut: '축소',
   },
   fr: {
     aiToolReadFm: 'Lecture des propriétés du document',
@@ -809,6 +821,9 @@ export const strings = {
     aiToolReplaceDone: '{n} bloc(s) réécrit(s)',
     aiToolWebSearch: 'Recherche Web',
     aiToolWebSearchDone: 'Recherche « {query} » · {count} résultats',
+    zoom: 'Zoom',
+    zoomIn: 'Zoom avant',
+    zoomOut: 'Zoom arrière',
   },
   de: {
     aiToolReadFm: 'Dokumenteigenschaften lesen',
@@ -975,6 +990,9 @@ export const strings = {
     aiToolReplaceDone: '{n} Block/Blöcke umgeschrieben',
     aiToolWebSearch: 'Websuche',
     aiToolWebSearchDone: '„{query}" gesucht · {count} Treffer',
+    zoom: 'Zoom',
+    zoomIn: 'Vergrößern',
+    zoomOut: 'Verkleinern',
   },
   es: {
     aiToolReadFm: 'Leer propiedades del documento',
@@ -1142,6 +1160,9 @@ export const strings = {
     aiToolReplaceDone: '{n} bloque(s) reescrito(s)',
     aiToolWebSearch: 'Búsqueda web',
     aiToolWebSearchDone: 'Búsqueda de «{query}» · {count} resultados',
+    zoom: 'Zoom',
+    zoomIn: 'Acercar',
+    zoomOut: 'Alejar',
   },
   th: {
     aiToolReadFm: 'อ่านคุณสมบัติเอกสาร',
@@ -1302,6 +1323,9 @@ export const strings = {
     aiToolReplaceDone: 'เขียนใหม่แล้ว {n} บล็อก',
     aiToolWebSearch: 'ค้นหาเว็บ',
     aiToolWebSearchDone: 'ค้นหา "{query}" · {count} รายการ',
+    zoom: 'ซูม',
+    zoomIn: 'ขยาย',
+    zoomOut: 'ย่อ',
   },
   id: {
     aiToolReadFm: 'Baca properti dokumen',
@@ -1464,6 +1488,9 @@ export const strings = {
     aiToolReplaceDone: '{n} blok ditulis ulang',
     aiToolWebSearch: 'Pencarian web',
     aiToolWebSearchDone: 'Mencari "{query}" · {count} hasil',
+    zoom: 'Zum',
+    zoomIn: 'Perbesar',
+    zoomOut: 'Perkecil',
   },
   ru: {
     aiToolReadFm: 'Чтение свойств документа',
@@ -1627,6 +1654,9 @@ export const strings = {
     aiToolReplaceDone: 'Переписано блоков: {n}',
     aiToolWebSearch: 'Веб-поиск',
     aiToolWebSearchDone: 'Поиск «{query}» · {count} результатов',
+    zoom: 'Масштаб',
+    zoomIn: 'Увеличить',
+    zoomOut: 'Уменьшить',
   },
   ar: {
     aiToolReadFm: 'قراءة خصائص المستند',
@@ -1787,6 +1817,9 @@ export const strings = {
     aiToolReplaceDone: 'أعيدت كتابة {n} كتلة',
     aiToolWebSearch: 'بحث ويب',
     aiToolWebSearchDone: 'بحث عن "{query}" · {count} نتيجة',
+    zoom: 'التكبير',
+    zoomIn: 'تكبير',
+    zoomOut: 'تصغير',
   },
   pt: {
     aiToolReadFm: 'Ler propriedades do documento',
@@ -1952,6 +1985,9 @@ export const strings = {
     aiToolReplaceDone: '{n} bloco(s) reescrito(s)',
     aiToolWebSearch: 'Pesquisa na Web',
     aiToolWebSearchDone: 'Pesquisa por "{query}" · {count} resultados',
+    zoom: 'Zoom',
+    zoomIn: 'Ampliar',
+    zoomOut: 'Reduzir',
   },
   it: {
     aiToolReadFm: 'Lettura delle proprietà del documento',
@@ -2117,6 +2153,9 @@ export const strings = {
     aiToolReplaceDone: '{n} blocchi riscritti',
     aiToolWebSearch: 'Ricerca web',
     aiToolWebSearchDone: 'Cercato "{query}" · {count} risultati',
+    zoom: 'Zoom',
+    zoomIn: 'Ingrandisci',
+    zoomOut: 'Riduci',
   },
   pl: {
     aiToolReadFm: 'Odczyt właściwości dokumentu',
@@ -2280,6 +2319,9 @@ export const strings = {
     aiToolReplaceDone: 'Przepisano bloki: {n}',
     aiToolWebSearch: 'Wyszukiwanie w sieci',
     aiToolWebSearchDone: 'Wyszukano „{query}" · {count} wyników',
+    zoom: 'Zoom',
+    zoomIn: 'Powiększ',
+    zoomOut: 'Pomniejsz',
   },
   nl: {
     aiToolReadFm: 'Documenteigenschappen lezen',
@@ -2444,6 +2486,9 @@ export const strings = {
     aiToolReplaceDone: '{n} blok(ken) herschreven',
     aiToolWebSearch: 'Zoeken op internet',
     aiToolWebSearchDone: 'Gezocht naar "{query}" · {count} resultaten',
+    zoom: 'Zoom',
+    zoomIn: 'Inzoomen',
+    zoomOut: 'Uitzoomen',
   },
   ms: {
     aiToolReadFm: 'Baca sifat dokumen',
@@ -2606,6 +2651,9 @@ export const strings = {
     aiToolReplaceDone: '{n} blok ditulis semula',
     aiToolWebSearch: 'Carian web',
     aiToolWebSearchDone: 'Cari "{query}" · {count} hasil',
+    zoom: 'Zum',
+    zoomIn: 'Zum masuk',
+    zoomOut: 'Zum keluar',
   },
   he: {
     aiToolReadFm: 'קריאת מאפייני המסמך',
@@ -2765,6 +2813,9 @@ export const strings = {
     aiToolReplaceDone: 'שוכתבו {n} בלוקים',
     aiToolWebSearch: 'חיפוש ברשת',
     aiToolWebSearchDone: 'חיפוש "{query}" · {count} תוצאות',
+    zoom: 'זום',
+    zoomIn: 'הגדלה',
+    zoomOut: 'הקטנה',
   },
   hi: {
     aiToolReadFm: 'दस्तावेज़ गुण पढ़ें',
@@ -2928,6 +2979,9 @@ export const strings = {
     aiToolReplaceDone: '{n} ब्लॉक पुनः लिखे',
     aiToolWebSearch: 'वेब खोज',
     aiToolWebSearchDone: '"{query}" खोजा · {count} परिणाम',
+    zoom: 'ज़ूम',
+    zoomIn: 'ज़ूम इन',
+    zoomOut: 'ज़ूम आउट',
   },
   'zh-TW': {
     aiToolReadFm: '讀取文件屬性',
@@ -3086,5 +3140,8 @@ export const strings = {
     aiToolReplaceDone: '已改寫 {n} 個區塊',
     aiToolWebSearch: '網路搜尋',
     aiToolWebSearchDone: '搜尋「{query}」· {count} 筆結果',
+    zoom: '縮放',
+    zoomIn: '放大',
+    zoomOut: '縮小',
   },
 } as const

--- a/apps/markdown/tests/zoom-labels.test.ts
+++ b/apps/markdown/tests/zoom-labels.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { strings } from '../src/renderer/i18n/strings'
+
+/**
+ * Status-bar zoom controls (App.tsx) must speak the UI language like the
+ * PDF app does — never hardcoded English aria-labels. zh defines the key
+ * set; every locale carries real zoom/zoomIn/zoomOut content.
+ */
+
+const locales = Object.keys(strings) as Array<keyof typeof strings>
+
+describe('markdown zoom labels', () => {
+  it.each(locales)('locale %s labels the zoom controls', (locale) => {
+    const table = strings[locale] as Record<string, unknown>
+    for (const key of ['zoom', 'zoomIn', 'zoomOut']) {
+      expect(typeof table[key]).toBe('string')
+      expect((table[key] as string).trim().length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
The markdown status-bar zoom controls used hardcoded English `aria-label`s while the PDF app localizes the same controls — screen-reader users in any other locale heard English in markdown but their language in PDF. Adds `zoom`/`zoomIn`/`zoomOut` keys to all 19 markdown locales (button strings copied from PDF's translations) and wires the three labels through `t()`.

## Related issue
Code-scan find (no open issue covers markdown zoom labels).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI (zh defines the new keys per the `StringKey = keyof typeof strings.zh` contract)
- [ ] `npm test` — CI, including the new `apps/markdown/tests/zoom-labels.test.ts` (every locale carries all three keys non-empty)

## Screenshots
N/A — behavior: zoom out/slider/zoom in announce in the UI language.

## Contributor checklist
- [x] Translations sourced from the PDF app's reviewed strings, not invented
- [x] Conventional Commits message (`feat(markdown): ...`)
- [x] Parity test added
