### PR TITLE
test(markdown): cover print HTML builder output

### DIFF
--- a/apps/markdown/tests/print-html.test.ts
+++ b/apps/markdown/tests/print-html.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildPrintHtml } from '../src/renderer/export/printHtml'
+
+// The KaTeX stylesheet is inlined with Vite's `?inline` query; stub it so the
+// test asserts the builder's own behavior rather than the bundler's.
+vi.mock('katex/dist/katex.min.css?inline', () => ({ default: '' }))
+
+function editorRoot(innerHtml: string): HTMLElement {
+  const root = document.createElement('div')
+  root.setAttribute('contenteditable', 'true')
+  root.innerHTML = innerHtml
+  return root
+}
+
+describe('buildPrintHtml', () => {
+  it('builds a self-contained document with base, title, and styles', () => {
+    const html = buildPrintHtml(editorRoot('<h1>Hello</h1><p>World</p>'), 'Notes')
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('<base href="')
+    expect(html).toContain('<title>Notes</title>')
+    // KaTeX stylesheet plus the print-theme stylesheet.
+    expect(html.match(/<style>/g)?.length).toBeGreaterThanOrEqual(2)
+    expect(html).toContain('<h1>Hello</h1>')
+  })
+
+  it('escapes the document title', () => {
+    const html = buildPrintHtml(editorRoot('<p>x</p>'), 'A&B <C>')
+    expect(html).toContain('<title>A&amp;B &lt;C></title>')
+    expect(html).not.toContain('<title>A&B <C></title>')
+  })
+
+  it('strips editor-only chrome from the clone', () => {
+    const html = buildPrintHtml(
+      editorRoot(
+        '<p contenteditable="true">text</p>' +
+          '<div class="md-codeblock-bar"><button>copy</button></div>',
+      ),
+      'Notes',
+    )
+    expect(html).not.toContain('contenteditable')
+    expect(html).not.toContain('md-codeblock-bar')
+    expect(html).toContain('<p>text</p>')
+  })
+})


### PR DESCRIPTION
## Summary

- What changed? Adds `apps/markdown/tests/print-html.test.ts` covering the print HTML builder's pre-existing behavior: self-contained document structure (doctype, base, title, both stylesheets), title escaping, stripping of `contenteditable` attributes, and removal of editor-only code-block chrome. No runtime change.
- Why? The builder had no coverage; this locks its contract for the print-quality work shipping alongside it.

## Related issue

Related to #211 (covers the markdown print builder; does not change runtime behavior).

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test asserts only pre-existing behavior, so it passes with or without the print-CSS changes.

## Screenshots or recordings

Not applicable (no UI change; test-only).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
