### PR TITLE
fix(electron-utils): skip drop files whose path resolution throws

### DIFF
--- a/packages/electron-utils/src/drop-open.ts
+++ b/packages/electron-utils/src/drop-open.ts
@@ -29,6 +29,15 @@ const MAX_DROPPED_FILES = 20
 /** the resolver signature webUtils.getPathForFile satisfies; injectable for tests */
 type PathResolver = (file: File) => string
 
+/** Resolve one dropped file, tolerating resolver failures (see droppableFilePaths). */
+function tryResolvePath(file: File, getPathForFile: PathResolver): string {
+  try {
+    return getPathForFile(file).trim()
+  } catch {
+    return ''
+  }
+}
+
 /**
  * Resolve an event's dropped files to local paths. Returns null when the drag
  * carries no OS files at all (internal text/element drags), or [] when it does
@@ -44,14 +53,9 @@ export function droppableFilePaths(
   for (const file of Array.from(transfer.files)) {
     // A throwing resolver (e.g. a sandboxed entry Electron cannot map) must
     // not abort the whole drop: skip that file like a virtual entry.
-    let resolved = ''
-    try {
-      resolved = getPathForFile(file).trim()
-    } catch {
-      continue
-    }
-    // non-empty guard covers virtual entries (e.g. page-referenced blobs) that resolve to ''
-    if (resolved) paths.push(resolved)
+    // Non-empty guard covers virtual entries (e.g. page-referenced blobs).
+    const path = tryResolvePath(file, getPathForFile)
+    if (path) paths.push(path)
   }
   return paths
 }

--- a/packages/electron-utils/src/drop-open.ts
+++ b/packages/electron-utils/src/drop-open.ts
@@ -42,9 +42,16 @@ export function droppableFilePaths(
   if (!transfer || !transfer.types.includes('Files')) return null
   const paths: string[] = []
   for (const file of Array.from(transfer.files)) {
+    // A throwing resolver (e.g. a sandboxed entry Electron cannot map) must
+    // not abort the whole drop: skip that file like a virtual entry.
+    let resolved = ''
+    try {
+      resolved = getPathForFile(file).trim()
+    } catch {
+      continue
+    }
     // non-empty guard covers virtual entries (e.g. page-referenced blobs) that resolve to ''
-    const path = getPathForFile(file).trim()
-    if (path) paths.push(path)
+    if (resolved) paths.push(resolved)
   }
   return paths
 }

--- a/packages/electron-utils/tests/drop-open.test.ts
+++ b/packages/electron-utils/tests/drop-open.test.ts
@@ -101,6 +101,14 @@ describe('droppableFilePaths', () => {
     )
     expect(result).toEqual(['/tmp/doc.docx'])
   })
+
+  it('skips files whose path resolution throws instead of aborting the drop', () => {
+    const result = droppableFilePaths(fileDrag(['bad.docx', 'good.docx']) as never, (file) => {
+      if ((file as { name: string }).name === 'bad.docx') throw new Error('denied')
+      return '/tmp/good.docx'
+    })
+    expect(result).toEqual(['/tmp/good.docx'])
+  })
 })
 
 describe('partitionDropPayload', () => {


### PR DESCRIPTION
## Summary

- What changed? droppableFilePaths now skips a file when getPathForFile throws, instead of letting the exception abort the whole drop.
- Why? A single unmappable entry (sandboxed/proxy File the API cannot map) previously killed the entire multi-file drop — no files opened. Skipping matches the existing virtual-entry handling (empty resolutions are already dropped, not fatal).

## Related issue

Self-identified hardening (same drop pipeline as partitionDropPayload).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added regression test in drop-open.test.ts (throwing resolver skips one file, keeps the other).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.