### PR TITLE
fix(docs): allow typing below a trailing table via trailing paragraph

### DIFF
--- a/apps/docs/src/renderer/editor/convert.ts
+++ b/apps/docs/src/renderer/editor/convert.ts
@@ -88,6 +88,17 @@ export function blocksToPmDoc(blocks: Block[], sections?: SectionInfo[]): PmNode
       attrs: { docxIndex: null, styleId: null, aiChanged: false },
     })
   }
+  // A trailing table strands the caret: ProseMirror needs a textblock after
+  // it for ArrowDown/click-below to land on. Word itself requires a final
+  // paragraph after a trailing table, so synthesize one (docxIndex null keeps
+  // it out of the save patch, like the empty-doc paragraph above).
+  const last = content[content.length - 1]
+  if (last && last.type === 'docTable') {
+    content.push({
+      type: 'docParagraph',
+      attrs: { docxIndex: null, styleId: null, aiChanged: false },
+    })
+  }
   return { type: 'doc', content }
 }
 

--- a/apps/docs/tests/convert-regressions.test.ts
+++ b/apps/docs/tests/convert-regressions.test.ts
@@ -520,3 +520,40 @@ describe('paragraph direction inference (run w:rtl / RTL script, no w:bidi)', ()
     expect(pmNodeToGeneratedBlock(doc.content![0]).format?.bidi).toBeUndefined()
   })
 })
+
+describe('trailing table paragraph (issue #266)', () => {
+  const tableBlock: Block = {
+    id: 'b0',
+    type: 'table',
+    docxIndex: 0,
+    originalXml: '<w:tbl/>',
+    table: {
+      rows: [[{ paras: ['x'] }]],
+      rowHeightsTwips: [500],
+      rowHeightRules: ['atLeast'],
+    },
+  }
+  const paraBlock: Block = {
+    id: 'b1',
+    type: 'paragraph',
+    docxIndex: 1,
+    originalXml: '<w:p/>',
+    runs: [{ text: 'tail' }],
+  }
+
+  it('appends an unindexed paragraph after a trailing table', () => {
+    const doc = blocksToPmDoc([tableBlock])
+    expect(doc.content!.length).toBe(2)
+    const last = doc.content![1]
+    expect(last.type).toBe('docParagraph')
+    // Unindexed like the empty-doc fallback, so the save patch skips it.
+    expect(last.attrs!.docxIndex).toBeNull()
+  })
+
+  it('leaves docs ending in a paragraph untouched', () => {
+    const doc = blocksToPmDoc([tableBlock, paraBlock])
+    expect(doc.content!.length).toBe(2)
+    expect(doc.content![1].type).toBe('docParagraph')
+    expect(doc.content![1].attrs!.docxIndex).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- What changed? blocksToPmDoc now appends an unindexed trailing paragraph when the document ends in a table, giving the caret a textblock below the last table.
- Why is this change needed? With a trailing table the cursor is trapped: ArrowDown/click below the table has no position (issue #266).

## Related issue

Fixes #266.

## Validation

- [x] npm run format:check (prettier clean on both touched files)
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New tests: apps/docs/tests/convert-regressions.test.ts appends an unindexed paragraph after a trailing table and leaves paragraph-ending docs untouched.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.