### PR TITLE
fix(sheets): drop staged attachments on New chat

### DIFF
--- a/apps/sheets/src/renderer/App.tsx
+++ b/apps/sheets/src/renderer/App.tsx
@@ -1343,6 +1343,11 @@ export function App(): React.JSX.Element {
     setAiBusy(false)
     setChat([])
     setHistoricChat([])
+    // Unsent composer attachments would otherwise ride into the next chat's
+    // file context (availableAttachments merges sent + live) — same as docs
+    // (#224) and slides. The typed draft itself is kept.
+    setAttachments([])
+    setAttachNotice(null)
     sentAttachmentsRef.current = []
     setPreview(null)
     lazyPreviewRef.current = null


### PR DESCRIPTION
## Summary

- What changed? sheets New chat now clears staged composer attachments and the attach notice alongside the transcript.
- Why? Unsent staged files otherwise ride into the next chat's file context (availableAttachments merges sent + live composer files) — the same bug #224 fixed in docs and #234 fixes in slides. Sheets keeps the same merge shape in App.tsx, so it needs the same clear.

## Related issue

Mirrors #224 (docs) and #234 (slides) for sheets.

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. No dedicated component test — same omission as #219 (seeding staged attachments requires driving the Univer-backed App; verified against the merge site and the docs sibling covered by ai-new-chat-attachments.test.ts).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.