### PR TITLE
fix(shell): reject Windows reserved and trailing-dot rename names

### DIFF
--- a/apps/shell/src/main/rename-validation.ts
+++ b/apps/shell/src/main/rename-validation.ts
@@ -7,9 +7,18 @@ import { basename, dirname } from 'node:path'
 // eslint-disable-next-line no-control-regex -- the C0 range IS the check: Windows forbids controls in names.
 export const RENAME_ILLEGAL_NAME_CHARS = /[\\/:*?"<>|\u0000-\u001f]/
 
+/** Windows device names reserved with or without an extension (CON.pdf is still CON). */
+const RENAME_RESERVED_BASE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i
+
 /** True when the trimmed name is usable as a file name. */
 export function isValidRenameName(name: string): boolean {
-  return name.length > 0 && !RENAME_ILLEGAL_NAME_CHARS.test(name)
+  if (name.length === 0 || name.length > 255) return false
+  if (RENAME_ILLEGAL_NAME_CHARS.test(name)) return false
+  // Windows strips trailing dots/spaces: renaming to "file." lands elsewhere,
+  // so reject with the localized gate instead of a surprising rename.
+  if (name.endsWith('.')) return false
+  if (RENAME_RESERVED_BASE.test(name)) return false
+  return true
 }
 
 /** True when target names the same file with different letter case only

--- a/apps/shell/tests/home-rename-validation.test.ts
+++ b/apps/shell/tests/home-rename-validation.test.ts
@@ -18,4 +18,26 @@ describe('home rename validation', () => {
     expect(isCaseOnlyRename('/d/report.pdf', '/d/other.pdf')).toBe(false)
     expect(isCaseOnlyRename('/d/report.pdf', '/e/report.pdf')).toBe(false)
   })
+
+  it('rejects Windows reserved names, trailing dots, and overlong names', () => {
+    for (const bad of [
+      'CON',
+      'con.pdf',
+      'PRN.docx',
+      'aux',
+      'NUL.txt',
+      'COM1',
+      'com9.pdf',
+      'LPT1',
+      'lpt9.xlsx',
+    ]) {
+      expect(isValidRenameName(bad)).toBe(false)
+    }
+    expect(isValidRenameName('report.')).toBe(false)
+    expect(isValidRenameName('.')).toBe(false)
+    expect(isValidRenameName('a'.repeat(256))).toBe(false)
+    expect(isValidRenameName('com10.pdf')).toBe(true)
+    expect(isValidRenameName('my CON file.pdf')).toBe(true)
+    expect(isValidRenameName('a'.repeat(255))).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

- What changed? isValidRenameName now rejects Windows device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 with or without extension), trailing dots, and names over 255 chars.
- Why? Follow-up to #221: those names pass the illegal-char gate today, then renameSync throws a raw OS error (or Windows silently strips the dot). Rejecting upfront keeps the localized errBadName path instead of leaking raw errors.

## Related issue

Follow-up to #221 (Home rename validation hardening)

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added regression tests in home-rename-validation.test.ts (reserved names, trailing dot, length bounds, com10/my-CON allowed).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.