### PR TITLE
test(font-metrics): fix eviction expectation and restore the unmapped-codepoint probe

### DIFF
--- a/packages/font-metrics/tests/advance.test.ts
+++ b/packages/font-metrics/tests/advance.test.ts
@@ -43,7 +43,7 @@ describe('advanceWidths', () => {
 
   it('marks unmapped codepoints as NaN instead of guessing', () => {
     if (!hasHelvetica) return
-    const w = advanceWidths('Helvetica', '￿x', 12)!
+    const w = advanceWidths('Helvetica', '\u{10FFF0}x', 12)!
     expect(Number.isNaN(w[0]!)).toBe(true)
     expect(w[1]!).toBeGreaterThan(0)
   })
@@ -69,7 +69,7 @@ describe('evictOldestEntry', () => {
     expect([...cache.keys()]).toEqual(['b', 'c'])
   })
 
-  it('evicts repeatedly until under max', () => {
+  it('evicts repeatedly until one slot is free', () => {
     const cache = new Map([
       ['a', 1],
       ['b', 2],
@@ -77,6 +77,6 @@ describe('evictOldestEntry', () => {
       ['d', 4],
     ])
     evictOldestEntry(cache, 2)
-    expect([...cache.keys()]).toEqual(['c', 'd'])
+    expect([...cache.keys()]).toEqual(['d'])
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #281, which merged with its new test red on `main`:

- `evicts repeatedly until under max` expected two survivors, but `evictOldestEntry` frees one slot (size < max) so four entries capped at two leave one. The call site is right; the expectation is fixed.
- The `marks unmapped codepoints as NaN` probe had its `'\u{10FFF0}x'` literal replaced by a raw U+FFFF, which changes what the test checks. Restored.

## Validation

- `packages/font-metrics` tests pass locally (16), `tsc --noEmit` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)