### PR TITLE
fix(electron-utils): trim and normalize URLs in safeExternalUrl

### DIFF
--- a/packages/electron-utils/src/safe-external-url.ts
+++ b/packages/electron-utils/src/safe-external-url.ts
@@ -12,17 +12,21 @@ export interface SafeExternalUrlOptions {
 const DEFAULT_PROTOCOLS: readonly string[] = ['http:', 'https:']
 
 /**
- * Returns the URL string when it parses and its protocol is on the allowlist,
- * otherwise null. Callers must not fall back to opening the raw input.
+ * Returns the trimmed URL string when it parses and its protocol is on the
+ * allowlist, otherwise null. Callers must not fall back to opening the raw
+ * input. Trims because the WHATWG parser silently strips surrounding
+ * whitespace, so validating the raw input but returning it verbatim would
+ * hand `shell.openExternal` a URL that fails there.
  */
 export function safeExternalUrl(url: unknown, options?: SafeExternalUrlOptions): string | null {
   if (typeof url !== 'string') return null
+  const text = url.trim()
   let parsed: URL
   try {
-    parsed = new URL(url)
+    parsed = new URL(text)
   } catch {
     return null
   }
   const allowed = options?.allowedProtocols ?? DEFAULT_PROTOCOLS
-  return allowed.includes(parsed.protocol) ? url : null
+  return allowed.includes(parsed.protocol) ? text : null
 }

--- a/packages/electron-utils/tests/safe-external-url.test.ts
+++ b/packages/electron-utils/tests/safe-external-url.test.ts
@@ -35,4 +35,13 @@ describe('safeExternalUrl', () => {
     expect(safeExternalUrl('mailto:a@b.com', opts)).toBe('mailto:a@b.com')
     expect(safeExternalUrl('http://example.com', opts)).toBeNull()
   })
+
+  it('trims surrounding whitespace instead of returning it verbatim', () => {
+    // The WHATWG parser strips surrounding whitespace while parsing, so the
+    // untrimmed input validates but would fail in shell.openExternal.
+    expect(safeExternalUrl('  https://example.com/a?b=c  ')).toBe('https://example.com/a?b=c')
+    expect(safeExternalUrl('\nhttp://example.com\n')).toBe('http://example.com')
+    expect(safeExternalUrl('   ')).toBeNull()
+    expect(safeExternalUrl('  file:///etc/passwd  ')).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

- What changed? safeExternalUrl now validates and returns the trimmed URL instead of validating the WHATWG-parsed form but returning the raw input verbatim.
- Why is this change needed? Pasted doc-embedded links with surrounding whitespace passed validation yet failed in shell.openExternal.

## Related issue

Related to #36.

## Validation

- [x] npm run format:check (prettier clean on both touched files)
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: packages/electron-utils/tests/safe-external-url.test.ts trims surrounding whitespace.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.