### PR TITLE
fix(docs): preserve scroll position when zooming

### DIFF
--- a/apps/docs/src/renderer/App.tsx
+++ b/apps/docs/src/renderer/App.tsx
@@ -516,6 +516,7 @@ export function App() {
   )
   const [status, setStatus] = useState('')
   const [zoom, setZoom] = useState(100)
+  const scrollContainerRef = useRef<HTMLElement>(null)
   // Word-style dark page (editor/dark-page.ts): on by default in the dark theme,
   // View ▸ Dark Mode flips it for the session (Word's Switch Modes); a theme
   // switch drops the override and follows the new theme again
@@ -1029,16 +1030,48 @@ export function App() {
 
   // Pinch-to-zoom: Chromium delivers trackpad pinch as a wheel event
   // with ctrlKey set. Also support ⌘+scroll. Must be non-passive to preventDefault.
+  // The cursor-anchored zoom center is stashed for the zoom effect below so a
+  // Ctrl+wheel zoom keeps the content under the cursor in place (issue #238).
+  const zoomCenterRef = useRef<{ x: number; y: number } | null>(null)
   useEffect(() => {
     const onWheel = (e: WheelEvent) => {
       if (!e.ctrlKey && !e.metaKey) return
       if (!(e.target as HTMLElement | null)?.closest?.('.editor-scroll')) return
       e.preventDefault()
+      const container = scrollContainerRef.current
+      if (container) {
+        const rect = container.getBoundingClientRect()
+        zoomCenterRef.current = {
+          x: e.clientX - rect.left + container.scrollLeft,
+          y: e.clientY - rect.top + container.scrollTop,
+        }
+      }
       setZoom((z) => Math.min(200, Math.max(50, z - e.deltaY * 0.6)))
     }
     window.addEventListener('wheel', onWheel, { passive: false })
     return () => window.removeEventListener('wheel', onWheel)
   }, [])
+
+  // Preserve scroll position when zoom changes (issue #238): rescale the
+  // scroll offsets around the zoom anchor (cursor for wheel zoom, viewport
+  // center for slider/menu/ribbon zoom) so the visible page stays in view.
+  const prevZoomRef = useRef(zoom)
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const prevZoom = prevZoomRef.current
+    if (prevZoom === zoom) return
+    prevZoomRef.current = zoom
+
+    const ratio = zoom / prevZoom
+    const anchor = zoomCenterRef.current
+    const centerX = anchor ? anchor.x : container.scrollLeft + container.clientWidth / 2
+    const centerY = anchor ? anchor.y : container.scrollTop + container.clientHeight / 2
+    zoomCenterRef.current = null
+
+    container.scrollLeft = centerX * ratio - container.clientWidth / 2
+    container.scrollTop = centerY * ratio - container.clientHeight / 2
+  }, [zoom])
 
   // ---- protection enforcement (Review > Protect Document) ----
   const editRestriction = protection?.enforced ? protection.edit : null
@@ -4585,7 +4618,7 @@ export function App() {
               />
             )}
             <div className="editor-area">
-              <main className="editor-scroll">
+              <main className="editor-scroll" ref={scrollContainerRef}>
                 {doc ? (
                   <div
                     className={docZoomClass}


### PR DESCRIPTION
## Summary

- What changed? `apps/docs/src/renderer/App.tsx` now preserves the viewing position across zoom changes: the Ctrl/⌘+wheel handler stashes the cursor-anchored document point in a ref, and a zoom effect rescales the scroll offsets around that anchor (viewport center for slider/menu/ribbon zoom) so the visible page stays in view.
- Why? Changing zoom (Ctrl+wheel or the zoom slider) scrolled the document to a different page (#238).

## Related issue

Fixes #238.

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. Verified by reading: anchor math (`scroll = center * (newZoom / oldZoom) - viewport / 2`), ref (not DOM dataset) storage, `HTMLElement` ref typing for the `<main>` scroll container.

## Screenshots or recordings

Not applicable (scroll-position behavior; zoom in/out on a multi-page document to verify the page stays put).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
