### PR TITLE
feat(markdown): add outline view for heading navigation

### DIFF
--- a/apps/markdown/src/renderer/App.tsx
+++ b/apps/markdown/src/renderer/App.tsx
@@ -30,6 +30,7 @@ import type { ExportFormat, SaveMode } from '../shared/ipc'
 
 type LoadStatus = 'loading' | 'ready' | 'error'
 type SaveState = 'idle' | 'saving' | 'saved' | 'failed'
+type ViewMode = 'print' | 'outline'
 
 const MIN_ZOOM = 50
 const MAX_ZOOM = 200
@@ -128,6 +129,7 @@ export default function App() {
   const queueSeqRef = useRef(0)
   const [autoSave, setAutoSave] = useState(() => localStorage.getItem('mdapp.autoSave') === '1')
   const [zoom, setZoom] = useState(100)
+  const [viewMode, setViewMode] = useState<ViewMode>('print')
 
   const statusRef = useRef<LoadStatus>('loading')
   const dirtyRef = useRef(false)
@@ -585,7 +587,7 @@ export default function App() {
   }
 
   return (
-    <div className="app">
+    <div className={`app view-${viewMode}`}>
       <Ribbon
         editor={editor}
         disabled={status !== 'ready'}
@@ -603,6 +605,8 @@ export default function App() {
           setAiOpen(true)
           setAiPreset((prev) => ({ text, nonce: (prev?.nonce ?? 0) + 1 }))
         }}
+        viewMode={viewMode}
+        onViewMode={(mode: ViewMode) => setViewMode(mode)}
       />
       {status === 'loading' && <div className="center-note">{t('loading')}</div>}
       <div className="app-main" style={status === 'ready' ? undefined : { display: 'none' }}>

--- a/apps/markdown/src/renderer/components/Ribbon.tsx
+++ b/apps/markdown/src/renderer/components/Ribbon.tsx
@@ -19,6 +19,7 @@ import {
   IconInlineCode,
   IconLink,
   IconNumbered,
+  IconOutlineView,
   IconPicture,
   IconProperties,
   IconRedo,
@@ -42,6 +43,8 @@ interface Props {
   aiOpen: boolean
   onToggleAi: () => void
   onAiPreset: (instruction: string) => void
+  viewMode: 'print' | 'outline'
+  onViewMode: (mode: 'print' | 'outline') => void
 }
 
 type BlockStyle = 'paragraph' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'quote' | 'codeBlock'
@@ -161,6 +164,8 @@ export function Ribbon({
   aiOpen,
   onToggleAi,
   onAiPreset,
+  viewMode,
+  onViewMode,
 }: Props) {
   const { t } = useI18n()
   const collapse = useRibbonCollapse('mdapp.ribbonCollapsed')
@@ -482,6 +487,28 @@ export function Ribbon({
             </IconBtn>
           </div>
         </div>
+
+        <div className="rb-sep" />
+
+        <div className="ribbon-group">
+          <div className="ribbon-group-items">
+            <button
+              type="button"
+              className={`rb-big view-toggle${viewMode === 'outline' ? ' active' : ''}`}
+              data-tip={t('ribbonOutlineViewTip')}
+              disabled={disabled}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onViewMode(viewMode === 'outline' ? 'print' : 'outline')}
+            >
+              <span className="rb-big-icon">
+                <IconOutlineView size={26} />
+              </span>
+              <span>{t('ribbonOutlineView')}</span>
+            </button>
+          </div>
+        </div>
+
+        <div className="rb-spacer" />
       </div>
       <RibbonCollapseButton
         state={collapse}

--- a/apps/markdown/src/renderer/components/icons.tsx
+++ b/apps/markdown/src/renderer/components/icons.tsx
@@ -20,6 +20,7 @@ export {
   IconUndo,
   IconRedo,
   IconCopy,
+  IconOutlineView,
 } from '../../../../docs/src/renderer/components/icons'
 
 interface IconProps {

--- a/apps/markdown/src/renderer/i18n/strings.ts
+++ b/apps/markdown/src/renderer/i18n/strings.ts
@@ -162,6 +162,8 @@ export const strings = {
     zoom: '缩放',
     zoomIn: '放大',
     zoomOut: '缩小',
+    ribbonOutlineView: '大纲',
+    ribbonOutlineViewTip: '大纲视图:只显示标题层级,可直接编辑标题',
   },
   en: {
     aiToolReadFm: 'Read document properties',
@@ -331,6 +333,8 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Zoom in',
     zoomOut: 'Zoom out',
+    ribbonOutlineView: 'Outline',
+    ribbonOutlineViewTip: 'Outline view: show only the heading hierarchy; headings stay editable',
   },
   ja: {
     aiToolReadFm: 'ドキュメントのプロパティを読み取り',
@@ -498,6 +502,8 @@ export const strings = {
     zoom: 'ズーム',
     zoomIn: '拡大',
     zoomOut: '縮小',
+    ribbonOutlineView: 'アウトライン',
+    ribbonOutlineViewTip: 'アウトライン表示:見出しの階層のみを表示し、見出しを直接編集可能',
   },
   ko: {
     aiToolReadFm: '문서 속성 읽기',
@@ -666,6 +672,8 @@ export const strings = {
     zoom: '줌',
     zoomIn: '확대',
     zoomOut: '축소',
+    ribbonOutlineView: '개요',
+    ribbonOutlineViewTip: '개요 보기: 제목 수준만 표시하며 제목을 직접 편집 가능',
   },
   fr: {
     aiToolReadFm: 'Lecture des propriétés du document',
@@ -839,6 +847,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Zoom avant',
     zoomOut: 'Zoom arrière',
+    ribbonOutlineView: 'Plan',
+    ribbonOutlineViewTip:
+      'Vue Plan : afficher uniquement la hiérarchie des titres ; les titres restent modifiables',
   },
   de: {
     aiToolReadFm: 'Dokumenteigenschaften lesen',
@@ -1011,6 +1022,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Vergrößern',
     zoomOut: 'Verkleinern',
+    ribbonOutlineView: 'Gliederung',
+    ribbonOutlineViewTip:
+      'Gliederungsansicht: nur die Überschriftenhierarchie anzeigen; Überschriften bleiben bearbeitbar',
   },
   es: {
     aiToolReadFm: 'Leer propiedades del documento',
@@ -1184,6 +1198,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Acercar',
     zoomOut: 'Alejar',
+    ribbonOutlineView: 'Esquema',
+    ribbonOutlineViewTip:
+      'Vista de esquema: mostrar solo la jerarquía de títulos; los títulos se pueden editar',
   },
   th: {
     aiToolReadFm: 'อ่านคุณสมบัติเอกสาร',
@@ -1350,6 +1367,8 @@ export const strings = {
     zoom: 'ซูม',
     zoomIn: 'ขยาย',
     zoomOut: 'ย่อ',
+    ribbonOutlineView: 'เค้าร่าง',
+    ribbonOutlineViewTip: 'มุมมองเค้าร่าง: แสดงเฉพาะลำดับชั้นหัวเรื่อง และแก้ไขหัวเรื่องได้โดยตรง',
   },
   id: {
     aiToolReadFm: 'Baca properti dokumen',
@@ -1518,6 +1537,9 @@ export const strings = {
     zoom: 'Zum',
     zoomIn: 'Perbesar',
     zoomOut: 'Perkecil',
+    ribbonOutlineView: 'Kerangka',
+    ribbonOutlineViewTip:
+      'Tampilan kerangka: hanya tampilkan hierarki judul; judul tetap dapat diedit',
   },
   ru: {
     aiToolReadFm: 'Чтение свойств документа',
@@ -1687,6 +1709,9 @@ export const strings = {
     zoom: 'Масштаб',
     zoomIn: 'Увеличить',
     zoomOut: 'Уменьшить',
+    ribbonOutlineView: 'Структура',
+    ribbonOutlineViewTip:
+      'Режим структуры: показывать только иерархию заголовков; заголовки можно редактировать',
   },
   ar: {
     aiToolReadFm: 'قراءة خصائص المستند',
@@ -1853,6 +1878,9 @@ export const strings = {
     zoom: 'التكبير',
     zoomIn: 'تكبير',
     zoomOut: 'تصغير',
+    ribbonOutlineView: 'مخطط تفصيلي',
+    ribbonOutlineViewTip:
+      'عرض المخطط التفصيلي: إظهار التسلسل الهرمي للعناوين فقط؛ وتبقى العناوين قابلة للتحرير',
   },
   pt: {
     aiToolReadFm: 'Ler propriedades do documento',
@@ -2024,6 +2052,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Ampliar',
     zoomOut: 'Reduzir',
+    ribbonOutlineView: 'Estrutura de Tópicos',
+    ribbonOutlineViewTip:
+      'Vista de estrutura: mostrar apenas a hierarquia de títulos; os títulos permanecem editáveis',
   },
   it: {
     aiToolReadFm: 'Lettura delle proprietà del documento',
@@ -2195,6 +2226,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Ingrandisci',
     zoomOut: 'Riduci',
+    ribbonOutlineView: 'Struttura',
+    ribbonOutlineViewTip:
+      'Visualizzazione struttura: mostra solo la gerarchia dei titoli; i titoli restano modificabili',
   },
   pl: {
     aiToolReadFm: 'Odczyt właściwości dokumentu',
@@ -2364,6 +2398,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Powiększ',
     zoomOut: 'Pomniejsz',
+    ribbonOutlineView: 'Konspekt',
+    ribbonOutlineViewTip:
+      'Widok konspektu: pokazuj tylko hierarchię nagłówków; nagłówki można edytować',
   },
   nl: {
     aiToolReadFm: 'Documenteigenschappen lezen',
@@ -2534,6 +2571,9 @@ export const strings = {
     zoom: 'Zoom',
     zoomIn: 'Inzoomen',
     zoomOut: 'Uitzoomen',
+    ribbonOutlineView: 'Overzicht',
+    ribbonOutlineViewTip:
+      'Overzichtsweergave: alleen de koppenhiërarchie tonen; koppen blijven bewerkbaar',
   },
   ms: {
     aiToolReadFm: 'Baca sifat dokumen',
@@ -2702,6 +2742,9 @@ export const strings = {
     zoom: 'Zum',
     zoomIn: 'Zum masuk',
     zoomOut: 'Zum keluar',
+    ribbonOutlineView: 'Rangka',
+    ribbonOutlineViewTip:
+      'Paparan rangka: papar hierarki tajuk sahaja; tajuk kekal boleh disunting',
   },
   he: {
     aiToolReadFm: 'קריאת מאפייני המסמך',
@@ -2867,6 +2910,8 @@ export const strings = {
     zoom: 'זום',
     zoomIn: 'הגדלה',
     zoomOut: 'הקטנה',
+    ribbonOutlineView: 'חלוקה לרמות',
+    ribbonOutlineViewTip: 'תצוגת חלוקה לרמות: הצג רק את היררכיית הכותרות; הכותרות ניתנות לעריכה',
   },
   hi: {
     aiToolReadFm: 'दस्तावेज़ गुण पढ़ें',
@@ -3036,6 +3081,9 @@ export const strings = {
     zoom: 'ज़ूम',
     zoomIn: 'ज़ूम इन',
     zoomOut: 'ज़ूम आउट',
+    ribbonOutlineView: 'रूपरेखा',
+    ribbonOutlineViewTip:
+      'रूपरेखा दृश्य: केवल शीर्षकों का पदानुक्रम दिखाएँ; शीर्षक संपादन योग्य रहते हैं',
   },
   'zh-TW': {
     aiToolReadFm: '讀取文件屬性',
@@ -3200,5 +3248,7 @@ export const strings = {
     zoom: '縮放',
     zoomIn: '放大',
     zoomOut: '縮小',
+    ribbonOutlineView: '大綱模式',
+    ribbonOutlineViewTip: '大綱模式：只顯示標題階層，可直接編輯標題',
   },
 } as const

--- a/apps/markdown/src/renderer/styles.css
+++ b/apps/markdown/src/renderer/styles.css
@@ -602,6 +602,12 @@ html.genoffice-popover-open .ribbon-tabs {
   color: var(--text-primary);
 }
 
+/* outline view toggle: same open state as the AI entries */
+.rb-big.view-toggle.active {
+  background: var(--active-bg);
+  color: var(--text-primary);
+}
+
 .ai-feature-icon {
   display: grid;
   place-items: center;
@@ -2766,4 +2772,77 @@ div.tiptap-mathematics-render {
 
 .app-toast.success .app-toast-icon {
   color: var(--md-toast-ok);
+}
+
+/* ==================== Outline View ==================== */
+/* When view-outline is active, hide all non-heading content and show only headings */
+
+.view-outline .doc-page > :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {
+  display: none;
+}
+
+.view-outline .doc-page {
+  padding: 24px;
+}
+
+.view-outline .doc-page h1,
+.view-outline .doc-page h2,
+.view-outline .doc-page h3,
+.view-outline .doc-page h4,
+.view-outline .doc-page h5,
+.view-outline .doc-page h6 {
+  margin: 0;
+  padding: 8px 0 8px 0;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.view-outline .doc-page h1:hover,
+.view-outline .doc-page h2:hover,
+.view-outline .doc-page h3:hover,
+.view-outline .doc-page h4:hover,
+.view-outline .doc-page h5:hover,
+.view-outline .doc-page h6:hover {
+  background: var(--hover);
+}
+
+.view-outline .doc-page h1 {
+  font-size: 1.5rem;
+  padding-left: 0;
+}
+.view-outline .doc-page h2 {
+  font-size: 1.3rem;
+  padding-left: 16px;
+}
+.view-outline .doc-page h3 {
+  font-size: 1.15rem;
+  padding-left: 32px;
+}
+.view-outline .doc-page h4 {
+  font-size: 1.05rem;
+  padding-left: 48px;
+}
+.view-outline .doc-page h5 {
+  font-size: 1rem;
+  padding-left: 64px;
+}
+.view-outline .doc-page h6 {
+  font-size: 0.95rem;
+  padding-left: 80px;
+}
+
+.view-outline .doc-page h1::before,
+.view-outline .doc-page h2::before,
+.view-outline .doc-page h3::before,
+.view-outline .doc-page h4::before,
+.view-outline .doc-page h5::before,
+.view-outline .doc-page h6::before {
+  content: '▸';
+  display: inline-block;
+  width: 16px;
+  text-align: center;
+  margin-right: 8px;
+  color: var(--text);
+  font-size: 0.8em;
 }

--- a/apps/markdown/tests/outline-labels.test.ts
+++ b/apps/markdown/tests/outline-labels.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { strings } from '../src/renderer/i18n/strings'
+
+/**
+ * Outline view toggle (Ribbon.tsx) must speak the UI language like the
+ * zoom controls do — never hardcoded English labels. zh defines the key
+ * set; every locale carries real ribbonOutlineView/ribbonOutlineViewTip
+ * content.
+ */
+
+const locales = Object.keys(strings) as Array<keyof typeof strings>
+
+describe('markdown outline view labels', () => {
+  it.each(locales)('locale %s labels the outline view toggle', (locale) => {
+    const table = strings[locale] as Record<string, unknown>
+    for (const key of ['ribbonOutlineView', 'ribbonOutlineViewTip']) {
+      expect(typeof table[key]).toBe('string')
+      expect((table[key] as string).trim().length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- What changed? Adds an outline view mode to the markdown editor: a View-group ribbon toggle (`apps/markdown/src/renderer/components/Ribbon.tsx`, `IconOutlineView` re-exported from the docs icon library) flips `viewMode` state in `App.tsx`, and new `view-outline` CSS (`styles.css`) shows only the heading hierarchy (indented per level, headings stay editable). Adds `ribbonOutlineView` / `ribbonOutlineViewTip` strings to all 19 locales in `apps/markdown/src/renderer/i18n/strings.ts` (zh defines the key set; wording follows the docs app's outline strings) plus `apps/markdown/tests/outline-labels.test.ts` asserting every locale carries both keys.
- Why? The markdown editor had no outline/navigation aid (#244); this mirrors the docs app's outline view pattern.

## Related issue

Fixes #244.

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: `apps/markdown/tests/outline-labels.test.ts` (mirrors the existing `zoom-labels.test.ts` convention).

## Screenshots or recordings

Not applicable (CSS-gated view mode; verify by toggling the Outline button in the markdown ribbon).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
