### PR TITLE
fix(shell): normalize recents ext filter dots case and whitespace

### DIFF
--- a/apps/shell/src/main/recent-files.ts
+++ b/apps/shell/src/main/recent-files.ts
@@ -48,7 +48,12 @@ export function normalizeRecentQuery(
   const limit = Number.isFinite(query.limit)
     ? Math.min(RECENT_PAGE_MAX, Math.max(0, Math.floor(query.limit!)))
     : RECENT_PAGE_DEFAULT
-  const ext = typeof query.ext === 'string' && query.ext ? query.ext.toLowerCase() : undefined
+  // Sidebar keys are bare extensions ("xlsx"), but IPC callers may send
+  // ".xlsx", " XLSX ", or "..." — normalize so openable files cannot hide
+  // behind a filter that only differs in dots/case/whitespace.
+  const rawExt =
+    typeof query.ext === 'string' ? query.ext.trim().toLowerCase().replace(/^\.+/, '') : ''
+  const ext = rawExt ? rawExt : undefined
   return { offset, limit, ext }
 }
 

--- a/apps/shell/tests/home-counts.test.ts
+++ b/apps/shell/tests/home-counts.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createI18n } from '@genoffice/i18n'
-import { pageRecentPaths } from '../src/main/recent-files'
+import { normalizeRecentQuery, pageRecentPaths } from '../src/main/recent-files'
 import { fileCountKey, timelineCountKey, visiblePageCount } from '../src/renderer/src/counts'
 import { strings } from '../src/renderer/src/strings'
 
@@ -73,6 +73,28 @@ describe('home visible counts', () => {
     ])
     expect(page.entries[0].mtimeMs).toBe(0)
     expect(page.entries[0].ext).toBe('xlsx')
+  })
+})
+
+describe('recent query ext normalization', () => {
+  it('trims whitespace, strips leading dots, and lowercases the filter', () => {
+    expect(normalizeRecentQuery({ ext: '.XLSX' }).ext).toBe('xlsx')
+    expect(normalizeRecentQuery({ ext: ' xlsx ' }).ext).toBe('xlsx')
+    expect(normalizeRecentQuery({ ext: '...md' }).ext).toBe('md')
+    expect(normalizeRecentQuery({ ext: '...' }).ext).toBeUndefined()
+    expect(normalizeRecentQuery({ ext: '' }).ext).toBeUndefined()
+    expect(normalizeRecentQuery({}).ext).toBeUndefined()
+  })
+
+  it('applies the normalized filter to the page', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shell-counts-'))
+    tempDirs.push(dir)
+    const bookPath = join(dir, 'book.xlsx')
+    writeFileSync(bookPath, 'sheet')
+
+    const page = pageRecentPaths([bookPath], { ext: '.XLSX', limit: 50 }, new Set())
+    expect(page.total).toBe(1)
+    expect(page.entries.map((entry) => entry.path)).toEqual([bookPath])
   })
 })
 


### PR DESCRIPTION
## Summary

- What changed? normalizeRecentQuery now trims whitespace, strips leading dots, and lowercases the ext filter; empty/dot-only filters become undefined (no filter).
- Why? IPC callers may send .XLSX, ' xlsx ', or '...' — today those miss the family/exact match and hide openable files behind a filter that only differs in dots/case/whitespace, violating the family invariant. Normalizing keeps recents/starred filtering robust.

## Related issue

Follow-up to the recents family work (#217); no open issue — self-identified robustness gap.

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added regression tests in home-counts.test.ts (normalization unit + page filter).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.