### PR TITLE
fix(sheets): use -1 for unfrozen axis when opening frozen panes

### DIFF
--- a/apps/sheets/src/renderer/univer-sync.ts
+++ b/apps/sheets/src/renderer/univer-sync.ts
@@ -362,6 +362,26 @@ export function applyFormatPatchToRange(
   }
 }
 
+/**
+ * File freeze state mapped onto Univer's `setFreeze` shape for workbook open.
+ * Univer uses -1 as the "no freeze on this axis" sentinel (see the
+ * freeze-top-row/freeze-first-col commands); a literal 0 start misaligns the
+ * frozen viewport or opens the grid blank, so an unfrozen axis maps to -1.
+ */
+export function toUniverFreeze(freeze: { frozenRows: number; frozenColumns: number } | null): {
+  freeze?: { xSplit: number; ySplit: number; startRow: number; startColumn: number }
+} {
+  if (freeze === null) return {}
+  return {
+    freeze: {
+      xSplit: freeze.frozenColumns,
+      ySplit: freeze.frozenRows,
+      startRow: freeze.frozenRows === 0 ? -1 : freeze.frozenRows,
+      startColumn: freeze.frozenColumns === 0 ? -1 : freeze.frozenColumns,
+    },
+  }
+}
+
 export function loadWorkbookSkeleton(runtime: UniverRuntime | null, file: WorkbookFile): void {
   if (!runtime) return
   const activeWorkbook = runtime.univerAPI.getActiveWorkbook()
@@ -422,16 +442,7 @@ export function loadWorkbookSkeleton(runtime: UniverRuntime | null, file: Workbo
             defaultColumnWidth: characterWidthToPixels(
               sheet.defaultColumnWidth ?? paddedBaseColumnWidth(sheet.baseColumnWidth),
             ),
-            ...(sheet.freeze === null
-              ? {}
-              : {
-                  freeze: {
-                    xSplit: sheet.freeze.frozenColumns,
-                    ySplit: sheet.freeze.frozenRows,
-                    startRow: sheet.freeze.frozenRows,
-                    startColumn: sheet.freeze.frozenColumns,
-                  },
-                }),
+            ...toUniverFreeze(sheet.freeze),
             // Excel restores the saved normal-view zoom on open; without it
             // a sheet authored at 70% opens cropped to the 100% viewport.
             ...(sheet.zoomScale === undefined ? {} : { zoomRatio: sheet.zoomScale / 100 }),

--- a/apps/sheets/tests/univer-range-loading.test.ts
+++ b/apps/sheets/tests/univer-range-loading.test.ts
@@ -159,6 +159,67 @@ describe('loadWorkbookSkeleton', () => {
       columnCount: 26,
     })
   })
+
+  it('maps an unfrozen axis to the -1 sentinel on open (issue #196)', () => {
+    const openWithFreeze = (freeze: { frozenRows: number; frozenColumns: number } | null) => {
+      const created: Array<{ sheets: Record<string, { freeze?: unknown }> }> = []
+      const runtime = {
+        univer: undoStub,
+        univerAPI: {
+          getActiveWorkbook: () => null,
+          disposeUnit: () => undefined,
+          createWorkbook: (config: (typeof created)[number]) => {
+            created.push(config)
+            return { getSheetBySheetId: () => null, setActiveSheet: () => undefined }
+          },
+        },
+      }
+      const file = {
+        sha256: 'frozen',
+        name: 'Frozen.xlsx',
+        visuals: [],
+        sheets: [
+          {
+            id: 'sheet-1',
+            name: 'Sheet1',
+            rowCount: 10,
+            columnCount: 5,
+            hidden: false,
+            showGridLines: true,
+            tabColor: null,
+            defaultRowHeight: null,
+            defaultColumnWidth: null,
+            freeze,
+            columnWidths: [],
+          },
+        ],
+      }
+      loadWorkbookSkeleton(runtime as never, file as never)
+      return created[0]?.sheets['sheet-1'] as { freeze?: unknown }
+    }
+
+    // Rows-only and columns-only freezes keep -1 on the unfrozen axis, matching
+    // the in-app freeze commands; a literal 0 start misaligns the viewport.
+    expect(openWithFreeze({ frozenRows: 1, frozenColumns: 0 }).freeze).toEqual({
+      xSplit: 0,
+      ySplit: 1,
+      startRow: 1,
+      startColumn: -1,
+    })
+    expect(openWithFreeze({ frozenRows: 0, frozenColumns: 1 }).freeze).toEqual({
+      xSplit: 1,
+      ySplit: 0,
+      startRow: -1,
+      startColumn: 1,
+    })
+    expect(openWithFreeze({ frozenRows: 2, frozenColumns: 3 }).freeze).toEqual({
+      xSplit: 3,
+      ySplit: 2,
+      startRow: 2,
+      startColumn: 3,
+    })
+    expect(openWithFreeze(null)).not.toHaveProperty('freeze')
+  })
 })
 
 interface Range {


### PR DESCRIPTION
## Summary

- What changed? File-open freeze mapping now emits Univer's -1 sentinel on the unfrozen axis (via a new exported toUniverFreeze helper), matching the in-app freeze-top-row/freeze-first-col commands.
- Why is this change needed? Opening a rows-only or columns-only frozen sheet passed startRow/startColumn 0, misaligning the frozen viewport (issue #196: missing rows / blank grid).

## Related issue

Related to #196.

## Validation

- [x] npm run format:check (prettier clean on both touched files)
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: apps/sheets/tests/univer-range-loading.test.ts maps rows-only/cols-only/both/none through loadWorkbookSkeleton.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.