### PR TITLE
fix(docs): complete ruler tab cycle with Bar, hide clear stops

### DIFF
--- a/apps/docs/src/renderer/components/Ruler.tsx
+++ b/apps/docs/src/renderer/components/Ruler.tsx
@@ -6,6 +6,12 @@ import { t, type StringKey } from '../i18n/locale'
 
 const twipsToPx = (twips: number) => (twips / 1440) * 96
 
+/** A `clear` stop cancels an inherited stop — it marks no position, so the
+    ruler renders nothing for it (write-back still carries it). Exported for tests. */
+export function isRenderableTabStop(stop: TabStop): boolean {
+  return stop.val !== 'clear'
+}
+
 /** Horizontal ruler above the page: inch numbers, gray margin zones, tab stops. */
 export function Ruler({
   section,
@@ -28,7 +34,7 @@ export function Ruler({
 
   // Tab stop type cycling (Word: click ruler button to cycle L/C/R/Decimal/Bar)
   const [nextTabType, setNextTabType] = useState<TabStop['val']>('left')
-  const TAB_TYPE_CYCLE: TabStop['val'][] = ['left', 'center', 'right', 'decimal']
+  const TAB_TYPE_CYCLE: TabStop['val'][] = ['left', 'center', 'right', 'decimal', 'bar']
   const TAB_TYPE_LABELS: Record<string, string> = {
     left: 'L',
     center: '⊥',
@@ -42,7 +48,7 @@ export function Ruler({
     right: 'appTabRight',
     decimal: 'appTabDecimal',
     bar: 'appTabBar',
-    clear: 'appTabBar',
+    clear: 'appTabClear',
   }
 
   // Get current tab stops from focused paragraph. rel stops mirror w:ptab
@@ -172,24 +178,29 @@ export function Ruler({
         />
       ))}
 
-      {/* Custom tab stops (interactive) */}
-      {stops.map((stop, i) => (
-        <span
-          key={`${stop.pos}-${i}`}
-          data-ruler-stop={i}
-          className={`ruler-tab ruler-tab-${stop.val}`}
-          style={{ left: twipsToPx(stop.pos) }}
-          data-tip={
-            t('appTabStopTitle', {
-              type: t(TAB_TYPE_NAME_KEYS[stop.val]),
-              pos: Math.round((stop.pos / 144) * 10) / 10,
-            }) + (stop.leader ? t('appTabLeader', { leader: stop.leader }) : '')
-          }
-          onMouseDown={(e) => handleTabMouseDown(e, i)}
-        >
-          {TAB_TYPE_LABELS[stop.val]}
-        </span>
-      ))}
+      {/* Custom tab stops (interactive). A `clear` stop cancels inherited
+          stops at its position — it places no mark, so it renders nothing
+          (returning null keeps data-ruler-stop indexes aligned with `stops`
+          for drag handling) while write-back still preserves it. */}
+      {stops.map((stop, i) =>
+        !isRenderableTabStop(stop) ? null : (
+          <span
+            key={`${stop.pos}-${i}`}
+            data-ruler-stop={i}
+            className={`ruler-tab ruler-tab-${stop.val}`}
+            style={{ left: twipsToPx(stop.pos) }}
+            data-tip={
+              t('appTabStopTitle', {
+                type: t(TAB_TYPE_NAME_KEYS[stop.val]),
+                pos: Math.round((stop.pos / 144) * 10) / 10,
+              }) + (stop.leader ? t('appTabLeader', { leader: stop.leader }) : '')
+            }
+            onMouseDown={(e) => handleTabMouseDown(e, i)}
+          >
+            {TAB_TYPE_LABELS[stop.val]}
+          </span>
+        ),
+      )}
     </div>
   )
 }

--- a/apps/docs/src/renderer/i18n/app/ar.ts
+++ b/apps/docs/src/renderer/i18n/app/ar.ts
@@ -225,6 +225,7 @@ export const ar = {
   appTabRight: 'يمين',
   appTabDecimal: 'عشري',
   appTabBar: 'شريط',
+  appTabClear: 'مسح',
   appAiSettings: 'إعدادات الذكاء الاصطناعي',
   appGensparkAccount: 'حساب Genspark',
   appChecking: 'جارٍ التحقق…',

--- a/apps/docs/src/renderer/i18n/app/de.ts
+++ b/apps/docs/src/renderer/i18n/app/de.ts
@@ -238,6 +238,7 @@ export const de = {
   appTabRight: 'Rechts',
   appTabDecimal: 'Dezimal',
   appTabBar: 'Vertikale Linie',
+  appTabClear: 'Löschen',
   appAiSettings: 'KI-Einstellungen',
   appGensparkAccount: 'Genspark-Konto',
   appChecking: 'Wird überprüft…',

--- a/apps/docs/src/renderer/i18n/app/en.ts
+++ b/apps/docs/src/renderer/i18n/app/en.ts
@@ -224,6 +224,7 @@ export const en = {
   appTabRight: 'Right',
   appTabDecimal: 'Decimal',
   appTabBar: 'Bar',
+  appTabClear: 'Clear',
   appAiSettings: 'AI Settings',
   appGensparkAccount: 'Genspark account',
   appChecking: 'Checking…',

--- a/apps/docs/src/renderer/i18n/app/es.ts
+++ b/apps/docs/src/renderer/i18n/app/es.ts
@@ -234,6 +234,7 @@ export const es = {
   appTabRight: 'Derecha',
   appTabDecimal: 'Decimal',
   appTabBar: 'Barra',
+  appTabClear: 'Borrar',
   appAiSettings: 'Configuración de IA',
   appGensparkAccount: 'Cuenta de Genspark',
   appChecking: 'Comprobando…',

--- a/apps/docs/src/renderer/i18n/app/fr.ts
+++ b/apps/docs/src/renderer/i18n/app/fr.ts
@@ -238,6 +238,7 @@ export const fr = {
   appTabRight: 'Droite',
   appTabDecimal: 'Décimal',
   appTabBar: 'Barre',
+  appTabClear: 'Effacer',
   appAiSettings: 'Paramètres IA',
   appGensparkAccount: 'Compte Genspark',
   appChecking: 'Vérification…',

--- a/apps/docs/src/renderer/i18n/app/he.ts
+++ b/apps/docs/src/renderer/i18n/app/he.ts
@@ -223,6 +223,7 @@ export const he = {
   appTabRight: 'ימין',
   appTabDecimal: 'עשרוני',
   appTabBar: 'קו',
+  appTabClear: 'נקה',
   appAiSettings: 'הגדרות AI',
   appGensparkAccount: 'חשבון Genspark',
   appChecking: 'בודק…',

--- a/apps/docs/src/renderer/i18n/app/hi.ts
+++ b/apps/docs/src/renderer/i18n/app/hi.ts
@@ -228,6 +228,7 @@ export const hi = {
   appTabRight: 'दायाँ',
   appTabDecimal: 'दशमलव',
   appTabBar: 'बार',
+  appTabClear: 'साफ़ करें',
   appAiSettings: 'AI सेटिंग्स',
   appGensparkAccount: 'Genspark खाता',
   appChecking: 'जाँच हो रही है…',

--- a/apps/docs/src/renderer/i18n/app/id.ts
+++ b/apps/docs/src/renderer/i18n/app/id.ts
@@ -230,6 +230,7 @@ export const id = {
   appTabRight: 'Kanan',
   appTabDecimal: 'Desimal',
   appTabBar: 'Batang',
+  appTabClear: 'Hapus',
   appAiSettings: 'Pengaturan AI',
   appGensparkAccount: 'Akun Genspark',
   appChecking: 'Memeriksa…',

--- a/apps/docs/src/renderer/i18n/app/it.ts
+++ b/apps/docs/src/renderer/i18n/app/it.ts
@@ -232,6 +232,7 @@ export const it = {
   appTabRight: 'Destra',
   appTabDecimal: 'Decimale',
   appTabBar: 'Barra',
+  appTabClear: 'Cancella',
   appAiSettings: 'Impostazioni IA',
   appGensparkAccount: 'Account Genspark',
   appChecking: 'Verifica in corso…',

--- a/apps/docs/src/renderer/i18n/app/ja.ts
+++ b/apps/docs/src/renderer/i18n/app/ja.ts
@@ -247,6 +247,7 @@ export const ja = {
   appTabRight: '右揃え',
   appTabDecimal: '小数点揃え',
   appTabBar: '縦棒',
+  appTabClear: 'クリア',
   // AI settings
   appAiSettings: 'AI 設定',
   appGensparkAccount: 'Genspark アカウント',

--- a/apps/docs/src/renderer/i18n/app/ko.ts
+++ b/apps/docs/src/renderer/i18n/app/ko.ts
@@ -247,6 +247,7 @@ export const ko = {
   appTabRight: '오른쪽',
   appTabDecimal: '소수점',
   appTabBar: '세로 막대',
+  appTabClear: '지우기',
   // AI settings
   appAiSettings: 'AI 설정',
   appGensparkAccount: 'Genspark 계정',

--- a/apps/docs/src/renderer/i18n/app/ms.ts
+++ b/apps/docs/src/renderer/i18n/app/ms.ts
@@ -232,6 +232,7 @@ export const ms = {
   appTabRight: 'Kanan',
   appTabDecimal: 'Perpuluhan',
   appTabBar: 'Bar',
+  appTabClear: 'Padam',
   appAiSettings: 'Tetapan AI',
   appGensparkAccount: 'Akaun Genspark',
   appChecking: 'Menyemak…',

--- a/apps/docs/src/renderer/i18n/app/nl.ts
+++ b/apps/docs/src/renderer/i18n/app/nl.ts
@@ -238,6 +238,7 @@ export const nl = {
   appTabRight: 'Rechts',
   appTabDecimal: 'Decimaal',
   appTabBar: 'Balk',
+  appTabClear: 'Wissen',
   appAiSettings: 'AI-instellingen',
   appGensparkAccount: 'Genspark-account',
   appChecking: 'Controleren…',

--- a/apps/docs/src/renderer/i18n/app/pl.ts
+++ b/apps/docs/src/renderer/i18n/app/pl.ts
@@ -233,6 +233,7 @@ export const pl = {
   appTabRight: 'Prawy',
   appTabDecimal: 'Dziesiętny',
   appTabBar: 'Paskowy',
+  appTabClear: 'Wyczyść',
   appAiSettings: 'Ustawienia AI',
   appGensparkAccount: 'Konto Genspark',
   appChecking: 'Sprawdzanie…',

--- a/apps/docs/src/renderer/i18n/app/pt.ts
+++ b/apps/docs/src/renderer/i18n/app/pt.ts
@@ -229,6 +229,7 @@ export const pt = {
   appTabRight: 'Direita',
   appTabDecimal: 'Decimal',
   appTabBar: 'Barra',
+  appTabClear: 'Limpar',
   appAiSettings: 'Configurações de IA',
   appGensparkAccount: 'Conta Genspark',
   appChecking: 'Verificando…',

--- a/apps/docs/src/renderer/i18n/app/ru.ts
+++ b/apps/docs/src/renderer/i18n/app/ru.ts
@@ -230,6 +230,7 @@ export const ru = {
   appTabRight: 'По правому краю',
   appTabDecimal: 'По разделителю',
   appTabBar: 'С чертой',
+  appTabClear: 'Очистить',
   appAiSettings: 'Настройки ИИ',
   appGensparkAccount: 'Учетная запись Genspark',
   appChecking: 'Проверка…',

--- a/apps/docs/src/renderer/i18n/app/th.ts
+++ b/apps/docs/src/renderer/i18n/app/th.ts
@@ -228,6 +228,7 @@ export const th = {
   appTabRight: 'ขวา',
   appTabDecimal: 'จุดทศนิยม',
   appTabBar: 'แถบ',
+  appTabClear: 'ล้าง',
   appAiSettings: 'การตั้งค่า AI',
   appGensparkAccount: 'บัญชี Genspark',
   appChecking: 'กำลังตรวจสอบ…',

--- a/apps/docs/src/renderer/i18n/app/zh-TW.ts
+++ b/apps/docs/src/renderer/i18n/app/zh-TW.ts
@@ -218,6 +218,7 @@ export const zhTW = {
   appTabRight: '靠右',
   appTabDecimal: '小數點',
   appTabBar: '分隔線',
+  appTabClear: '清除',
   appAiSettings: 'AI 設定',
   appGensparkAccount: 'Genspark 帳號',
   appChecking: '檢查中…',

--- a/apps/docs/src/renderer/i18n/app/zh.ts
+++ b/apps/docs/src/renderer/i18n/app/zh.ts
@@ -236,6 +236,7 @@ export const zh = {
   appTabRight: '右',
   appTabDecimal: '小数点',
   appTabBar: '竖线',
+  appTabClear: '清除',
   // AI settings
   appAiSettings: 'AI 设置',
   appGensparkAccount: 'Genspark 账号',

--- a/apps/docs/tests/ruler-tab-cycle.test.ts
+++ b/apps/docs/tests/ruler-tab-cycle.test.ts
@@ -1,0 +1,62 @@
+import type { TabStop } from '@genoffice/docx-engine'
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { isRenderableTabStop, Ruler } from '../src/renderer/components/Ruler'
+
+beforeAll(() => {
+  Element.prototype.scrollTo ??= () => {}
+})
+
+const section = {
+  pageWidth: 12240,
+  marginLeft: 1440,
+  marginRight: 1440,
+} as never
+
+function mountRuler(): { container: HTMLElement; cleanup: () => void } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(createElement(Ruler, { section, editor: null, onTabStopsChange: () => {} }))
+  })
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+describe('ruler tab type cycle', () => {
+  it('cycles L/C/R/Decimal/Bar like Word, then wraps', () => {
+    const { container, cleanup } = mountRuler()
+    try {
+      const button = container.querySelector<HTMLButtonElement>('.ruler-tab-type')
+      expect(button).not.toBeNull()
+      // Glyph legend: L left, ⊥ center, ⌐ right, . decimal, | bar.
+      const seen = [button!.textContent]
+      for (let i = 0; i < 4; i++) {
+        act(() => button!.click())
+        seen.push(button!.textContent)
+      }
+      expect(seen).toEqual(['L', '⊥', '⌐', '.', '|'])
+      act(() => button!.click())
+      expect(button!.textContent).toBe('L')
+    } finally {
+      cleanup()
+    }
+  })
+})
+
+describe('isRenderableTabStop', () => {
+  it('hides clear stops (they cancel inheritance, mark no position)', () => {
+    const stop = (val: TabStop['val']): TabStop => ({ pos: 100, val })
+    expect(isRenderableTabStop(stop('clear'))).toBe(false)
+    expect(isRenderableTabStop(stop('left'))).toBe(true)
+    expect(isRenderableTabStop(stop('bar'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Two ruler gaps: the tab-type button cycled L/C/R/Decimal but never Bar despite the Word-parity comment promising it (Bar stops were unreachable from the UI), and file-born `clear` stops rendered as empty markers with Bar's tooltip (a `clear` stop cancels inheritance — it marks no position).

## Related issue
Code-scan find (no open issue covers the ruler cycle).

## Validation
- [x] `format:check` — verified locally with the repo-pinned Prettier 3.9.6
- [ ] `lint` — CI
- [ ] `typecheck` — CI (all 19 app locales carry the new `appTabClear` key per the shard contract)
- [ ] `npm test` — CI, including the new `apps/docs/tests/ruler-tab-cycle.test.ts` (click-cycle L/C/R/Decimal/Bar/wrap + clear-stop predicate)

## Screenshots
N/A — behavior: fifth click reaches the `|` Bar glyph; `clear` stops no longer paint empty markers (write-back still preserves them, drag indexes unchanged).

## Contributor checklist
- [x] `clear` filtering returns null in place so `data-ruler-stop` indexes stay aligned
- [x] Conventional Commits message (`fix(docs): ...`)
- [x] Regression tests added
