### PR TITLE
fix(ai-provider): allow keyless custom endpoints for local models

### DIFF
--- a/packages/ai-provider/src/protocols/openai-compatible.ts
+++ b/packages/ai-provider/src/protocols/openai-compatible.ts
@@ -154,7 +154,7 @@ async function openAiCompatibleTurn(
     signal: wd.signal,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${config.apiKey}`,
+      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
       ...gensparkAttributionHeaders(baseUrl),
     },
     body: JSON.stringify({
@@ -304,7 +304,7 @@ export async function chatOpenAiCompatible(
     signal: wd.signal,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${config.apiKey}`,
+      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
       ...gensparkAttributionHeaders(baseUrl),
     },
     body: JSON.stringify({

--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -209,8 +209,14 @@ export function activeProvider(settings: AiSettings): AiProviderId {
   if (provider === 'genspark') return 'genspark'
   const meta = AI_PROVIDERS.find((m) => m.id === provider)
   const config = settings.providers?.[provider]
-  if (!meta || !config?.apiKey || !config.model) return 'genspark'
-  if (meta.needsBaseUrl && !config.baseUrl) return 'genspark'
+  if (!meta || !config?.model) return 'genspark'
+  if (meta.needsBaseUrl) {
+    // Custom OpenAI-compatible endpoints (Ollama, LM Studio, vLLM) accept
+    // anonymous requests: base URL + model suffice, the key stays optional.
+    if (!config.baseUrl) return 'genspark'
+    return provider
+  }
+  if (!config.apiKey) return 'genspark'
   return provider
 }
 

--- a/packages/ai-provider/tests/chat.test.ts
+++ b/packages/ai-provider/tests/chat.test.ts
@@ -101,6 +101,31 @@ describe('chatForProvider', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('custom: omits Authorization when the key is empty for local servers', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ choices: [{ message: { content: 'ok' } }] }))
+    vi.stubGlobal('fetch', fetchMock)
+    await chatForProvider(
+      'custom',
+      { apiKey: '', model: 'llama3', baseUrl: 'http://localhost:11434/v1' },
+      'sys',
+      'hi',
+    )
+    const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+    fetchMock.mockClear()
+    await chatForProvider(
+      'custom',
+      { apiKey: 'k', model: 'm', baseUrl: 'https://my-endpoint.example.com/v1' },
+      'sys',
+      'hi',
+    )
+    expect((fetchMock.mock.calls[0]![1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer k',
+    )
+  })
+
   it('genspark: routes by model prefix to the proxy endpoints', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/ai-provider/tests/chat.test.ts
+++ b/packages/ai-provider/tests/chat.test.ts
@@ -115,6 +115,7 @@ describe('chatForProvider', () => {
     const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>
     expect(headers.Authorization).toBeUndefined()
     fetchMock.mockClear()
+    fetchMock.mockResolvedValue(jsonResponse({ choices: [{ message: { content: 'ok' } }] }))
     await chatForProvider(
       'custom',
       { apiKey: 'k', model: 'm', baseUrl: 'https://my-endpoint.example.com/v1' },

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -226,6 +226,15 @@ describe('activeProvider', () => {
     expect(activeProvider(settings)).toBe('custom')
   })
 
+  it('allows keyless custom endpoints for local servers', () => {
+    const settings = defaultAiSettings()
+    settings.provider = 'custom'
+    settings.providers.custom.apiKey = ''
+    settings.providers.custom.baseUrl = 'http://localhost:11434/v1'
+    settings.providers.custom.model = 'llama3'
+    expect(activeProvider(settings)).toBe('custom')
+  })
+
   it('falls back to genspark for unknown ids from a hand-edited settings file', () => {
     const settings = defaultAiSettings()
     settings.provider = 'nonsense' as AiProviderId

--- a/packages/ai-provider/tests/stream.test.ts
+++ b/packages/ai-provider/tests/stream.test.ts
@@ -803,6 +803,23 @@ describe('streamForProvider: openai-compatible', () => {
     ).rejects.toThrow(/Base URL/)
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  it('omits Authorization for keyless custom endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(sseStream(['data: [DONE]'])))
+    vi.stubGlobal('fetch', fetchMock)
+    const { cb } = collector()
+    await streamForProvider(
+      'custom',
+      { apiKey: '', model: 'llama3', baseUrl: 'http://localhost:11434/v1' },
+      'sys',
+      [],
+      [],
+      100,
+      cb,
+    ).catch(() => {})
+    const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
 })
 
 describe('streamForProvider: genspark', () => {


### PR DESCRIPTION
## Summary

- What changed? activeProvider now honors custom when baseUrl+model are set even with an empty apiKey; OpenAI-compatible chat/stream omit the Authorization header when the key is empty.
- Why? Local OpenAI-compatible servers (Ollama, LM Studio, vLLM) accept anonymous requests. Previously a keyless custom config silently fell back to genspark, and an empty key was still sent as Bearer empty, which strict local gateways reject. This unblocks local-document workflows from #45 without changing any other provider's key requirement.

## Related issue

Part of #45 (custom endpoint with optional key; does not close the full settings-window proposal)

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof (same as prior passes). Added regression tests: providers.test.ts keyless custom, chat.test.ts + stream.test.ts Authorization omission.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.