### PR TITLE
fix(ai-provider): omit temperature for OpenAI o-series reasoning models

### DIFF
--- a/packages/ai-provider/src/registry.ts
+++ b/packages/ai-provider/src/registry.ts
@@ -40,13 +40,14 @@ function metaOf(id: AiProviderId): AiProviderMeta {
  * route — vendor API, the Genspark proxy, OpenRouter's vendor-prefixed ids,
  * or a mirror behind a custom base URL. Kimi K3 answers "only 1 is allowed";
  * OpenAI's GPT-5 reasoning family rejects any temperature other than the
- * default outright. Google's Gemini 3 docs strongly recommend keeping the
- * default temperature of 1.0 for the whole Gemini 3 family, since lower
+ * default outright, and the o-series reasoning models (o1/o3/o4) likewise
+ * only accept the default. Google's Gemini 3 docs strongly recommend keeping
+ * the default temperature of 1.0 for the whole Gemini 3 family, since lower
  * values may cause looping or degraded reasoning, so our hard-coded 0.3
  * must not be sent there either.
  */
 export function modelHasFixedSampling(model: string): boolean {
-  return /(^|\/)(kimi-k3|gpt-5|gemini-3)/.test(model)
+  return /(^|\/)(kimi-k3|gpt-5|gemini-3|o1(-mini|-preview)?|o3(-mini)?|o4-mini)/.test(model)
 }
 
 /**

--- a/packages/ai-provider/tests/registry.test.ts
+++ b/packages/ai-provider/tests/registry.test.ts
@@ -73,6 +73,23 @@ describe('provider registry', () => {
     }
   })
 
+  it('marks the OpenAI o-series reasoning models as fixed-sampling', () => {
+    for (const model of ['o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o4-mini']) {
+      expect(AI_PROVIDER_ADAPTERS.openai.resolveEndpoint(config(model))).toEqual({
+        protocol: 'openai-compatible',
+        baseUrl: 'https://api.openai.com/v1',
+        omitTemperature: true,
+        useMaxCompletionTokens: true,
+      })
+    }
+    // Non-reasoning models still carry the configured temperature.
+    expect(AI_PROVIDER_ADAPTERS.openai.resolveEndpoint(config('gpt-4o'))).toEqual({
+      protocol: 'openai-compatible',
+      baseUrl: 'https://api.openai.com/v1',
+      useMaxCompletionTokens: true,
+    })
+  })
+
   it('resolves the catalog additions to their OpenAI-compatible endpoints', () => {
     const cases: Array<[AiProviderId, string, string]> = [
       ['glm', 'glm-5.3', 'https://open.bigmodel.cn/api/paas/v4'],


### PR DESCRIPTION
## Summary

- What changed? `modelHasFixedSampling` (`packages/ai-provider/src/registry.ts`) now also matches OpenAI's o-series reasoning models (`o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, `o4-mini`), so every route (direct OpenAI, Codex CLI entries, custom mirrors, OpenCode gateways) omits the temperature field for them instead of sending the hard-coded 0.3 the API rejects. Test asserts the endpoint shape for all six ids plus a negative control (`gpt-4o` still carries temperature).
- Why? The Codex model list (and any o-series selection) would otherwise fail with temperature rejections, the same class of bug the GPT-5 family fix addressed.

## Related issue

Related to #212 (the Codex CLI catalog lists `o1-preview`/`o1-mini`, which need this routing to work).

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: `packages/ai-provider/tests/registry.test.ts` ("marks the OpenAI o-series reasoning models as fixed-sampling"); verified the regex against every model id in the catalog for over-matching.

## Screenshots or recordings

Not applicable (request-shape fix; no UI change).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
