### PR TITLE
fix(pdf): suffix Windows reserved auto-rename bases

### DIFF
--- a/apps/pdf/src/main/pdf-main.ts
+++ b/apps/pdf/src/main/pdf-main.ts
@@ -577,7 +577,10 @@ function sanitizeAutoRenameBase(raw: string): string | null {
     .replace(/^\.+|\.+$/g, '')
     .trim()
   if (!cleaned) return null
-  return cleaned.length > 40 ? cleaned.slice(0, 40).trim() : cleaned
+  // Windows device names stay reserved with an extension (CON.pdf is still
+  // CON): suffix them so the no-clobber move works there instead of failing.
+  const safe = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(cleaned) ? cleaned + '_' : cleaned
+  return safe.length > 40 ? safe.slice(0, 40).trim() : safe
 }
 
 export type NoClobberMoveResult = 'moved' | 'occupied' | 'failed'

--- a/apps/pdf/tests/auto-rename.test.ts
+++ b/apps/pdf/tests/auto-rename.test.ts
@@ -150,6 +150,16 @@ describe('pdf auto-rename', () => {
     expect(basename(result.path!)).toBe('Q3 Plan draft.pdf')
   })
 
+  it('suffixes Windows reserved names so the rename works there too', () => {
+    const path = makePdfFile()
+    markPdfUntitledPath(path)
+    createPdfView(path)
+
+    const result = rename(lastWebContents.id, path, 'CON')
+    expect(result.renamed).toBe(true)
+    expect(basename(result.path!)).toBe('CON_.pdf')
+  })
+
   it('retries an occupied candidate without altering the winning file bytes', () => {
     const path = makePdfFile()
     const occupiedPath = join(path, '..', 'Report.pdf')


### PR DESCRIPTION
## Summary

- What changed? sanitizeAutoRenameBase appends _ to Windows device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9).
- Why? Those stems stay reserved with an extension (CON.pdf is still CON), so the no-clobber move fails on Windows and the rename silently does nothing. Suffixing keeps content-derived naming working there; harmless elsewhere.

## Related issue

Self-identified (same reserved-name family as the shell rename gate).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added regression test in auto-rename.test.ts (CON -> CON_.pdf).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.