### PR TITLE
fix(sheets): label force-string popup as warning not error

### DIFF
--- a/apps/sheets/src/renderer/App.tsx
+++ b/apps/sheets/src/renderer/App.tsx
@@ -333,7 +333,7 @@ import { installMultiRowAutofit } from './autofit-multi-row'
 import { registerExcelJumpNav } from './excel-jump-nav'
 import { registerExcelShortcuts } from './excel-shortcuts'
 import { installCopyMaterialize } from './copy-materialize'
-import { applyUniverLocale } from './univer-locales'
+import { applyUniverLocale, FORCE_STRING_POPUP_LOCALE } from './univer-locales'
 import { installRuleDetail } from './univer-rule-detail'
 import { installActiveCellDataValidationChrome } from './data-validation-dropdown'
 import { installFormulaNullResultFix } from './formula-null-result'
@@ -1471,6 +1471,8 @@ export function App(): React.JSX.Element {
           // mergeLocales shallow-merges namespaces, so the existing entries must
           // be spread; otherwise the whole sheets-ui namespace gets overwritten
           // (the sheet-tab context menu turns into bare keys).
+          // #236: force-string renders correctly, so the popup is a warning,
+          // not an error (shared constant with univer-locales.ts).
           {
             'sheets-ui': {
               ...(UniverPresetSheetsCoreEnUS as Record<string, Record<string, unknown>>)[
@@ -1483,10 +1485,7 @@ export function App(): React.JSX.Element {
                     Record<string, Record<string, string>>
                   >
                 )['sheets-ui']?.info,
-                error: 'Number stored as text',
-                forceStringInfo:
-                  'The value in this cell is stored as text — it will not be treated as a ' +
-                  'number in formulas.',
+                ...FORCE_STRING_POPUP_LOCALE,
               },
             },
           },

--- a/apps/sheets/src/renderer/univer-locales.ts
+++ b/apps/sheets/src/renderer/univer-locales.ts
@@ -217,6 +217,17 @@ export function univerLocaleFor(lang: string): LocaleType | null {
   return UNIVER_LOCALES[lang]?.type ?? null
 }
 
+// Force-string cell popup copy (#236): the value renders correctly, so the
+// popup title must read as a warning, not an error. Shared by the en-US boot
+// locale in App.tsx and applyUniverLocale below so a language switch cannot
+// regress one of the two sites.
+export const FORCE_STRING_POPUP_LOCALE = {
+  error: 'Warning',
+  forceStringInfo:
+    'The value in this cell is stored as text — it will not be treated as a ' +
+    'number in formulas.',
+} as const
+
 export async function applyUniverLocale(runtime: UniverRuntime, lang: string): Promise<void> {
   const entry = UNIVER_LOCALES[lang]
   if (!entry) return
@@ -229,10 +240,7 @@ export async function applyUniverLocale(runtime: UniverRuntime, lang: string): P
     ...merged['sheets-ui'],
     info: {
       ...(merged['sheets-ui']?.info as Record<string, string> | undefined),
-      error: 'Number stored as text',
-      forceStringInfo:
-        'The value in this cell is stored as text — it will not be treated as a ' +
-        'number in formulas.',
+      ...FORCE_STRING_POPUP_LOCALE,
     },
   }
   const localeService = runtime.univer.__getInjector().get(LocaleService)

--- a/apps/sheets/tests/univer-locales.test.ts
+++ b/apps/sheets/tests/univer-locales.test.ts
@@ -1,7 +1,7 @@
 import { LocaleType } from '@univerjs/core'
 import { describe, expect, it } from 'vitest'
 
-import { univerLocaleFor } from '../src/renderer/univer-locales'
+import { FORCE_STRING_POPUP_LOCALE, univerLocaleFor } from '../src/renderer/univer-locales'
 
 describe('univerLocaleFor', () => {
   it('maps every app language Univer has packs for', () => {
@@ -23,5 +23,10 @@ describe('univerLocaleFor', () => {
       default: Record<string, { list?: { name?: string } }>
     }
     expect(pack.default['sheets-data-validation']?.list?.name).toBe('值必须是列表中的值')
+  })
+
+  it('labels the force-string popup as a warning, not an error (#236)', () => {
+    expect(FORCE_STRING_POPUP_LOCALE.error).toBe('Warning')
+    expect(FORCE_STRING_POPUP_LOCALE.forceStringInfo).toContain('stored as text')
   })
 })


### PR DESCRIPTION
## Summary

- What changed? Sheets force-string ("number stored as text") cell popup title now reads `Warning` instead of `Error`. The copy lives in one shared `FORCE_STRING_POPUP_LOCALE` constant used by both the en-US boot locale (`App.tsx`) and the runtime language switcher (`applyUniverLocale`), so switching languages cannot regress one site.
- Why? The cell renders correctly — a format notice, not a failure (#236). Maintainer confirmed it should be a warning, not an error. The popup chrome itself is upstream Univer; this changes the label this repo controls.

## Related issue

Fixes #236.

## Validation

- [ ] npm run format:check
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Added `apps/sheets/tests/univer-locales.test.ts` regression test asserting the popup title is `Warning` (fails on the old `Number stored as text` title).

## Screenshots or recordings

Not applicable (string-only change; Univer popup chrome unchanged).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
