### PR TITLE
fix(docs): decline Windows reserved names for auto file naming

### DIFF
--- a/apps/docs/src/renderer/file-actions.ts
+++ b/apps/docs/src/renderer/file-actions.ts
@@ -445,7 +445,7 @@ function pmNodeText(node: PmNode): string {
 }
 
 /** Sanitize a heading into a safe filename base: strip illegal path chars, collapse whitespace, cap length; null if invalid. (Mirrors slides' draft naming.) */
-function sanitizeFileBaseName(raw: string): string | null {
+export function sanitizeFileBaseName(raw: string): string | null {
   const cleaned = raw
     // eslint-disable-next-line no-control-regex -- stripping control chars is the point here
     .replace(/[\\/:*?"<>|\u0000-\u001f]/g, ' ')
@@ -455,6 +455,10 @@ function sanitizeFileBaseName(raw: string): string | null {
     .replace(/^\.+|\.+$/g, '')
     .trim()
   if (!cleaned) return null
+  // Windows device names stay reserved with an extension (CON.docx is still
+  // CON): decline them so the first save keeps the Untitled name instead of
+  // proposing a file Windows cannot create (same family as the pdf/shell guards).
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(cleaned)) return null
   return cleaned.length > 40 ? cleaned.slice(0, 40).trim() : cleaned
 }
 

--- a/apps/docs/tests/auto-file-name.test.ts
+++ b/apps/docs/tests/auto-file-name.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { sanitizeFileBaseName } from '../src/renderer/file-actions'
+
+describe('sanitizeFileBaseName', () => {
+  it('keeps an ordinary heading as the file base', () => {
+    expect(sanitizeFileBaseName('Quarterly report')).toBe('Quarterly report')
+  })
+
+  it('declines Windows reserved names so the save keeps its Untitled name', () => {
+    for (const reserved of ['CON', 'prn', 'AUX', 'nul', 'COM1', 'com9', 'LPT1', 'lpt9']) {
+      expect(sanitizeFileBaseName(reserved)).toBeNull()
+    }
+    expect(sanitizeFileBaseName('My CON file')).toBe('My CON file')
+    expect(sanitizeFileBaseName('com10')).toBe('com10')
+  })
+})


### PR DESCRIPTION
## Summary

- What changed? sanitizeFileBaseName (now exported for tests) returns null for Windows device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9).
- Why? A first heading of CON made the first silent save propose CON.docx, which Windows cannot create (reserved stem with any extension). Declining keeps the Untitled name instead of a doomed proposal — same reserved-name family as the pdf auto-rename and shell rename gates.

## Related issue

Self-identified (same family as #237 and #230).

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added auto-file-name.test.ts (ordinary heading kept; reserved declined; CON-containing and com10 allowed).

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.