### PR TITLE
fix(slides): respect AI composer spellcheck pref

### DIFF
--- a/apps/slides/src/renderer/ai/AiPanel.tsx
+++ b/apps/slides/src/renderer/ai/AiPanel.tsx
@@ -38,7 +38,7 @@ import {
   settingsSupportVision,
 } from './slide-qc'
 import { useI18n, t as tGlobal, aiLangDirective, type TFunc } from '../i18n/locale'
-import { AiScopeQuote, Markdown, type AiScopeQuoteData } from '@genoffice/ui'
+import { AiScopeQuote, Markdown, useAiPanelPrefs, type AiScopeQuoteData } from '@genoffice/ui'
 import { GensparkMark } from '../components/icons'
 import sendEnterOn from '../assets/send-enter-on.png'
 import sendEnterOff from '../assets/send-enter-off.png'
@@ -403,6 +403,9 @@ export function AiPanel({
   // Panel chrome follows the UI language; message text follows its own content (dir=auto below)
   const isRtl = lang === 'ar' || lang === 'he'
   const [input, setInput] = useState('')
+  // Shared AI panel pref (Settings → General): the bespoke slides composer
+  // must honor it like the shared AiComposer does.
+  const { spellcheck } = useAiPanelPrefs()
   const [busy, setBusy] = useState(false)
   const [chat, setChat] = useState<ChatEntry[]>([])
   /** Past conversation restored from JSONL (read-only transcript, not fed to the model) */
@@ -2367,6 +2370,7 @@ export function AiPanel({
               ref={inputRef}
               value={input}
               dir="auto"
+              spellCheck={spellcheck}
               data-slides-ai-input="true"
               data-deck-undo-ready={!busy && !inputEditedSinceRunRef.current ? 'true' : 'false'}
               placeholder={t(deckEmpty ? 'aiInputPlaceholderGen' : 'aiInputPlaceholder')}

--- a/apps/slides/tests/ai-panel-collapse.test.ts
+++ b/apps/slides/tests/ai-panel-collapse.test.ts
@@ -26,6 +26,7 @@ vi.mock('react-konva', () => {
 
 import { AiPanel } from '../src/renderer/ai/AiPanel'
 import { AI_PROVIDERS, type AiSettings } from '../src/shared/ipc'
+import { applyAiPanelPrefs } from '@genoffice/ui'
 
 const settings: AiSettings = {
   provider: 'anthropic',
@@ -119,5 +120,20 @@ describe('AiPanel collapse (slides)', () => {
     expect(onExpand).toHaveBeenCalledTimes(1)
 
     cleanup()
+  })
+
+  it('reflects the shared spellcheck pref on the composer (issue #249)', () => {
+    applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: false })
+    try {
+      const { container, cleanup } = mount(createElement(AiPanel, panelProps()))
+      const textarea = container.querySelector<HTMLTextAreaElement>(
+        'textarea[data-slides-ai-input]',
+      )
+      expect(textarea).not.toBeNull()
+      expect(textarea!.spellcheck).toBe(false)
+      cleanup()
+    } finally {
+      applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- What changed? The bespoke slides AI composer now reads the shared AI panel spellcheck pref (Settings → General) via useAiPanelPrefs and passes it to its textarea, like the shared AiComposer used by docs/sheets/pdf/markdown.
- Why is this change needed? Slides was the only app whose AI draft kept the Chromium red squiggle after the user disabled AI spellcheck (issue #249); font sizing already flows through the shared CSS.

## Related issue

Related to #249.

## Validation

- [x] npm run format:check (prettier clean on both touched files)
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm test

List any checks not run and explain why: No node_modules in this checkout; relying on CI as proof. New test: apps/slides/tests/ai-panel-collapse.test.ts reflects the shared spellcheck pref on the composer.

## Screenshots or recordings

Not applicable.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.