### PR TITLE
fix(slides): strip stale embedded-font subsets after text edits

### DIFF
--- a/packages/pptx-engine/src/embedded-fonts.ts
+++ b/packages/pptx-engine/src/embedded-fonts.ts
@@ -43,6 +43,51 @@ export function eotToSfnt(bytes: Uint8Array): Uint8Array | null {
   return sfnt
 }
 
+/**
+ * Remove the package's embedded fonts: <p:embeddedFontLst> and the
+ * embedTrueTypeFonts/saveSubsetFonts attributes in presentation.xml, the font
+ * relationships in its rels, the ppt/fonts/*.fntdata parts, and the
+ * [Content_Types] fntdata declaration.
+ *
+ * Why: the embedded subsets cannot be re-generated after a text edit (MicroType
+ * Express compression needs a licensed compressor), and WPS honors a stale
+ * subset strictly — glyphs it doesn't cover render as invisible text while the
+ * in-app system-font fallback shows them fine. Stripping makes every viewer
+ * fall back to system fonts. Idempotent; returns whether anything was stripped.
+ */
+export function stripEmbeddedFonts(archive: PackageArchive): boolean {
+  const presPath = 'ppt/presentation.xml'
+  const pres = archive.readText(presPath)
+  if (!pres || !pres.includes('embeddedFont')) return false
+
+  const nextPres = pres
+    .replace(/<p:embeddedFontLst>[\s\S]*?<\/p:embeddedFontLst>/, '')
+    .replace(/ embedTrueTypeFonts="[^"]*"/, '')
+    .replace(/ saveSubsetFonts="[^"]*"/, '')
+  archive.entries.set(presPath, Buffer.from(nextPres, 'utf8'))
+
+  const relsPath = 'ppt/_rels/presentation.xml.rels'
+  const rels = archive.readText(relsPath)
+  if (rels) {
+    const nextRels = rels.replace(/<Relationship\b[^>]*\bType="[^"]*\/font"[^>]*\/>/g, '')
+    if (nextRels !== rels) archive.entries.set(relsPath, Buffer.from(nextRels, 'utf8'))
+  }
+
+  const ctPath = '[Content_Types].xml'
+  const ct = archive.readText(ctPath)
+  if (ct) {
+    const nextCt = ct
+      .replace(/<Default\b[^>]*\bExtension="fntdata"[^>]*\/>/g, '')
+      .replace(/<Override\b[^>]*\bPartName="\/ppt\/fonts\/[^"]*"[^>]*\/>/g, '')
+    if (nextCt !== ct) archive.entries.set(ctPath, Buffer.from(nextCt, 'utf8'))
+  }
+
+  for (const path of [...archive.entries.keys()]) {
+    if (/^ppt\/fonts\/[^/]+\.fntdata$/.test(path)) archive.entries.delete(path)
+  }
+  return true
+}
+
 /** Usable (uncompressed) embedded faces of a package; empty when none are declared. */
 export function listEmbeddedFonts(archive: PackageArchive): EmbeddedFontFace[] {
   const presXml = archive.readText('ppt/presentation.xml')

--- a/packages/pptx-engine/src/index.ts
+++ b/packages/pptx-engine/src/index.ts
@@ -48,6 +48,7 @@ import {
 import { BLANK_SLIDE_XML } from './blank'
 import { escapeXmlAttr } from './xml-utils'
 import { elementSpid } from './animation'
+import { stripEmbeddedFonts } from './embedded-fonts'
 import { ensureCreationId, matchesElementRef } from './identity'
 import { listMasterParts, parseMasterPart } from './master-edit'
 import type {
@@ -727,6 +728,14 @@ function slideIsDirty(s: Slide): boolean {
 
 function buildZip(opened: OpenedPptx): JSZip {
   const { deck, archive } = opened
+  // Embedded-font subsets can't be re-generated after a text edit (MicroType
+  // Express needs a licensed compressor), and WPS honors a stale subset
+  // strictly: glyphs it doesn't cover render as invisible text while the in-app
+  // system-font fallback shows them fine. Once any content edit lands, strip
+  // the embedding so every viewer falls back to system fonts.
+  if (deck.slides.some((s) => s.structureDirty || s.elements.some((e) => e.dirty))) {
+    stripEmbeddedFonts(archive)
+  }
   const dirtyByPath = new Map<string, Slide>()
   for (const s of deck.slides) {
     if (slideIsDirty(s)) dirtyByPath.set(s.path, s)
@@ -1706,6 +1715,9 @@ function registerNewSlide(opened: OpenedPptx, sourceIndex: number, newPath: stri
 
   const slide = parseSlideFromArchive(archive, newPath)
   if (!slide) return null
+  // A new slide can carry text the embedded-font subsets don't cover (they go
+  // stale the moment text changes); structureDirty lets the save strip them.
+  slide.structureDirty = true
   deck.slides.splice(sourceIndex + 1, 0, slide)
   return slide
 }

--- a/packages/pptx-engine/tests/embedded-fonts.test.ts
+++ b/packages/pptx-engine/tests/embedded-fonts.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import JSZip from 'jszip'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import { PackageArchive } from '../src/zip'
-import { eotToSfnt, listEmbeddedFonts } from '../src/embedded-fonts'
+import { eotToSfnt, listEmbeddedFonts, stripEmbeddedFonts } from '../src/embedded-fonts'
+import { openPptx, savePptx, setElementFont, duplicateSlide } from '../src/index'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fx = (name: string) => readFileSync(join(here, 'fixtures', name))
 
 /** Minimal valid-enough sfnt payload: TrueType magic + filler. */
 function fakeSfnt(seed = 1): Uint8Array {
@@ -92,5 +99,141 @@ describe('listEmbeddedFonts', () => {
     )
     const archive = await PackageArchive.open(await zip.generateAsync({ type: 'uint8array' }))
     expect(listEmbeddedFonts(archive)).toEqual([])
+  })
+})
+
+describe('stripEmbeddedFonts', () => {
+  async function archiveWithFonts(): Promise<PackageArchive> {
+    const zip = new JSZip()
+    zip.file(
+      'ppt/presentation.xml',
+      '<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" embedTrueTypeFonts="1" saveSubsetFonts="1">' +
+        '<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>' +
+        '<p:embeddedFontLst>' +
+        '<p:embeddedFont><p:font typeface="MiSans"/><p:regular r:id="rId7"/></p:embeddedFont>' +
+        '</p:embeddedFontLst>' +
+        '<p:sldSz cx="12192000" cy="6858000"/></p:presentation>',
+    )
+    zip.file(
+      'ppt/_rels/presentation.xml.rels',
+      '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+        '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>' +
+        '<Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="fonts/font1.fntdata"/>' +
+        '</Relationships>',
+    )
+    zip.file(
+      '[Content_Types].xml',
+      '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+        '<Default Extension="fntdata" ContentType="application/x-fontdata"/>' +
+        '<Default Extension="xml" ContentType="application/xml"/>' +
+        '</Types>',
+    )
+    zip.file('ppt/fonts/font1.fntdata', eotWrap(fakeSfnt(), 0x5))
+    return PackageArchive.open(await zip.generateAsync({ type: 'uint8array' }))
+  }
+
+  it('removes embeddedFontLst, font rels, fntdata parts and the content-type declaration', async () => {
+    const archive = await archiveWithFonts()
+    expect(stripEmbeddedFonts(archive)).toBe(true)
+
+    const pres = archive.readText('ppt/presentation.xml')!
+    expect(pres).not.toContain('embeddedFont')
+    expect(pres).not.toContain('embedTrueTypeFonts')
+    expect(pres).not.toContain('saveSubsetFonts')
+    expect(pres).toContain('<p:sldIdLst>')
+
+    const rels = archive.readText('ppt/_rels/presentation.xml.rels')!
+    expect(rels).not.toContain('/font"')
+    expect(rels).toContain('slides/slide1.xml') // non-font rels survive
+
+    const ct = archive.readText('[Content_Types].xml')!
+    expect(ct).not.toContain('fntdata')
+    expect(ct).toContain('Extension="xml"')
+
+    expect(archive.has('ppt/fonts/font1.fntdata')).toBe(false)
+  })
+
+  it('is a no-op when no embedded fonts are declared', async () => {
+    const archive = await archiveWithFonts()
+    stripEmbeddedFonts(archive)
+    expect(stripEmbeddedFonts(archive)).toBe(false)
+  })
+})
+
+describe('save strips stale embedded-font subsets after edits', () => {
+  /** Fixture deck with an embeddedFontLst + fntdata part injected. */
+  async function fixtureWithEmbeddedFonts(): Promise<Uint8Array> {
+    const zip = await JSZip.loadAsync(fx('01_standard_business.pptx'))
+    const pres = await zip.file('ppt/presentation.xml')!.async('string')
+    zip.file(
+      'ppt/presentation.xml',
+      pres
+        .replace('<p:presentation ', '<p:presentation embedTrueTypeFonts="1" saveSubsetFonts="1" ')
+        .replace(
+          '</p:presentation>',
+          '<p:embeddedFontLst><p:embeddedFont><p:font typeface="MiSans"/><p:regular r:id="rId900"/></p:embeddedFont></p:embeddedFontLst></p:presentation>',
+        ),
+    )
+    const rels = await zip.file('ppt/_rels/presentation.xml.rels')!.async('string')
+    zip.file(
+      'ppt/_rels/presentation.xml.rels',
+      rels.replace(
+        '</Relationships>',
+        '<Relationship Id="rId900" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="fonts/font1.fntdata"/></Relationships>',
+      ),
+    )
+    const ct = await zip.file('[Content_Types].xml')!.async('string')
+    zip.file(
+      '[Content_Types].xml',
+      ct.replace(
+        /<Types[^>]*>/,
+        '$&<Default Extension="fntdata" ContentType="application/x-fontdata"/>',
+      ),
+    )
+    zip.file('ppt/fonts/font1.fntdata', eotWrap(fakeSfnt(), 0x5))
+    return zip.generateAsync({ type: 'uint8array' })
+  }
+
+  async function savedPresentationXml(bytes: Uint8Array): Promise<JSZip> {
+    return JSZip.loadAsync(bytes)
+  }
+
+  it('keeps embedded fonts on a no-edit save', async () => {
+    const opened = await openPptx(await fixtureWithEmbeddedFonts())
+    const zip = await savedPresentationXml(await savePptx(opened))
+    const pres = await zip.file('ppt/presentation.xml')!.async('string')
+    expect(pres).toContain('embeddedFontLst')
+    expect(zip.file('ppt/fonts/font1.fntdata')).not.toBeNull()
+  })
+
+  it('strips embedded fonts once a run is edited', async () => {
+    const opened = await openPptx(await fixtureWithEmbeddedFonts())
+    const slide = opened.deck.slides.find((s) =>
+      s.elements.some(
+        (e) => (e.type === 'text' || e.type === 'shape') && (e as any).text?.paragraphs?.length,
+      ),
+    )!
+    const el = slide.elements.find(
+      (e) => (e.type === 'text' || e.type === 'shape') && (e as any).text?.paragraphs?.length,
+    )!
+    expect(setElementFont(slide, el.id, { color: '#123456' })).toBe(true)
+
+    const zip = await savedPresentationXml(await savePptx(opened))
+    const pres = await zip.file('ppt/presentation.xml')!.async('string')
+    expect(pres).not.toContain('embeddedFont')
+    expect(pres).not.toContain('embedTrueTypeFonts')
+    const rels = await zip.file('ppt/_rels/presentation.xml.rels')!.async('string')
+    expect(rels).not.toContain('/font"')
+    expect(zip.file('ppt/fonts/font1.fntdata')).toBeNull()
+  })
+
+  it('strips embedded fonts when a slide is duplicated (new text may not be in the subsets)', async () => {
+    const opened = await openPptx(await fixtureWithEmbeddedFonts())
+    expect(duplicateSlide(opened, 0)).not.toBeNull()
+
+    const zip = await savedPresentationXml(await savePptx(opened))
+    const pres = await zip.file('ppt/presentation.xml')!.async('string')
+    expect(pres).not.toContain('embeddedFont')
+    expect(zip.file('ppt/fonts/font1.fntdata')).toBeNull()
   })
 })


### PR DESCRIPTION
## 问题

用户报告：genoffice 修改后的 PPT 在 WPS 中打开时文字"变白"（不可见），应用内正常。

**根因**：原文件带有 WPS 保存时嵌入的字体子集（MicroType Express 压缩的 EOT，`embedTrueTypeFonts="1"`）。genoffice 只读嵌入字体、从不更新（`embedded-fonts.ts` 跳过 MTX 压缩格式）。文本编辑后，子集中没有新字的字形，而 WPS 严格使用嵌入子集渲染 → 缺字形渲染为空白，视觉上像"字体变白"。应用内因跳过 MTX 字体回退到系统字体，所以显示正常。

实测确认：剥离嵌入字体后的文件在 WPS 中显示完全正常。

## 修复

保存时一旦检测到内容编辑（任意 slide 有 `structureDirty` 或元素 `dirty`，含 insert/duplicate 的新幻灯片），剥离嵌入字体：

- `presentation.xml`：移除 `<p:embeddedFontLst>` 与 `embedTrueTypeFonts`/`saveSubsetFonts` 属性
- `presentation.xml.rels`：移除 font 关系
- 删除 `ppt/fonts/*.fntdata` 与 `[Content_Types].xml` 的 fntdata 声明

剥离是对 archive 的原地修改，幂等，后续保存持续生效；无编辑的保存保持字节不变、保留嵌入。各端阅读器回退系统字体渲染。

**已知限制**：母版/版式视图的文本编辑直写 archive，不经过 deck dirty 检测，不会触发剥离（边缘场景）。

## 测试

- 新增 5 个测试（`embedded-fonts.test.ts`）：strip 单元测试（完整性、幂等）+ 集成测试（无编辑保留 / 文本编辑后剥离 / 复制幻灯片后剥离）
- `pptx-engine` 全套 841 测试通过，tsc 无错误；`apps/slides` 630 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)