### PR TITLE
test(docs): cover mixed-width section page boxes (issue #246)

### DIFF
--- a/apps/docs/tests/pagination.test.ts
+++ b/apps/docs/tests/pagination.test.ts
@@ -2392,6 +2392,17 @@ describe('sectionPageBox — editor/preview physical page parity', () => {
     expect(letterLandscape.height).toBeCloseTo(816)
     expect(letterLandscape.footerDist).toBeCloseTo(24)
   })
+
+  it("keeps each section's own box when pages differ in width (issue #246)", () => {
+    // A4 portrait followed by a narrower page: mixed-width documents must
+    // keep per-section geometry so every page measures against its own width.
+    const portrait = sectionPageBox(sec({ pageWidth: 11906 }).settings)
+    const narrow = sectionPageBox(sec({ pageWidth: 8391 }).settings)
+    expect(portrait.width).toBeCloseTo((11906 / 1440) * 96)
+    expect(narrow.width).toBeCloseTo((8391 / 1440) * 96)
+    expect(narrow.contentWidth).toBeCloseTo(((8391 - 1440 - 1440) / 1440) * 96)
+    expect(narrow.width).toBeLessThan(portrait.width)
+  })
 })
 
 describe('tableHeaderFlags', () => {


### PR DESCRIPTION
## Summary

- What changed? Extends the `sectionPageBox` suite in `apps/docs/tests/pagination.test.ts` with a mixed-width case: an A4-portrait section and a narrower section each report their own page/content box, locking the per-section geometry that mixed-width documents (#246) depend on. No runtime change.
- Why? Guards the geometry layer behind multi-width page rendering against regressions.

## Related issue

Related to #246 (regression coverage for mixed-width section geometry; does not change runtime behavior).

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: `apps/docs/tests/pagination.test.ts` ("keeps each section's own box when pages differ in width"), extending the existing `sectionPageBox` block with its `sec()` helper.

## Screenshots or recordings

Not applicable (no UI change; test-only).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
