### PR TITLE
fix(pdf): increase print quality to 300 DPI with lossless PNG

### DIFF
--- a/apps/pdf/src/renderer/print.ts
+++ b/apps/pdf/src/renderer/print.ts
@@ -1,13 +1,15 @@
 import type { PDFDocumentProxy } from 'pdfjs-dist'
 
-const PRINT_SCALE = 150 / 72
+const PRINT_SCALE = 300 / 72
 
 /**
- * Sequentially render pages as JPEG images into a print-only container (canvas discarded
+ * Sequentially render pages as PNG images into a print-only container (canvas discarded
  * immediately to avoid keeping full-doc hi-res bitmaps in memory), then hand off to the
  * system print dialog; clean up after it closes (including cancel).
  * Caller flushes unsaved changes and re-getDocument first — rotations/deleted pages are
  * already in the file.
+ *
+ * Uses 300 DPI with lossless PNG for maximum text clarity (issue #211).
  */
 export async function printPdf(doc: PDFDocumentProxy): Promise<void> {
   const root = document.createElement('div')
@@ -20,7 +22,8 @@ export async function printPdf(doc: PDFDocumentProxy): Promise<void> {
     canvas.height = Math.floor(viewport.height)
     await page.render({ canvas, viewport }).promise
     const img = document.createElement('img')
-    img.src = canvas.toDataURL('image/jpeg', 0.92)
+    // Use lossless PNG at 300 DPI for maximum text quality (issue #211)
+    img.src = canvas.toDataURL('image/png')
     root.appendChild(img)
   }
   canvas.width = 0

--- a/apps/pdf/tests/print.test.ts
+++ b/apps/pdf/tests/print.test.ts
@@ -52,6 +52,19 @@ describe('printPdf', () => {
     expect(document.querySelector('.pdf-print-root')).toBeNull()
   })
 
+  it('renders at 300 DPI with lossless PNG for crisp text (issue #211)', async () => {
+    const getViewport = vi.fn(({ scale }: { scale: number }) => ({
+      width: 612 * scale,
+      height: 792 * scale,
+    }))
+    const render = vi.fn(() => ({ promise: Promise.resolve() }))
+    const getPage = vi.fn(async () => ({ getViewport, render }))
+    const doc = { numPages: 1, getPage } as unknown as PDFDocumentProxy
+    await printPdf(doc)
+    expect(getViewport).toHaveBeenCalledWith({ scale: 300 / 72 })
+    expect(HTMLCanvasElement.prototype.toDataURL).toHaveBeenCalledWith('image/png')
+  })
+
   it('waits for afterprint before resolving', async () => {
     const { doc } = fakeDoc(1)
     let fireAfterPrint: () => void = () => {}


### PR DESCRIPTION
## Summary

- What changed? `printPdf` (`apps/pdf/src/renderer/print.ts`) now renders pages at 300 DPI instead of 150 DPI and encodes them as lossless PNG instead of JPEG (0.92). Adds a test asserting the 300/72 viewport scale and the `image/png` encoding.
- Why? Printed text was visibly degraded by low-resolution, lossy page images (#211).

## Related issue

Related to #211 (print-quality half; printer-settings dialog selection is out of scope).

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: `apps/pdf/tests/print.test.ts` ("renders at 300 DPI with lossless PNG for crisp text"); existing print-lifecycle tests are untouched.

## Screenshots or recordings

Not applicable (print-output fidelity; print a multi-page PDF to verify).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
