### PR TITLE
test(sheets): cover multi-match-per-row find navigation (issue #220)

### DIFF
--- a/apps/sheets/tests/lazy-find.test.ts
+++ b/apps/sheets/tests/lazy-find.test.ts
@@ -599,6 +599,81 @@ describe('installLazyFindBridge', () => {
     bridge.dispose()
   })
 
+  it('visits every same-row match in order and wraps (issue #220)', async () => {
+    // Issue #220's repro: the same word in A10, C10, F10 and H10 of one row
+    // must each surface as an individual stop, with Next cycling through
+    // every occurrence instead of reporting one match per row.
+    const harness = facade(state({}))
+    const inner = new CursorInnerModel([
+      match('s1', 9, 0),
+      match('s1', 9, 2),
+      match('s1', 9, 5),
+      match('s1', 9, 7),
+      match('s1', 12, 1),
+    ])
+    inner.onFocus = (row, column) => {
+      harness.active.row = row
+      harness.active.column = column
+    }
+    const builtin = { find: vi.fn().mockResolvedValue([inner]), terminate: vi.fn() }
+    harness.providers.add(builtin)
+    const bridge = installLazyFindBridge(harness)
+
+    mockRead.mockResolvedValue(mapped([]))
+
+    const models = await harnessLookup(harness)(query({ findString: 'Example' }))
+    const model = models[0]!
+    await vi.waitFor(() => expect(model.getMatches()).toHaveLength(5))
+
+    const move = () => model.moveToNextMatch({ loop: true }) as LazyCellMatch | null
+    const posOf = (m: LazyCellMatch | null) =>
+      `${m!.range.range.startRow}:${m!.range.range.startColumn}`
+    expect(posOf(move())).toBe('9:0')
+    expect(posOf(move())).toBe('9:2')
+    expect(posOf(move())).toBe('9:5')
+    expect(posOf(move())).toBe('9:7')
+    expect(posOf(move())).toBe('12:1')
+    // Full cycle wraps back to the first same-row hit.
+    expect(posOf(move())).toBe('9:0')
+    bridge.dispose()
+  })
+
+  it('walks Previous through every same-row match in reverse (issue #220)', async () => {
+    const harness = facade(state({}))
+    const inner = new CursorInnerModel([
+      match('s1', 9, 0),
+      match('s1', 9, 2),
+      match('s1', 9, 5),
+      match('s1', 9, 7),
+      match('s1', 12, 1),
+    ])
+    inner.onFocus = (row, column) => {
+      harness.active.row = row
+      harness.active.column = column
+    }
+    const builtin = { find: vi.fn().mockResolvedValue([inner]), terminate: vi.fn() }
+    harness.providers.add(builtin)
+    const bridge = installLazyFindBridge(harness)
+
+    mockRead.mockResolvedValue(mapped([]))
+
+    const models = await harnessLookup(harness)(query({ findString: 'Example' }))
+    const model = models[0]!
+    await vi.waitFor(() => expect(model.getMatches()).toHaveLength(5))
+
+    const move = () => model.moveToPreviousMatch({ loop: true }) as LazyCellMatch | null
+    const posOf = (m: LazyCellMatch | null) =>
+      `${m!.range.range.startRow}:${m!.range.range.startColumn}`
+    expect(posOf(move())).toBe('12:1')
+    expect(posOf(move())).toBe('9:7')
+    expect(posOf(move())).toBe('9:5')
+    expect(posOf(move())).toBe('9:2')
+    expect(posOf(move())).toBe('9:0')
+    // Full cycle wraps back to the last hit.
+    expect(posOf(move())).toBe('12:1')
+    bridge.dispose()
+  })
+
   it('keeps file matches findable under style-only journal edits', async () => {
     const journalCells = new Map([
       [


### PR DESCRIPTION
## Summary

- What changed? Adds two regression tests through the real lazy-find bridge (`facade` + `installLazyFindBridge` + file-backed scan) encoding issue #220's suggested repro: the same word in A10, C10, F10 and H10 of one row plus a match on another row. Asserts `getMatches()` surfaces all five as individual stops and that Next/Previous visit every one in order with wrap-around. No runtime change.
- Why? Locks extension-layer coverage for the reported find-navigation scenario so a future regression is caught by CI.

## Related issue

Related to #220 (regression coverage; does not change runtime behavior).

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New tests: `apps/sheets/tests/lazy-find.test.ts` ("visits every same-row match in order and wraps", "walks Previous through every same-row match in reverse").

## Screenshots or recordings

Not applicable (no UI change; test-only).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
