### PR TITLE
fix(shell): include xls in the sheets recents filter family

### DIFF
--- a/apps/shell/src/main/recent-files.ts
+++ b/apps/shell/src/main/recent-files.ts
@@ -59,7 +59,7 @@ export function normalizeRecentQuery(
 
 /** sidebar filter keys that stand for a family of extensions, not one exact ext */
 const EXT_FAMILY: Record<string, readonly string[]> = {
-  xlsx: ['xlsx', 'xlsm'],
+  xlsx: ['xlsx', 'xlsm', 'xls'],
   html: ['html', 'htm'],
 }
 

--- a/apps/shell/tests/home-counts.test.ts
+++ b/apps/shell/tests/home-counts.test.ts
@@ -54,6 +54,26 @@ describe('home visible counts', () => {
     expect(page.entries.map((entry) => entry.path)).toEqual([bookPath, macroPath])
   })
 
+  it('counts legacy .xls under the sheets (xlsx) filter', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shell-counts-'))
+    tempDirs.push(dir)
+    const bookPath = join(dir, 'book.xlsx')
+    const legacyPath = join(dir, 'legacy.xls')
+    const docPath = join(dir, 'notes.docx')
+    writeFileSync(bookPath, 'sheet')
+    writeFileSync(legacyPath, 'sheet')
+    writeFileSync(docPath, 'doc')
+
+    const page = pageRecentPaths(
+      [bookPath, legacyPath, docPath],
+      { ext: 'xlsx', offset: 0, limit: 50 },
+      new Set(),
+    )
+
+    expect(page.total).toBe(2)
+    expect(page.entries.map((entry) => entry.path)).toEqual([bookPath, legacyPath])
+  })
+
   it('keeps unavailable paths listed at their position, flagged missing (r158)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'shell-counts-'))
     tempDirs.push(dir)


### PR DESCRIPTION
## Summary

- What changed? The sidebar sheets (\xlsx\) recents filter family now includes legacy \.xls\ alongside \xlsx\/\xlsm\.
- Why is this change needed? Legacy \.xls\ files are openable (open dialog Excel filter and sheet routing both include \xls\), but were silently hidden by the recents filter.

## Related issue

Related to #36.

## Validation

- [x] npm run format:check (prettier clean on both touched files)
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: apps/shell/tests/home-counts.test.ts counts legacy .xls under the sheets filter.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.