### PR TITLE
fix(ai-provider): trim model whitespace and remap padded retired ids

### DIFF
--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -264,13 +264,14 @@ export function maxOutputTokensOf(
     : clampMaxOutputTokens(settings.maxOutputTokens)
 }
 
-/** pasted keys/URLs often carry stray whitespace, which turns into a 401 with a valid key */
+/** pasted keys/URLs/model ids often carry stray whitespace, which turns into a 401 with a valid key */
 function trimConfigs(providers: AiSettings['providers']): AiSettings['providers'] {
   const trimmed = { ...providers }
   for (const [id, config] of Object.entries(trimmed)) {
     trimmed[id as AiProviderId] = {
       ...config,
       apiKey: config.apiKey?.trim() ?? '',
+      model: config.model?.trim() ?? '',
       ...(config.baseUrl !== undefined ? { baseUrl: config.baseUrl.trim() } : {}),
     }
   }
@@ -301,7 +302,7 @@ export function resolveAiSettings(
     if (stored.apiKey) {
       defaults.providers.custom = {
         apiKey: stored.apiKey.trim(),
-        model: stored.model ?? '',
+        model: stored.model?.trim() ?? '',
         baseUrl: (stored.baseUrl ?? 'https://api.openai.com/v1').trim(),
       }
     }
@@ -309,7 +310,9 @@ export function resolveAiSettings(
   }
   return {
     provider: stored.provider ?? defaults.provider,
-    providers: trimConfigs(migrateRetiredModels({ ...defaults.providers, ...stored.providers })),
+    // Trim before migrating: a pasted " deepseek-reasoner " must still hit
+    // the retired-id remap instead of being sent to the API verbatim.
+    providers: migrateRetiredModels(trimConfigs({ ...defaults.providers, ...stored.providers })),
     gskToolsEnabled: stored.gskToolsEnabled ?? defaults.gskToolsEnabled ?? true,
     // clamped on read: a hand-edited settings file with an absurd cap must not be
     // forwarded to the endpoint verbatim

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -139,23 +139,42 @@ describe('resolveAiSettings', () => {
     const resolved = resolveAiSettings(
       {
         providers: {
-          deepseek: { apiKey: ' sk-user\n', model: 'deepseek-v4-pro' },
-          custom: { apiKey: 'k', model: 'm', baseUrl: ' http://localhost:1234/v1 ' },
+          deepseek: { apiKey: ' sk-user\n', model: ' deepseek-v4-pro ' },
+          custom: { apiKey: 'k', model: ' m ', baseUrl: ' http://localhost:1234/v1 ' },
         } as never,
       },
       defaultAiSettings(),
     )
     expect(resolved.providers.deepseek.apiKey).toBe('sk-user')
+    expect(resolved.providers.deepseek.model).toBe('deepseek-v4-pro')
     expect(resolved.providers.deepseek.baseUrl).toBeUndefined()
+    expect(resolved.providers.custom.model).toBe('m')
     expect(resolved.providers.custom.baseUrl).toBe('http://localhost:1234/v1')
+  })
+
+  it('still remaps retired model ids padded with whitespace', () => {
+    const resolved = resolveAiSettings(
+      {
+        providers: {
+          deepseek: { apiKey: 'sk-user', model: ' deepseek-reasoner ' },
+        } as never,
+      },
+      defaultAiSettings(),
+    )
+    expect(resolved.providers.deepseek.model).toBe('deepseek-v4-flash')
   })
 
   it('trims the legacy single-endpoint key and base URL too', () => {
     const resolved = resolveAiSettings(
-      { apiKey: ' legacy-key ', baseUrl: ' https://legacy.example.com/v1 ' },
+      {
+        apiKey: ' legacy-key ',
+        model: ' legacy-model ',
+        baseUrl: ' https://legacy.example.com/v1 ',
+      },
       defaultAiSettings(),
     )
     expect(resolved.providers.custom.apiKey).toBe('legacy-key')
+    expect(resolved.providers.custom.model).toBe('legacy-model')
     expect(resolved.providers.custom.baseUrl).toBe('https://legacy.example.com/v1')
   })
 


### PR DESCRIPTION
## Summary

- What changed? trimConfigs now trims stored model ids (plus legacy migration); resolveAiSettings trims before the retired-model remap instead of after.
- Why? A pasted ' gpt-5.6-terra ' or ' deepseek-reasoner ' misses exact-match logic: the key/URL trim covered apiKey/baseUrl but not model, and a padded retired id (' deepseek-reasoner ') skipped the remap entirely, sending a vendor-rejected id to the API. Trim-first keeps pasted configs working.

## Related issue

Self-identified settings-robustness gap (same family as the key/URL trim).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Extended providers.test.ts (model trim, padded retired remap, legacy model trim).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.