### PR TITLE
fix(sheets): fallback to cached values for external reference errors

### DIFF
--- a/apps/sheets/src/renderer/formula-cached-fallback.ts
+++ b/apps/sheets/src/renderer/formula-cached-fallback.ts
@@ -76,15 +76,29 @@ export function installCachedValueFallbackInterceptor(
       const key = `${location.row}:${location.col}`
       const edits = state.editJournal.cells.get(sheetId)
       // Style-only journal entries (hasValue false) don't change any input.
+      // A user overwrite owns the cell — keep the engine's live result.
       if (edits?.get(key)?.hasValue) return next(cell)
+      let hasValueEdits = false
+      if (edits) {
+        for (const entry of edits.values()) {
+          if (entry.hasValue) {
+            hasValueEdits = true
+            break
+          }
+        }
+      }
+      // Unavailable external links surface as #REF!, #N/A or #ERROR!: the
+      // engine cannot resolve them under any inputs, so like #NAME? they
+      // stay fallback-eligible even when the user edited elsewhere.
+      const isExternalRefError =
+        value === ErrorType.REF || value === ErrorType.NA || value === ErrorType.ERROR
       // Once the sheet has user content edits, a computed error (#DIV/0!,
       // #N/A, ...) may be the true result of the new inputs — keep it.
-      // #NAME? still falls back: the engine cannot evaluate that formula
-      // under any inputs, so the file's value remains the best display.
-      if (value !== ErrorType.NAME && edits) {
-        for (const entry of edits.values()) {
-          if (entry.hasValue) return next(cell)
-        }
+      // #NAME? and external-reference errors still fall back: the engine
+      // cannot evaluate those formulas under any inputs, so the file's
+      // value remains the best display.
+      if (value !== ErrorType.NAME && !isExternalRefError && hasValueEdits) {
+        return next(cell)
       }
       const cached = state.cachedFormulaValues.get(sheetId)?.get(key)
       if (cached === undefined || cached === value) return next(cell)

--- a/apps/sheets/tests/formula-cached-fallback.test.ts
+++ b/apps/sheets/tests/formula-cached-fallback.test.ts
@@ -136,8 +136,8 @@ describe('installCachedValueFallbackInterceptor', () => {
     expect(handler({ v: '#NAME?' }, at(0, 0), passthrough)).toMatchObject({ v: 42 })
   })
 
-  it('keeps computed errors on an edited sheet but still falls back for #NAME?', () => {
-    const state = makeState({ '0:0': 42, '0:1': 7 })
+  it('keeps computed errors on an edited sheet but falls back for #NAME? and external ref errors', () => {
+    const state = makeState({ '0:0': 42, '0:1': 7, '0:2': 3.14, '0:3': 'ext ref' })
     state.editJournal.cells.set('sheet-1', new Map([['9:9', { hasValue: true }]]))
     const { handler } = captureInterceptor({ current: state })
     // #DIV/0! may be the true result of the user's new inputs.
@@ -145,6 +145,11 @@ describe('installCachedValueFallbackInterceptor', () => {
     expect(handler(divide, at(0, 0), passthrough)).toBe(divide)
     // #NAME? cannot be computed under any inputs; the cache stays better.
     expect(handler({ v: '#NAME?' }, at(0, 1), passthrough)).toMatchObject({ v: 7 })
+    // External reference errors fall back to cache even on an edited sheet:
+    // the engine cannot resolve the link, so the file's value is the best display.
+    expect(handler({ v: '#REF!' }, at(0, 2), passthrough)).toMatchObject({ v: 3.14 })
+    expect(handler({ v: '#N/A' }, at(0, 3), passthrough)).toMatchObject({ v: 'ext ref' })
+    expect(handler({ v: '#ERROR!' }, at(0, 2), passthrough)).toMatchObject({ v: 3.14 })
   })
 
   it('keeps a genuine arithmetic #VALUE! instead of the stale cache', () => {


### PR DESCRIPTION
## Summary

- What changed? `installCachedValueFallbackInterceptor` (`apps/sheets/src/renderer/formula-cached-fallback.ts`) now treats unavailable-external-link errors (`#REF!`, `#N/A`, `#ERROR!`) like `#NAME?`: they fall back to the file's cached value even when the user edited other cells, because the engine cannot resolve them under any inputs. Genuine computed errors (`#DIV/0!`, plain-arithmetic `#VALUE!`) still keep the live engine result on edited sheets, and an edited cell itself still wins. Unedited-sheet behavior is unchanged.
- Why? Workbooks with links to unreachable external documents showed cascading `#ERROR!` where Excel/LibreOffice show cached values (#235).

## Related issue

Fixes #235.

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Extended `apps/sheets/tests/formula-cached-fallback.test.ts` ("keeps computed errors on an edited sheet but falls back for #NAME? and external ref errors"); existing cases (unedited-sheet fallback, style-only edits, genuine arithmetic `#VALUE!`) are preserved.

## Screenshots or recordings

Not applicable (display-value fallback; no chrome change).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
