### PR TITLE
fix(sheets): guard replaceOccurrences against empty needle

### DIFF
--- a/apps/sheets/src/domain/workbook-dsl.ts
+++ b/apps/sheets/src/domain/workbook-dsl.ts
@@ -1338,6 +1338,10 @@ export function replaceOccurrences(
   replace: string,
   matchCase: boolean,
 ): string {
+  // An empty needle matches every gap (split('') / /(?:)/gi): callers validate
+  // non-empty via the find_replace schema, but a direct call must stay a no-op
+  // rather than corrupting the cell — mirrors lazy-find's empty-needle guard.
+  if (!find) return text
   if (matchCase) return text.split(find).join(replace)
   const escaped = find.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   // Callback form: a literal `$` in the replacement must stay literal.

--- a/apps/sheets/tests/bulk-range-ops.test.ts
+++ b/apps/sheets/tests/bulk-range-ops.test.ts
@@ -193,6 +193,11 @@ describe('replaceOccurrences (shared by expansion and the chunked executor)', ()
   it('keeps a literal $ in the replacement literal', () => {
     expect(replaceOccurrences('price: X', 'X', '$1.00', false)).toBe('price: $1.00')
   })
+
+  it('leaves text unchanged for an empty needle', () => {
+    expect(replaceOccurrences('abc', '', 'X', false)).toBe('abc')
+    expect(replaceOccurrences('abc', '', 'X', true)).toBe('abc')
+  })
 })
 
 describe('InMemoryWorkbookAdapter (demo mode)', () => {


### PR DESCRIPTION
## Summary

- What changed? replaceOccurrences returns text unchanged when find is empty.
- Why? An empty needle matches every gap: split('') inserts the replacement between every char and /(?:)/gi rewrites the cell. Callers validate non-empty via the find_replace schema, but a direct call must stay a no-op rather than corrupting data — mirrors the empty-needle guard in lazy-find replaceAllOccurrences.

## Related issue

Self-identified consistency gap (find_replace schema min(1) vs shared helper).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added regression test in bulk-range-ops.test.ts.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.