### PR TITLE
fix(docs): resolve the @genoffice/ai-provider/browser subpath in vitest

### DIFF
--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '@genoffice/docx-engine': local('../../packages/docx-engine/src/index.ts'),
       '@genoffice/font-metrics': local('../../packages/font-metrics/src/index.ts'),
       '@genoffice/electron-utils': local('../../packages/electron-utils/src/index.ts'),
+      '@genoffice/ai-provider/browser': local('../../packages/ai-provider/src/browser.ts'),
       '@genoffice/ai-provider': local('../../packages/ai-provider/src/index.ts'),
       '@genoffice/i18n': local('../../packages/i18n/src/index.ts'),
       '@genoffice/ui': local('../../packages/ui/src/index.ts'),


### PR DESCRIPTION
## Summary

Follow-up to #267. The docs vitest config aliases the bare `@genoffice/ai-provider` name to `src/index.ts` as a string prefix, so the new `/browser` entry point resolved to `index.ts/browser` and the four suites that import `src/shared/ipc.ts` failed to load. Adding the subpath alias ahead of the bare one restores resolution; `npm test -w @genoffice/docs` passes locally (197 files).

## Validation

- [x] `npm test -w @genoffice/docs`
- [x] `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)