### PR TITLE
fix(pdf): align highlight and underline geometry

### DIFF
--- a/apps/pdf/src/renderer/annotations.ts
+++ b/apps/pdf/src/renderer/annotations.ts
@@ -94,6 +94,83 @@ export function quadSetsMatch(a: number[][], b: number[][], tol = 2): boolean {
   return true
 }
 
+interface ViewRect {
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+interface SelectionLine {
+  crossStart: number
+  crossEnd: number
+  minCrossSize: number
+  rects: ViewRect[]
+}
+
+const crossBounds = (r: ViewRect): [number, number] => [r.top, r.bottom]
+
+const mainBounds = (r: ViewRect): [number, number] => [r.left, r.right]
+
+const rectBounds = (rects: readonly ViewRect[]): ViewRect => ({
+  left: Math.min(...rects.map((r) => r.left)),
+  right: Math.max(...rects.map((r) => r.right)),
+  top: Math.min(...rects.map((r) => r.top)),
+  bottom: Math.max(...rects.map((r) => r.bottom)),
+})
+
+/** Pick the one common line band that overlaps most; ties stay independent. */
+function matchingLine(lines: readonly SelectionLine[], rect: ViewRect): SelectionLine | null {
+  const [start, end] = crossBounds(rect)
+  const crossSize = end - start
+  let match: SelectionLine | null = null
+  let bestOverlap = -1
+  let tied = false
+  for (const line of lines) {
+    const overlap = Math.min(end, line.crossEnd) - Math.max(start, line.crossStart)
+    if (overlap * 2 < Math.min(crossSize, line.minCrossSize)) continue
+    if (overlap > bestOverlap) {
+      match = line
+      bestOverlap = overlap
+      tied = false
+    } else if (overlap === bestOverlap) tied = true
+  }
+  return tied ? null : match
+}
+
+/** Unify each nearby fragment cluster on a visual line, without crossing wide gaps. */
+function normalizeSelectionRects(rects: readonly ViewRect[]): ViewRect[] {
+  const lineBands: SelectionLine[] = []
+  for (const rect of rects) {
+    const [crossStart, crossEnd] = crossBounds(rect)
+    const crossSize = crossEnd - crossStart
+    const line = matchingLine(lineBands, rect)
+    if (line) {
+      line.crossStart = Math.max(line.crossStart, crossStart)
+      line.crossEnd = Math.min(line.crossEnd, crossEnd)
+      line.minCrossSize = Math.min(line.minCrossSize, crossSize)
+      line.rects.push(rect)
+    } else lineBands.push({ crossStart, crossEnd, minCrossSize: crossSize, rects: [rect] })
+  }
+
+  return lineBands.flatMap((line) => {
+    const clusters: ViewRect[][] = []
+    for (const rect of line.rects) {
+      const previous = clusters.at(-1)
+      if (!previous) {
+        clusters.push([rect])
+        continue
+      }
+      const [previousStart, previousEnd] = mainBounds(rectBounds(previous))
+      const [start, end] = mainBounds(rect)
+      const gap = Math.max(start - previousEnd, previousStart - end, 0)
+      if (gap <= line.minCrossSize / 2) previous.push(rect)
+      else clusters.push([rect])
+    }
+    return clusters.map(rectBounds)
+  })
+}
+
 /**
  * Current selection → PDF-coordinate quads grouped by visible page (y up; each quad
  * [x1,yMax,x2,yMax,x1,yMin,x2,yMin]). Returns null when the selection is empty.
@@ -127,7 +204,7 @@ export function selectionQuadsByPage(
       ),
   )
 
-  const byPage = new Map<number, number[][]>()
+  const rectsByPage = new Map<number, ViewRect[]>()
   const seen = new Set<string>()
   for (const r of rects) {
     const cx = (r.left + r.right) / 2
@@ -136,19 +213,28 @@ export function selectionQuadsByPage(
       (p) => cx >= p.left && cx <= p.right && cy >= p.top && cy <= p.bottom,
     )
     if (idx < 0 || !geoms[idx]) continue
-    const p = pageRects[idx]!
-    const g = geoms[idx]!
-    const [ax, ay] = viewToPdf(g, (r.left - p.left) / scale, (r.top - p.top) / scale)
-    const [bx, by] = viewToPdf(g, (r.right - p.left) / scale, (r.bottom - p.top) / scale)
-    const [x1, x2] = [Math.min(ax, bx), Math.max(ax, bx)]
-    const [yMin, yMax] = [Math.min(ay, by), Math.max(ay, by)]
-    const key = `${idx}:${Math.round(x1)}:${Math.round(x2)}:${Math.round(yMin)}:${Math.round(yMax)}`
+    const key = `${idx}:${Math.round(r.left)}:${Math.round(r.right)}:${Math.round(r.top)}:${Math.round(r.bottom)}`
     if (seen.has(key)) continue
     seen.add(key)
-    const quad = [x1, yMax, x2, yMax, x1, yMin, x2, yMin]
-    const list = byPage.get(idx)
-    if (list) list.push(quad)
-    else byPage.set(idx, [quad])
+    const list = rectsByPage.get(idx)
+    if (list) list.push(r)
+    else rectsByPage.set(idx, [r])
+  }
+
+  const byPage = new Map<number, number[][]>()
+  for (const [idx, pageSelectionRects] of rectsByPage) {
+    const p = pageRects[idx]!
+    const g = geoms[idx]!
+    const rects =
+      normRot(g.rot) % 180 === 0 ? normalizeSelectionRects(pageSelectionRects) : pageSelectionRects
+    const quads = rects.map((r) => {
+      const [ax, ay] = viewToPdf(g, (r.left - p.left) / scale, (r.top - p.top) / scale)
+      const [bx, by] = viewToPdf(g, (r.right - p.left) / scale, (r.bottom - p.top) / scale)
+      const [x1, x2] = [Math.min(ax, bx), Math.max(ax, bx)]
+      const [yMin, yMax] = [Math.min(ay, by), Math.max(ay, by)]
+      return [x1, yMax, x2, yMax, x1, yMin, x2, yMin]
+    })
+    if (quads.length > 0) byPage.set(idx, quads)
   }
   return byPage.size > 0 ? byPage : null
 }

--- a/apps/pdf/tests/annotations.test.ts
+++ b/apps/pdf/tests/annotations.test.ts
@@ -136,13 +136,16 @@ describe('selectionQuadsByPage', () => {
       height: bottom - top,
     }) as DOMRect
 
-  function setupPage(): { scrollEl: HTMLElement; pageEl: HTMLElement } {
+  function setupPage(pageRect = domRect(0, 0, 100, 200)): {
+    scrollEl: HTMLElement
+    pageEl: HTMLElement
+  } {
     const scrollEl = document.createElement('div')
     const pageEl = document.createElement('div')
     pageEl.className = 'pdf-page'
     scrollEl.appendChild(pageEl)
     document.body.appendChild(scrollEl)
-    vi.spyOn(pageEl, 'getBoundingClientRect').mockReturnValue(domRect(0, 0, 100, 200))
+    vi.spyOn(pageEl, 'getBoundingClientRect').mockReturnValue(pageRect)
     return { scrollEl, pageEl }
   }
 
@@ -215,5 +218,93 @@ describe('selectionQuadsByPage', () => {
     mockSelection(scrollEl, [domRect(20, 40, 100, 60)])
     const result = selectionQuadsByPage(scrollEl, [geom(0)], 2)
     expect(result!.get(0)).toEqual([[10, 180, 50, 180, 10, 170, 50, 170]])
+  })
+
+  it('normalizes mixed-height fragments on one visual line and bridges a word-sized gap', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [domRect(10, 20, 30, 32), domRect(35, 16, 80, 30)])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 184, 80, 184, 10, 168, 80, 168],
+    ])
+  })
+
+  it('normalizes each visual line independently in a multiline selection', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [
+      domRect(10, 20, 30, 32),
+      domRect(35, 16, 80, 30),
+      domRect(10, 50, 30, 62),
+      domRect(35, 46, 80, 60),
+    ])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 184, 80, 184, 10, 168, 80, 168],
+      [10, 154, 80, 154, 10, 138, 80, 138],
+    ])
+  })
+
+  it('keeps wide-gap fragments at their own vertical bounds', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [domRect(10, 20, 30, 32), domRect(70, 16, 90, 30)])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 180, 30, 180, 10, 168, 30, 168],
+      [70, 184, 90, 184, 70, 170, 90, 170],
+    ])
+  })
+
+  it('does not bridge a third line through an overlapping short fragment', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [
+      domRect(10, 10, 30, 20),
+      domRect(35, 15, 55, 25),
+      domRect(60, 20, 80, 30),
+    ])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 190, 55, 190, 10, 175, 55, 175],
+      [60, 180, 80, 180, 60, 170, 80, 170],
+    ])
+  })
+
+  it('keeps a fragment that equally overlaps two line bands independent', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [
+      domRect(10, 10, 30, 20),
+      domRect(60, 30, 80, 40),
+      domRect(35, 15, 55, 35),
+    ])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 190, 30, 190, 10, 180, 30, 180],
+      [60, 170, 80, 170, 60, 160, 80, 160],
+      [35, 185, 55, 185, 35, 165, 55, 165],
+    ])
+  })
+
+  it('does not let progressively eroded overlaps bridge every line into one group', () => {
+    const { scrollEl } = setupPage()
+    mockSelection(scrollEl, [
+      domRect(10, 10, 20, 20),
+      domRect(25, 15, 35, 25),
+      domRect(40, 17.5, 50, 27.5),
+      domRect(55, 18.75, 65, 28.75),
+    ])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(0)], 1)!.get(0)).toEqual([
+      [10, 190, 35, 190, 10, 175, 35, 175],
+      [40, 182.5, 65, 182.5, 40, 171.25, 65, 171.25],
+    ])
+  })
+
+  it.each([
+    [90, [10, 32, 30, 32, 10, 20, 30, 20], [35, 30, 80, 30, 35, 16, 80, 16]],
+    [270, [70, 180, 90, 180, 70, 168, 90, 168], [20, 184, 65, 184, 20, 170, 65, 170]],
+  ])('keeps sideways page rectangles unnormalized at %i degrees', (rot, first, second) => {
+    const { scrollEl } = setupPage(domRect(0, 0, 200, 100))
+    mockSelection(scrollEl, [domRect(20, 10, 32, 30), domRect(16, 35, 30, 80)])
+
+    expect(selectionQuadsByPage(scrollEl, [geom(rot)], 1)!.get(0)).toEqual([first, second])
   })
 })


### PR DESCRIPTION
## Summary

- Normalize adjacent PDF.js selection fragments to a shared visual-line height so highlights and underlines stay aligned.
- Bridge word-sized gaps while keeping wide gaps and separate lines independent.
- Preserve the existing per-rectangle behavior for 90/270-degree pages and add regression coverage for grouping edge cases.

## Related issue

No linked issue.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; 12 pre-existing warnings)
- [x] `npm run typecheck`
- [ ] `npm test`
- [x] `npm run test -w @genoffice/pdf` (43 files, 683 tests)
- [x] Manual validation with a mixed Chinese/Latin PDF at 186% zoom

`npm test` is not fully green in this local environment: 4 existing `packages/electron-utils/tests/remote-image.test.ts` cases depend on live DNS resolution of `sspark.genspark.ai`, which is blocked before their injected fetch mock runs. This branch does not modify `packages/electron-utils`.

## Screenshots or recordings

Not attached; the visible highlight and underline alignment was manually verified in the full GenOffice development shell.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test. Not applicable: no file open/save behavior changed.