### PR TITLE
feat(ai-provider): add Codex CLI as keyless local provider

### DIFF
--- a/apps/shell/src/renderer/src/provider-logos.tsx
+++ b/apps/shell/src/renderer/src/provider-logos.tsx
@@ -205,6 +205,11 @@ const LOGOS: Record<AiProviderId, ReactNode> = {
   ),
   'opencode-zen': opencodeLogo,
   'opencode-go': opencodeLogo,
+  codex: (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+    </svg>
+  ),
   custom: (
     <svg
       viewBox="0 0 24 24"

--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -210,6 +210,17 @@ export const AI_PROVIDERS: AiProviderMeta[] = [
     keyPlaceholder: 'API Key',
   },
   {
+    id: 'codex',
+    label: 'Codex CLI',
+    // Local Codex CLI runner over its OpenAI-compatible HTTP endpoint. Model
+    // ids follow the runner (any model the local Codex setup serves); the key
+    // stays optional for local servers (see activeProvider's needsBaseUrl path).
+    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'o1-preview', 'o1-mini'],
+    defaultModel: 'gpt-4o',
+    keyPlaceholder: 'Optional (local)',
+    needsBaseUrl: true,
+  },
+  {
     id: 'custom',
     label: 'Custom',
     models: [],

--- a/packages/ai-provider/src/registry.ts
+++ b/packages/ai-provider/src/registry.ts
@@ -251,6 +251,21 @@ export const AI_PROVIDER_ADAPTERS: Record<AiProviderId, ProviderAdapter> = {
       }
     },
   },
+  codex: {
+    meta: metaOf('codex'),
+    capabilities: { auth: 'api-key', vision: true },
+    // Local Codex CLI runner over its OpenAI-compatible HTTP endpoint. Like
+    // the generic custom endpoint the key stays optional — only the base URL
+    // and model are required (see activeProvider's needsBaseUrl path).
+    resolveEndpoint(config) {
+      if (!config.baseUrl) throw new Error('A Codex CLI endpoint requires a Base URL')
+      return {
+        protocol: 'openai-compatible',
+        baseUrl: config.baseUrl,
+        ...(modelHasFixedSampling(config.model) ? { omitTemperature: true } : {}),
+      }
+    },
+  },
 }
 
 /** Throws on ids not in the registry — settings files are user data and can carry anything. */

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -16,6 +16,7 @@ export type AiProviderId =
   | 'openrouter'
   | 'opencode-zen'
   | 'opencode-go'
+  | 'codex'
   | 'custom'
 
 /** Genspark account status (gsk login state; the sole auth source for AI features) */

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -265,6 +265,16 @@ describe('activeProvider', () => {
     expect(activeProvider(settings)).toBe('custom')
   })
 
+  it('allows keyless Codex CLI endpoints for local runners', () => {
+    const settings = defaultAiSettings()
+    expect(settings.providers.codex.baseUrl).toBe('')
+    settings.provider = 'codex'
+    expect(activeProvider(settings)).toBe('genspark') // no base URL yet
+    settings.providers.codex.apiKey = ''
+    settings.providers.codex.baseUrl = 'http://localhost:1234/v1'
+    expect(activeProvider(settings)).toBe('codex')
+  })
+
   it('falls back to genspark for unknown ids from a hand-edited settings file', () => {
     const settings = defaultAiSettings()
     settings.provider = 'nonsense' as AiProviderId

--- a/packages/ai-provider/tests/registry.test.ts
+++ b/packages/ai-provider/tests/registry.test.ts
@@ -193,6 +193,15 @@ describe('provider registry', () => {
     )
   })
 
+  it('uses the configured base URL for Codex CLI and rejects a missing one', () => {
+    expect(
+      AI_PROVIDER_ADAPTERS.codex.resolveEndpoint(config('gpt-4o', 'http://localhost:1234/v1')),
+    ).toEqual({ protocol: 'openai-compatible', baseUrl: 'http://localhost:1234/v1' })
+    expect(() => AI_PROVIDER_ADAPTERS.codex.resolveEndpoint(config('gpt-4o'))).toThrow(
+      'A Codex CLI endpoint requires a Base URL',
+    )
+  })
+
   it('only genspark authenticates through the gsk login', () => {
     for (const [id, adapter] of Object.entries(AI_PROVIDER_ADAPTERS)) {
       expect(adapter.capabilities.auth).toBe(id === 'genspark' ? 'gsk-login' : 'api-key')


### PR DESCRIPTION
## Summary

- What changed? Adds a `codex` (Codex CLI) provider across the AI stack: catalog entry in `packages/ai-provider/src/providers.ts` (OpenAI-compatible, `needsBaseUrl`, key placeholder marks the key optional for local servers), `codex` adapter in `packages/ai-provider/src/registry.ts` (requires a base URL, key stays optional via the existing `needsBaseUrl` path in `activeProvider`), `'codex'` in `AiProviderId` (`types.ts`), and a brand mark in the shell settings provider picker (`apps/shell/src/renderer/src/provider-logos.tsx`). Tests: keyless selection in `providers.test.ts`, endpoint resolution/rejection in `registry.test.ts`.
- Why? Requested in #212: run a local Codex CLI runner as an AI backend without an API key.

## Related issue

Fixes #212.

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New tests: `packages/ai-provider/tests/providers.test.ts` ("allows keyless Codex CLI endpoints for local runners"), `packages/ai-provider/tests/registry.test.ts` ("uses the configured base URL for Codex CLI and rejects a missing one").

## Screenshots or recordings

Not applicable (settings-picker entry; select Codex CLI in AI settings to verify).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
