### PR TITLE
Fix Slides PDF export for large presentations

### DIFF
--- a/apps/slides/src/main/pdf-export.ts
+++ b/apps/slides/src/main/pdf-export.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export interface PdfExportWindow {
+  loadFile(path: string): Promise<void>
+  webContents: {
+    executeJavaScript(script: string, userGesture?: boolean): Promise<unknown>
+    printToPDF(options: Electron.PrintToPDFOptions): Promise<Buffer>
+  }
+  destroy(): void
+}
+
+export interface ExportSlidesPdfOptions {
+  pngsBase64: string[]
+  widthPx: number
+  heightPx: number
+  filePath: string
+  createWindow(): PdfExportWindow
+  openExportedPdf(path: string): void
+}
+
+export interface ExportSlidesPdfResult {
+  ok: boolean
+  path?: string
+  error?: string
+}
+
+function buildPdfExportHtml(pngsBase64: string[], widthIn: number, heightIn: number): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+@page { size: ${widthIn}in ${heightIn}in; margin: 0; }
+html, body { margin: 0; padding: 0; }
+.page { width: ${widthIn}in; height: ${heightIn}in; overflow: hidden; page-break-after: always; }
+.page:last-child { page-break-after: auto; }
+.page img { display: block; width: 100%; height: 100%; }
+</style></head><body>${pngsBase64
+    .map((b64) => `<div class="page"><img src="data:image/png;base64,${b64}"></div>`)
+    .join('')}</body></html>`
+}
+
+/** Export rendered slide PNGs via an app-owned temporary HTML file. */
+export async function exportSlidesPdf({
+  pngsBase64,
+  widthPx,
+  heightPx,
+  filePath,
+  createWindow,
+  openExportedPdf,
+}: ExportSlidesPdfOptions): Promise<ExportSlidesPdfResult> {
+  // PDF page size: fixed 7.5in height, width by slide ratio (16:9 -> 13.333in, 4:3 -> 10in)
+  const heightIn = 7.5
+  const widthIn = Math.round((widthPx / heightPx) * heightIn * 1000) / 1000
+  const win = createWindow()
+  let tempDir: string | null = null
+  try {
+    tempDir = await mkdtemp(join(tmpdir(), 'genoffice-slides-pdf-'))
+    const htmlPath = join(tempDir, 'slides.html')
+    await writeFile(htmlPath, buildPdfExportHtml(pngsBase64, widthIn, heightIn), 'utf8')
+    await win.loadFile(htmlPath)
+    // Wait for fonts and all images to decode before printing, avoiding blank pages
+    await win.webContents.executeJavaScript(
+      'Promise.all([document.fonts.ready, ...Array.from(document.images).map((i) => i.decode().catch(() => {}))])',
+      true,
+    )
+    const pdf = await win.webContents.printToPDF({
+      landscape: false, // The page size is already landscape (width > height); passing landscape would rotate a second time
+      printBackground: true,
+      pageSize: { width: widthIn, height: heightIn },
+      margins: { top: 0, bottom: 0, left: 0, right: 0 },
+      preferCSSPageSize: false,
+    })
+    await writeFile(filePath, pdf)
+    openExportedPdf(filePath)
+    return { ok: true, path: filePath }
+  } catch (err) {
+    return { ok: false, error: String(err) }
+  } finally {
+    try {
+      win.destroy()
+    } finally {
+      if (tempDir) await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+}

--- a/apps/slides/src/main/slides-main.ts
+++ b/apps/slides/src/main/slides-main.ts
@@ -26,6 +26,7 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { userInfo } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { cleanupExpiredGeneratedPages } from './generated-page-temp'
+import { exportSlidesPdf } from './pdf-export'
 import { gskApiKey, gskSlideGenerate, setGskProxyUrl } from '@genoffice/ai-search'
 import {
   appMenuLabels,
@@ -4122,41 +4123,11 @@ export function registerSlidesIpc(): void {
   })
 
   ipcMain.handle('slides:export-pdf', async (_e, op: ExportPdfOp): Promise<ExportPdfResult> => {
-    // PDF page size: fixed 7.5in height, width by slide ratio (16:9 -> 13.333in, 4:3 -> 10in)
-    const heightIn = 7.5
-    const widthIn = Math.round((op.widthPx / op.heightPx) * heightIn * 1000) / 1000
-    const html = `<!doctype html><html><head><meta charset="utf-8"><style>
-@page { size: ${widthIn}in ${heightIn}in; margin: 0; }
-html, body { margin: 0; padding: 0; }
-.page { width: ${widthIn}in; height: ${heightIn}in; overflow: hidden; page-break-after: always; }
-.page:last-child { page-break-after: auto; }
-.page img { display: block; width: 100%; height: 100%; }
-</style></head><body>${op.pngsBase64
-      .map((b64) => `<div class="page"><img src="data:image/png;base64,${b64}"></div>`)
-      .join('')}</body></html>`
-    const win = new BrowserWindow({ show: false, webPreferences: { sandbox: true } })
-    try {
-      await win.loadURL('data:text/html;base64,' + Buffer.from(html, 'utf8').toString('base64'))
-      // Wait for fonts and all images to decode before printing, avoiding blank pages
-      await win.webContents.executeJavaScript(
-        'Promise.all([document.fonts.ready, ...Array.from(document.images).map((i) => i.decode().catch(() => {}))])',
-        true,
-      )
-      const pdf = await win.webContents.printToPDF({
-        landscape: false, // The page size is already landscape (width > height); passing landscape would rotate a second time
-        printBackground: true,
-        pageSize: { width: widthIn, height: heightIn },
-        margins: { top: 0, bottom: 0, left: 0, right: 0 },
-        preferCSSPageSize: false,
-      })
-      await writeFile(op.filePath, pdf)
-      openExportedPdf(op.filePath)
-      return { ok: true, path: op.filePath }
-    } catch (err) {
-      return { ok: false, error: String(err) }
-    } finally {
-      win.destroy()
-    }
+    return exportSlidesPdf({
+      ...op,
+      createWindow: () => new BrowserWindow({ show: false, webPreferences: { sandbox: true } }),
+      openExportedPdf,
+    })
   })
 
   ipcMain.handle(

--- a/apps/slides/tests/pdf-export.test.ts
+++ b/apps/slides/tests/pdf-export.test.ts
@@ -1,0 +1,161 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { PNG } from 'pngjs'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { exportSlidesPdf, type PdfExportWindow } from '../src/main/pdf-export'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function outputPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'genoffice-slides-pdf-test-'))
+  roots.push(root)
+  return join(root, 'export.pdf')
+}
+
+function singlePixelPngBase64(): string {
+  const png = new PNG({ width: 1, height: 1 })
+  png.data.set([0x12, 0x34, 0x56, 0xff])
+  return PNG.sync.write(png).toString('base64')
+}
+
+function deterministicNoisePngBase64(): string {
+  const png = new PNG({ width: 800, height: 800 })
+  let state = 0x12345678
+  const nextByte = (): number => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state >>> 24
+  }
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = nextByte()
+    png.data[i + 1] = nextByte()
+    png.data[i + 2] = nextByte()
+    png.data[i + 3] = 255
+  }
+  return PNG.sync.write(png).toString('base64')
+}
+
+class TestPdfWindow implements PdfExportWindow {
+  loadedPath: string | null = null
+  loadedHtml = ''
+  destroyed = false
+  tempDirectoryExistedAtDestroy: boolean | null = null
+  shouldFailLoad = false
+  shouldFailPrint = false
+  executedScript: string | null = null
+  executedWithUserGesture: boolean | undefined
+  printOptions: Electron.PrintToPDFOptions | null = null
+
+  async loadFile(path: string): Promise<void> {
+    this.loadedPath = path
+    this.loadedHtml = await readFile(path, 'utf8')
+    if (this.shouldFailLoad) throw new Error('load failed')
+  }
+
+  webContents = {
+    executeJavaScript: async (script: string, userGesture?: boolean): Promise<void> => {
+      this.executedScript = script
+      this.executedWithUserGesture = userGesture
+    },
+    printToPDF: async (options: Electron.PrintToPDFOptions): Promise<Buffer> => {
+      this.printOptions = options
+      if (this.shouldFailPrint) throw new Error('print failed')
+      return Buffer.from('PDF')
+    },
+  }
+
+  destroy(): void {
+    if (this.loadedPath) this.tempDirectoryExistedAtDestroy = existsSync(dirname(this.loadedPath))
+    this.destroyed = true
+  }
+}
+
+describe('slides PDF export', () => {
+  it('loads a temporary HTML file containing all PNGs, writes the PDF, then removes the directory', async () => {
+    const win = new TestPdfWindow()
+    const filePath = await outputPath()
+    const opened: string[] = []
+    const chromiumDataUrlLimit = 2 * 1024 * 1024
+    const firstPng = singlePixelPngBase64()
+    const secondPng = deterministicNoisePngBase64()
+    const decodedSecondPng = PNG.sync.read(Buffer.from(secondPng, 'base64'))
+
+    expect(decodedSecondPng.width).toBeGreaterThan(0)
+    expect(decodedSecondPng.height).toBeGreaterThan(0)
+
+    const result = await exportSlidesPdf({
+      pngsBase64: [firstPng, secondPng],
+      widthPx: 1600,
+      heightPx: 900,
+      filePath,
+      createWindow: () => win,
+      openExportedPdf: (path) => opened.push(path),
+    })
+
+    expect(result).toEqual({ ok: true, path: filePath })
+    expect(basename(win.loadedPath!)).toBe('slides.html')
+    expect(basename(dirname(win.loadedPath!))).toMatch(/^genoffice-slides-pdf-/)
+    expect(win.loadedHtml).toContain(`data:image/png;base64,${firstPng}`)
+    expect(win.loadedHtml.length).toBeGreaterThan(chromiumDataUrlLimit)
+    expect(win.loadedHtml.endsWith(`${secondPng}"></div></body></html>`)).toBe(true)
+    expect(win.loadedHtml).toContain('@page { size: 13.333in 7.5in; margin: 0; }')
+    expect(win.executedScript).toContain('document.fonts.ready')
+    expect(win.executedWithUserGesture).toBe(true)
+    expect(win.printOptions).toEqual({
+      landscape: false,
+      printBackground: true,
+      pageSize: { width: 13.333, height: 7.5 },
+      margins: { top: 0, bottom: 0, left: 0, right: 0 },
+      preferCSSPageSize: false,
+    })
+    await expect(readFile(filePath)).resolves.toEqual(Buffer.from('PDF'))
+    expect(opened).toEqual([filePath])
+    expect(existsSync(dirname(win.loadedPath!))).toBe(false)
+    expect(win.destroyed).toBe(true)
+    expect(win.tempDirectoryExistedAtDestroy).toBe(true)
+  })
+
+  it('removes the temporary directory and destroys the window when loading fails', async () => {
+    const win = new TestPdfWindow()
+    win.shouldFailLoad = true
+
+    const result = await exportSlidesPdf({
+      pngsBase64: ['png'],
+      widthPx: 4,
+      heightPx: 3,
+      filePath: await outputPath(),
+      createWindow: () => win,
+      openExportedPdf: () => {},
+    })
+
+    expect(result).toEqual({ ok: false, error: 'Error: load failed' })
+    expect(win.loadedPath).not.toBeNull()
+    expect(existsSync(dirname(win.loadedPath!))).toBe(false)
+    expect(win.destroyed).toBe(true)
+  })
+
+  it('removes the temporary directory and destroys the window when PDF printing fails', async () => {
+    const win = new TestPdfWindow()
+    win.shouldFailPrint = true
+
+    const result = await exportSlidesPdf({
+      pngsBase64: ['png'],
+      widthPx: 4,
+      heightPx: 3,
+      filePath: await outputPath(),
+      createWindow: () => win,
+      openExportedPdf: () => {},
+    })
+
+    expect(result).toEqual({ ok: false, error: 'Error: print failed' })
+    expect(win.loadedPath).not.toBeNull()
+    expect(existsSync(dirname(win.loadedPath!))).toBe(false)
+    expect(win.destroyed).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Load the Slides PDF print document from a temporary HTML file instead of a top-level Base64 data URL.
- Preserve the existing slide rendering, page sizing, image decoding wait, PDF options, output, and open-after-export behavior.
- Add regression coverage for valid PNG content larger than Chromium's navigation URL limit and for temporary-file cleanup on success and failure.

This is needed because encoding every rendered slide PNG inside an HTML data URL can exceed Chromium's navigation URL limit and fail with `ERR_INVALID_URL (-300)` for large presentations.

## Related issue

Not linked.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`

Full `npm test` was not run because the local environment has no Rust `cargo` for the Sheets sidecar, and two pre-existing macOS system-font assertions differ on this machine. Validation performed instead:

- `npx vitest run --exclude tests/system-fonts.test.ts` in `apps/slides`: 702 tests passed
- `npm test -- --run tests/pdf-export.test.ts` in `apps/slides`: 3 tests passed
- `npm run build` in `apps/slides`
- Manual export of the presentation that originally reproduced `ERR_INVALID_URL (-300)`

`npm run lint` completed with 0 errors and 12 existing warnings outside this change.

## Screenshots or recordings

Not applicable. This fixes an export failure without changing the UI.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. No strings were added or changed.
- [x] File open/save changes include an appropriate round-trip or fidelity test. The PDF export path has regression coverage for complete image payloads and output bytes.
