### PR TITLE
fix(slides): clear staged attachments on New chat

### DIFF
--- a/apps/slides/src/renderer/ai/AiPanel.tsx
+++ b/apps/slides/src/renderer/ai/AiPanel.tsx
@@ -1873,6 +1873,10 @@ export function AiPanel({
     // original message index, so stale entries would re-attach to unrelated
     // new messages after an index collision.
     setClarifyAnswers([])
+    // Unsent composer attachments would otherwise ride into the next chat's
+    // file context (availableAttachments merges sent + live), mirroring docs.
+    setAttachments([])
+    setAttachNotice(null)
     sentAttachmentsRef.current = []
     readAttachmentPathsRef.current.clear()
     inputRef.current?.focus()


### PR DESCRIPTION
## Summary

- What changed? slides New chat now clears staged composer attachments (plus the attach notice) alongside the transcript.
- Why? Unsent staged files ride into the next chat's file context (availableAttachments merges sent + live), the same bug #224 fixed in docs (and #239 in sheets). Rebased onto main `6d16796`; main already restored the `setClarifyAnswers` reset, so per review this keeps only `setAttachments` / `setAttachNotice`.

## Related issue

Mirrors #224 for slides (docs sibling; sheets sibling #239).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. No dedicated component test — seeding staged attachments requires driving a live loop; verified against the docs sibling covered by ai-new-chat-attachments.test.ts.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
