### PR TITLE
Fix macOS tab bar spacer on Windows and Linux

### DIFF
--- a/apps/shell/src/renderer/src/tabbar.css
+++ b/apps/shell/src/renderer/src/tabbar.css
@@ -27,8 +27,12 @@ html.genoffice-popover-open .tab-bar {
 
 /* room for the macOS traffic lights (titleBarStyle: hiddenInset) */
 .tab-bar-drag-spacer {
-  width: 78px;
+  width: 0;
   flex-shrink: 0;
+}
+
+body.vib .tab-bar-drag-spacer {
+  width: 78px;
 }
 
 /* scrollable middle section; empty space stays part of the window drag region.


### PR DESCRIPTION

## Summary

- Changed the tab bar drag spacer to use `0px` by default.
- Restored the `78px` spacer only on macOS via the existing `body.vib` class.
- This removes the unnecessary left offset of the Home tab on Windows and Linux while preserving the macOS traffic-light spacing.

## Related issue

N/A

## Validation

- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`

List any checks not run and explain why:

Not run. This is a small CSS-only platform-specific UI change and was manually verified on Windows.

## Screenshots or recordings

Before: Home tab has an unnecessary ~78px left spacer on Windows.
<img width="3199" height="290" alt="gh-before" src="https://github.com/user-attachments/assets/3eb1fecd-a6fb-4b0e-b816-ed03b1cf7383" />

After: Home tab aligns correctly near the left edge while keeping the normal tab-strip padding.
<img width="3199" height="286" alt="gh-after" src="https://github.com/user-attachments/assets/42898488-7ef2-4a11-aab7-b136f49c16e5" />

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources. (N/A — no user-facing strings changed.)
- [x] File open/save changes include an appropriate round-trip or fidelity test. (N/A — no file open/save behavior changed.)
