### PR TITLE
feat(ai-provider): add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ file, makes the change, and shows you exactly what it touched.
   on-device. Only the AI calls leave the machine, to the provider you choose.
 - **Your keys or none.** Sign in with Genspark and skip keys, or bring your own
   key for Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax,
-  Grok, Mistral, OpenRouter, or any OpenAI-compatible endpoint, local servers
-  included.
+  Grok, Mistral, OpenRouter, Requesty, or any OpenAI-compatible endpoint, local
+  servers included.
 
 **Get it:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon and Intel) ·
 [Windows](https://github.com/genspark-ai/genoffice/releases/latest) (x64 and Arm) ·
@@ -179,8 +179,8 @@ through the Genspark proxy (Claude, GPT and Gemini families) and the agents get
 web and image search, image generation, and image/audio/video analysis.
 
 **Or bring your own key.** Settings → AI lists Claude, OpenAI, Gemini,
-DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter and
-OpenCode Zen/Go, plus a custom slot for any OpenAI-compatible endpoint (base
+DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
+and OpenCode Zen/Go, plus a custom slot for any OpenAI-compatible endpoint (base
 URL + key), including local model servers. Search and media have their own
 per-capability providers under **AI Media & Search**: Serper or Tavily for web
 search, and OpenAI, Gemini, Doubao/Seedream, GLM, Grok, Qwen, MiniMax or any
@@ -336,7 +336,7 @@ convert to editable text rather than a page image.
 
 Yes. Besides the keyless Genspark sign-in, GenOffice supports bring your own
 key for Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax,
-Grok, Mistral, OpenRouter and OpenCode Zen/Go, plus any OpenAI-compatible
+Grok, Mistral, OpenRouter, Requesty and OpenCode Zen/Go, plus any OpenAI-compatible
 endpoint — including local model servers. Search, image generation and
 image/video analysis take their own keys under Settings → AI Media & Search.
 

--- a/apps/shell/src/renderer/src/provider-logos.tsx
+++ b/apps/shell/src/renderer/src/provider-logos.tsx
@@ -8,7 +8,7 @@ import type { AiProviderId } from '@genoffice/ai-provider'
 // generic icon for the "custom" endpoint.
 // Brand-colored logos keep their official colors in both themes (brand
 // assets, not chrome — see CLAUDE.md theming rules); monochrome marks
-// (OpenAI, Kimi, Grok, OpenRouter, OpenCode, Genspark, Custom) use
+// (OpenAI, Kimi, Grok, OpenRouter, Requesty, OpenCode, Genspark, Custom) use
 // currentColor so they stay legible in dark mode.
 //
 // Gradient-filled marks (Gemini, Qwen, MiniMax) are components so useId can
@@ -215,6 +215,19 @@ const LOGOS: Record<AiProviderId, ReactNode> = {
   openrouter: (
     <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" aria-hidden="true">
       <path d="M18.654 3.87a5.087 5.087 0 110 10.174L23.7 19.09c.64.641.187 1.737-.72 1.737H8.48a8.479 8.479 0 010-16.958h10.175zM8.479 7.26a5.087 5.087 0 100 10.176 5.087 5.087 0 000-10.175z" />
+    </svg>
+  ),
+  // plain "R" wordmark in a rounded square (no official vector mark in the icon set)
+  requesty: (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="2" y="2" width="20" height="20" rx="5" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M8.5 17.5v-11h4.25a3.25 3.25 0 010 6.5H8.5m4 0 3.5 4.5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   ),
   'opencode-zen': opencodeLogo,

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -47,7 +47,7 @@ GenOffice بديل مجاني ومفتوح المصدر لـ Microsoft Office ع
   الاصطناعي، وتُرسَل فقط إلى مزوّد الخدمة الذي تختاره.
 - **مفاتيحك أو بلا مفاتيح.** سجّل الدخول بواسطة Genspark لتجنّب إدارة المفاتيح،
   أو استخدم مفتاحك الخاص مع Claude أو OpenAI أو Gemini أو DeepSeek أو Kimi أو
-  GLM أو Qwen أو Doubao أو MiniMax أو Grok أو Mistral أو OpenRouter، أو أي
+  GLM أو Qwen أو Doubao أو MiniMax أو Grok أو Mistral أو OpenRouter أو Requesty، أو أي
   نقطة نهاية متوافقة مع OpenAI، بما في ذلك الخوادم المحلية.
 
 **الحصول عليه:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon و Intel) ·
@@ -184,7 +184,7 @@ macOS، والذكاء الاصطناعي فيها ناتج عن التوجيه 
 
 **أو استخدم مفتاحك الخاص.** تسرد صفحة Settings → AI مزوِّدين مثل Claude
 وOpenAI وGemini وDeepSeek وKimi وGLM وQwen وDoubao وMiniMax وGrok وMistral
-وOpenRouter وOpenCode Zen/Go، إضافة إلى خانة مخصَّصة لأي نقطة نهاية متوافقة مع
+وOpenRouter وRequesty وOpenCode Zen/Go، إضافة إلى خانة مخصَّصة لأي نقطة نهاية متوافقة مع
 OpenAI (عنوان أساسي + مفتاح)، بما في ذلك خوادم النماذج المحلية. ولكل من
 البحث والوسائط مزوِّدوه الخاصون بحسب القدرة تحت **AI Media & Search**: Serper
 أو Tavily للبحث عبر الويب، وOpenAI أو Gemini أو Doubao/Seedream أو GLM أو
@@ -343,7 +343,7 @@ macOS و Windows، فتُحوَّل إلى نص قابل للتحرير بدلً
 
 نعم. إلى جانب تسجيل الدخول بواسطة Genspark الذي لا يتطلب أي مفتاح، يدعم
 GenOffice استخدام مفتاحك الخاص مع Claude وOpenAI وGemini وDeepSeek وKimi
-وGLM وQwen وDoubao وMiniMax وGrok وMistral وOpenRouter وOpenCode Zen/Go،
+وGLM وQwen وDoubao وMiniMax وGrok وMistral وOpenRouter وRequesty وOpenCode Zen/Go،
 إضافة إلى أي نقطة نهاية متوافقة مع OpenAI — بما في ذلك خوادم النماذج المحلية.
 ولكل من البحث وتوليد الصور وتحليل الصور والفيديو مفاتيحه الخاصة تحت
 Settings → AI Media & Search.

--- a/docs/i18n/README.cs.md
+++ b/docs/i18n/README.cs.md
@@ -47,7 +47,7 @@ provede požadovanou úpravu a přesně vám ukáže, čeho se dotkl.
   jen volání AI, a to k poskytovateli, kterého si sami vyberete.
 - **Vaše klíče, nebo žádné.** Přihlaste se přes Genspark a klíče nepotřebujete,
   nebo použijte vlastní klíč pro Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM,
-  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter nebo jakýkoli OpenAI
+  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty nebo jakýkoli OpenAI
   kompatibilní endpoint, včetně lokálních serverů.
 
 **Stáhnout:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon a Intel) ·
@@ -184,7 +184,7 @@ webové a obrázkové vyhledávání, generování obrázků a analýzu
 obrázků/zvuku/videa.
 
 **Nebo použijte vlastní klíč.** Nastavení → AI nabízí Claude, OpenAI, Gemini,
-DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter
+DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
 a OpenCode Zen/Go, plus vlastní slot pro jakýkoli OpenAI kompatibilní
 endpoint (base URL + klíč), včetně lokálních serverů s modely. Vyhledávání
 a média mají vlastní poskytovatele pro každou schopnost pod **AI Media
@@ -344,7 +344,7 @@ OCR, takže se převedou na editovatelný text, ne na obrázek stránky.
 
 Ano. Kromě bezklíčového přihlášení Genspark GenOffice podporuje vlastní klíč
 pro Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-Mistral, OpenRouter a OpenCode Zen/Go, plus jakýkoli OpenAI kompatibilní
+Mistral, OpenRouter, Requesty a OpenCode Zen/Go, plus jakýkoli OpenAI kompatibilní
 endpoint — včetně lokálních serverů s modely. Vyhledávání, generování obrázků
 a analýza obrázků/videa mají vlastní klíče pod Nastavení → AI Media & Search.
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -50,7 +50,7 @@ er verändert hat.
 - **Deine Schlüssel oder keine.** Melde dich mit Genspark an und du brauchst
   keine Schlüssel, oder bring deinen eigenen Schlüssel für Claude, OpenAI,
   Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-  OpenRouter oder jeden OpenAI-kompatiblen Endpunkt mit – auch lokale Server
+  OpenRouter, Requesty oder jeden OpenAI-kompatiblen Endpunkt mit – auch lokale Server
   werden unterstützt.
 
 **Los geht's:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon und Intel) ·
@@ -191,7 +191,7 @@ sowie Bild-/Audio-/Videoanalyse.
 
 **Oder bring deinen eigenen Schlüssel mit.** Unter Einstellungen → KI stehen
 Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-Mistral, OpenRouter und OpenCode Zen/Go zur Wahl, plus ein freier Slot für
+Mistral, OpenRouter, Requesty und OpenCode Zen/Go zur Wahl, plus ein freier Slot für
 jeden OpenAI-kompatiblen Endpunkt (Basis-URL + Schlüssel), einschließlich
 lokaler Modell-Server. Suche und Medien haben eigene Anbieter je Fähigkeit
 unter KI-Medien & Suche: Serper oder Tavily für die Websuche und OpenAI,
@@ -357,7 +357,7 @@ Seitenbild konvertiert werden.
 
 Ja. Neben der schlüssellosen Genspark-Anmeldung unterstützt GenOffice das
 Mitbringen eigener Schlüssel für Claude, OpenAI, Gemini, DeepSeek, Kimi,
-GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter und OpenCode Zen/Go,
+GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty und OpenCode Zen/Go,
 plus jeden OpenAI-kompatiblen Endpunkt – einschließlich lokaler
 Modell-Server. Suche, Bildgenerierung und Bild-/Videoanalyse benötigen
 eigene Schlüssel unter Einstellungen → KI-Medien & Suche.

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -47,7 +47,7 @@ hace el cambio y te muestra exactamente qué tocó.
   tu equipo, hacia el proveedor que elijas.
 - **Tus claves o ninguna.** Inicia sesión con Genspark y olvídate de las
   claves, o usa tu propia clave para Claude, OpenAI, Gemini, DeepSeek, Kimi,
-  GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, o cualquier endpoint
+  GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty, o cualquier endpoint
   compatible con OpenAI, servidores locales incluidos.
 
 **Consíguelo:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon e Intel) ·
@@ -188,7 +188,7 @@ Gemini) y los agentes obtienen búsqueda web y de imágenes, generación de
 imágenes, y análisis de imagen/audio/video.
 
 **O usa tu propia clave.** Settings → AI incluye Claude, OpenAI, Gemini,
-DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter y
+DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty y
 OpenCode Zen/Go, además de una ranura personalizada para cualquier endpoint
 compatible con OpenAI (URL base + clave), incluidos servidores de modelos
 locales. La búsqueda y los medios tienen sus propios proveedores por
@@ -356,7 +356,7 @@ en lugar de una imagen de página.
 
 Sí. Además del inicio de sesión sin clave con Genspark, GenOffice admite tu
 propia clave para Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao,
-MiniMax, Grok, Mistral, OpenRouter y OpenCode Zen/Go, además de cualquier
+MiniMax, Grok, Mistral, OpenRouter, Requesty y OpenCode Zen/Go, además de cualquier
 endpoint compatible con OpenAI, incluidos servidores de modelos locales. La
 búsqueda, la generación de imágenes y el análisis de imagen/video usan sus
 propias claves en Settings → AI Media & Search.

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -50,7 +50,7 @@ modification, et vous montre exactement ce qu'il a touché.
   fournisseur de votre choix.
 - **Vos clés ou aucune.** Connectez-vous avec Genspark pour vous dispenser de
   clé, ou utilisez votre propre clé pour Claude, OpenAI, Gemini, DeepSeek,
-  Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, ou tout point
+  Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty, ou tout point
   de terminaison compatible OpenAI, y compris les serveurs locaux.
 
 **À télécharger :** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon et Intel) ·
@@ -192,7 +192,7 @@ les agents ont accès à la recherche web et d'images, à la génération
 d'images, et à l'analyse d'images, d'audio et de vidéo.
 
 **Ou utilisez votre propre clé.** Paramètres → IA propose Claude, OpenAI,
-Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter
+Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
 et OpenCode Zen/Go, ainsi qu'un emplacement personnalisé pour tout point de
 terminaison compatible OpenAI (URL de base + clé), y compris les serveurs de
 modèles locaux. La recherche et les médias disposent de leurs propres
@@ -363,7 +363,7 @@ en texte modifiable plutôt qu'en image de page.
 
 Oui. Outre la connexion Genspark sans clé, GenOffice prend en charge
 l'utilisation de votre propre clé pour Claude, OpenAI, Gemini, DeepSeek,
-Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter et OpenCode
+Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty et OpenCode
 Zen/Go, ainsi que tout point de terminaison compatible OpenAI — y compris les
 serveurs de modèles locaux. La recherche, la génération d'images et
 l'analyse d'images/vidéos utilisent leurs propres clés sous Paramètres → IA

--- a/docs/i18n/README.he.md
+++ b/docs/i18n/README.he.md
@@ -46,7 +46,7 @@ Windows ו-Linux. היא פותחת ושומרת קבצי `.docx`,‏ `.xlsx` ו
   שבחרתם.
 - **המפתחות שלכם, או בלי מפתחות בכלל.** התחברו עם Genspark ודלגו על הצורך
   במפתח, או הביאו מפתח משלכם עבור Claude,‏ OpenAI,‏ Gemini,‏ DeepSeek,‏
-  Kimi,‏ GLM,‏ Qwen,‏ Doubao,‏ MiniMax,‏ Grok,‏ Mistral,‏ OpenRouter, או כל
+  Kimi,‏ GLM,‏ Qwen,‏ Doubao,‏ MiniMax,‏ Grok,‏ Mistral,‏ OpenRouter,‏ Requesty, או כל
   endpoint תואם-OpenAI, כולל שרתים מקומיים.
 
 **להורדה:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) ‏(Apple Silicon ו-Intel) ·
@@ -181,7 +181,7 @@ brief) — משפט פתיחה, פלטת צבעים, טיפוגרפיה וכיו
 
 **או הביאו מפתח משלכם.** בתפריט Settings → AI מופיעים Claude,‏ OpenAI,‏
 Gemini,‏ DeepSeek,‏ Kimi,‏ GLM,‏ Qwen,‏ Doubao,‏ MiniMax,‏ Grok,‏ Mistral,‏
-OpenRouter ו-OpenCode Zen/Go, ובנוסף שדה מותאם אישית לכל endpoint
+OpenRouter,‏ Requesty ו-OpenCode Zen/Go, ובנוסף שדה מותאם אישית לכל endpoint
 תואם-OpenAI (כתובת בסיס + מפתח), כולל שרתי מודלים מקומיים. לחיפוש ולמדיה יש
 ספקים נפרדים לפי יכולת תחת **AI Media & Search**: Serper או Tavily לחיפוש
 ברשת, ו-OpenAI,‏ Gemini,‏ Doubao/Seedream,‏ GLM,‏ Grok,‏ Qwen,‏ MiniMax או
@@ -339,7 +339,7 @@ GenOffice נמצאת בפיתוח פעיל, והמשוב שלכם מעצב או�
 
 כן. מעבר להתחברות ל-Genspark שאינה דורשת מפתח, GenOffice מאפשרת להביא מפתח
 משלכם עבור Claude,‏ OpenAI,‏ Gemini,‏ DeepSeek,‏ Kimi,‏ GLM,‏ Qwen,‏ Doubao,‏
-MiniMax,‏ Grok,‏ Mistral,‏ OpenRouter ו-OpenCode Zen/Go, וכן כל endpoint
+MiniMax,‏ Grok,‏ Mistral,‏ OpenRouter,‏ Requesty ו-OpenCode Zen/Go, וכן כל endpoint
 תואם-OpenAI — כולל שרתי מודלים מקומיים. חיפוש, יצירת תמונות וניתוח
 תמונה/וידאו דורשים מפתחות נפרדים תחת Settings → AI Media & Search.
 

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -33,7 +33,7 @@ GenOffice, macOS, Windows और Linux के लिए Microsoft Office का 
 - **असली फ़ॉर्मैट, बाइट-प्रिज़र्विंग।** सिर्फ़ वही हिस्सा दोबारा लिखा जाता है जिसे आप एडिट करते हैं। फ़ाइल का बाकी हिस्सा बाइट-दर-बाइट वैसा ही रहता है, इसलिए डॉक्यूमेंट Word, Excel और PowerPoint में पहले जैसे ही काम करते रहते हैं।
 - **AI जिसे आप रिव्यू कर सकते हैं।** एडिट्स ट्रैक्ड चेंजेस और डिफ़ के रूप में आते हैं, जिन्हें एक क्लिक में रोलबैक किया जा सकता है। स्प्रेडशीट में पेस्ट किए गए नंबर नहीं, बल्कि लाइव फ़ॉर्मूला मिलते हैं। डेक और पेज कैनवस पर जनरेट होते हैं और पूरी तरह एडिटेबल बने रहते हैं।
 - **डिज़ाइन से ही लोकल।** फ़ाइलें आपकी मशीन पर ही खुलती, एडिट होती, सेव होती और कन्वर्ट होती हैं। PDF → Word / Excel / PowerPoint, Markdown → Word और HTML → Word — यह सभी कन्वर्शन ऑन-डिवाइस होते हैं। मशीन से बाहर सिर्फ़ AI कॉल्स जाती हैं, और वह भी आपके चुने हुए प्रोवाइडर तक।
-- **आपकी कीज़ या कोई कीज़ नहीं।** Genspark से साइन इन करें और कीज़ की झंझट से बचें, या Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter या किसी भी OpenAI-compatible endpoint के लिए अपनी खुद की key लाएँ — लोकल सर्वर भी शामिल हैं।
+- **आपकी कीज़ या कोई कीज़ नहीं।** Genspark से साइन इन करें और कीज़ की झंझट से बचें, या Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty या किसी भी OpenAI-compatible endpoint के लिए अपनी खुद की key लाएँ — लोकल सर्वर भी शामिल हैं।
 
 **पाएँ:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon और Intel) ·
 [Windows](https://github.com/genspark-ai/genoffice/releases/latest) (x64 और Arm) ·
@@ -161,7 +161,7 @@ GenOffice, macOS, Windows और Linux के लिए Microsoft Office का 
 
 **Genspark से साइन इन करें** और कुछ भी कॉन्फ़िगर करने की ज़रूरत नहीं: मॉडल कॉल्स Genspark प्रॉक्सी (Claude, GPT और Gemini फ़ैमिली) के ज़रिए रूट होती हैं, और एजेंट्स को वेब व इमेज सर्च, इमेज जनरेशन, और इमेज/ऑडियो/वीडियो एनालिसिस मिलता है।
 
-**या अपनी खुद की key लाएँ।** Settings → AI में Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter और OpenCode Zen/Go लिस्ट किए गए हैं, साथ ही किसी भी OpenAI-compatible endpoint (base URL + key) के लिए एक कस्टम स्लॉट है, जिसमें लोकल मॉडल सर्वर भी शामिल हैं। सर्च और मीडिया के अपने अलग, हर-कैपेबिलिटी प्रोवाइडर **AI Media & Search** के तहत हैं: वेब सर्च के लिए Serper या Tavily, और इमेज जनरेशन व इमेज/वीडियो एनालिसिस के लिए OpenAI, Gemini, Doubao/Seedream, GLM, Grok, Qwen, MiniMax या कोई भी OpenAI-compatible images endpoint।
+**या अपनी खुद की key लाएँ।** Settings → AI में Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty और OpenCode Zen/Go लिस्ट किए गए हैं, साथ ही किसी भी OpenAI-compatible endpoint (base URL + key) के लिए एक कस्टम स्लॉट है, जिसमें लोकल मॉडल सर्वर भी शामिल हैं। सर्च और मीडिया के अपने अलग, हर-कैपेबिलिटी प्रोवाइडर **AI Media & Search** के तहत हैं: वेब सर्च के लिए Serper या Tavily, और इमेज जनरेशन व इमेज/वीडियो एनालिसिस के लिए OpenAI, Gemini, Doubao/Seedream, GLM, Grok, Qwen, MiniMax या कोई भी OpenAI-compatible images endpoint।
 
 पूरा सूट लाइट, डार्क और सिस्टम थीम के साथ आता है। थीम सिर्फ़ स्क्रीन पर दिखने वाली चीज़ बदलती है: एक्सपोर्ट, प्रिंट और सेव की गई फ़ाइलें हमेशा डॉक्यूमेंट के अपने असली रंग बरकरार रखती हैं।
 
@@ -307,7 +307,7 @@ GenOffice पर सक्रिय रूप से काम चल रहा 
 
 हाँ। बिना-key वाले Genspark साइन-इन के अलावा, GenOffice Claude, OpenAI,
 Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-OpenRouter और OpenCode Zen/Go के लिए अपनी खुद की key लाने को सपोर्ट करता
+OpenRouter, Requesty और OpenCode Zen/Go के लिए अपनी खुद की key लाने को सपोर्ट करता
 है, साथ ही किसी भी OpenAI-compatible endpoint को — जिसमें लोकल मॉडल सर्वर
 भी शामिल हैं। सर्च, इमेज जनरेशन और इमेज/वीडियो एनालिसिस के लिए
 Settings → AI Media & Search के तहत अलग keys चाहिए।

--- a/docs/i18n/README.id.md
+++ b/docs/i18n/README.id.md
@@ -49,7 +49,7 @@ perubahan, dan menunjukkan dengan tepat bagian mana yang diubah.
 - **Kunci API Anda sendiri, atau tanpa kunci sama sekali.** Masuk dengan
   Genspark dan lewati urusan kunci API, atau gunakan kunci Anda sendiri untuk
   Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-  Mistral, OpenRouter, atau endpoint apa pun yang kompatibel dengan OpenAI,
+  Mistral, OpenRouter, Requesty, atau endpoint apa pun yang kompatibel dengan OpenAI,
   termasuk server lokal.
 
 **Unduh di sini:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon dan Intel) ·
@@ -187,7 +187,7 @@ agen mendapatkan akses pencarian web dan gambar, generasi gambar, serta
 analisis gambar/audio/video.
 
 **Atau bawa kunci Anda sendiri.** Settings → AI menampilkan Claude, OpenAI,
-Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter,
+Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty,
 dan OpenCode Zen/Go, plus slot khusus untuk endpoint apa pun yang kompatibel
 dengan OpenAI (base URL + kunci), termasuk server model lokal. Pencarian dan
 media memiliki penyedia tersendiri per kemampuan di bawah **AI Media &
@@ -353,7 +353,7 @@ gambar halaman.
 
 Ya. Selain masuk lewat Genspark tanpa kunci API, GenOffice mendukung
 penggunaan kunci Anda sendiri untuk Claude, OpenAI, Gemini, DeepSeek, Kimi,
-GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, dan OpenCode Zen/Go,
+GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty, dan OpenCode Zen/Go,
 plus endpoint apa pun yang kompatibel dengan OpenAI — termasuk server model
 lokal. Pencarian, generasi gambar, dan analisis gambar/video menggunakan
 kunci tersendiri di Settings → AI Media & Search.

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -47,7 +47,7 @@ applica la modifica e ti mostra esattamente cosa ha toccato.
   le chiamate AI lasciano la macchina, verso il provider che scegli.
 - **Le tue chiavi, o nessuna.** Accedi con Genspark e non dovrai configurare
   nulla, oppure usa la tua chiave per Claude, OpenAI, Gemini, DeepSeek, Kimi,
-  GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter o qualsiasi endpoint
+  GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty o qualsiasi endpoint
   compatibile con OpenAI, inclusi i server locali.
 
 **Scaricalo:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon e Intel) ·
@@ -186,7 +186,7 @@ e gli agenti hanno accesso a ricerca web e per immagini, generazione di
 immagini e analisi di immagini/audio/video.
 
 **Oppure usa la tua chiave.** In Settings → AI trovi Claude, OpenAI, Gemini,
-DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter e
+DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty e
 OpenCode Zen/Go, più uno slot personalizzato per qualsiasi endpoint
 compatibile con OpenAI (base URL + chiave), inclusi i server con modelli
 locali. Ricerca e media hanno i propri provider per singola funzionalità
@@ -355,7 +355,7 @@ invece che in un'immagine di pagina.
 
 Sì. Oltre all'accesso Genspark senza chiavi, GenOffice supporta l'uso della
 tua chiave per Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao,
-MiniMax, Grok, Mistral, OpenRouter e OpenCode Zen/Go, più qualsiasi endpoint
+MiniMax, Grok, Mistral, OpenRouter, Requesty e OpenCode Zen/Go, più qualsiasi endpoint
 compatibile con OpenAI — inclusi i server con modelli locali. Ricerca,
 generazione di immagini e analisi di immagini/video richiedono le proprie
 chiavi in Settings → AI Media & Search.

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -33,7 +33,7 @@ GenOffice は、macOS・Windows・Linux で動作する、Microsoft Office に�
 - **実際のファイル形式、バイト単位で保持。** 編集した部分だけが書き換えられます。それ以外の部分はファイル内でバイト単位そのまま保持されるため、ドキュメントは Word・Excel・PowerPoint でも問題なく動作し続けます。
 - **レビューできる AI。** 編集内容は変更履歴と差分として反映され、ワンクリックで元に戻せます。スプレッドシートには貼り付けの数値ではなく、実際に機能する数式が入ります。デッキやページはキャンバス上に生成され、そのまま自由に編集できます。
 - **設計からローカル動作。** ファイルの開く・編集・保存・変換はすべてお使いのマシン上で行われます。PDF → Word / Excel / PowerPoint、Markdown → Word、HTML → Word の変換もすべてオンデバイスで実行されます。マシンの外に出るのは、選択した AI プロバイダーへの呼び出しだけです。
-- **キーを使うか使わないかはあなた次第。** Genspark でサインインすればキーの用意は不要です。あるいは、Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、または任意の OpenAI 互換エンドポイント（ローカルサーバーを含む）向けに、自分の API キーを持ち込むこともできます。
+- **キーを使うか使わないかはあなた次第。** Genspark でサインインすればキーの用意は不要です。あるいは、Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty、または任意の OpenAI 互換エンドポイント（ローカルサーバーを含む）向けに、自分の API キーを持ち込むこともできます。
 
 **入手方法：** [macOS](https://github.com/genspark-ai/genoffice/releases/latest)（Apple Silicon および Intel）·
 [Windows](https://github.com/genspark-ai/genoffice/releases/latest)（x64 および Arm）·
@@ -164,7 +164,7 @@ GenOffice は、macOS・Windows・Linux で動作する、Microsoft Office に�
 動画の解析機能も利用できます。
 
 **あるいは自分のキーを持ち込む。** 設定 → AI には Claude、OpenAI、Gemini、DeepSeek、Kimi、
-GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、OpenCode Zen/Go が並び、さらに任意
+GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty、OpenCode Zen/Go が並び、さらに任意
 の OpenAI 互換エンドポイント（ベース URL + キー、ローカルモデルサーバーを含む）を登録できる
 カスタム枠も用意されています。検索とメディア関連は **AI メディア＆検索** の下で機能ごとに個
 別のプロバイダーを設定できます：Web 検索には Serper か Tavily、画像生成と画像／動画解析には
@@ -319,7 +319,7 @@ Office でも問題なく動作し続けます。
 <summary><b>自分の AI モデルや API キーを使えますか？</b></summary>
 
 はい。キー不要の Genspark サインインに加えて、GenOffice は Claude、OpenAI、Gemini、
-DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、OpenCode Zen/Go 向け
+DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty、OpenCode Zen/Go 向け
 に自分のキーを持ち込むことができ、任意の OpenAI 互換エンドポイント（ローカルモデルサーバー
 を含む）にも対応しています。検索、画像生成、画像／動画解析は、設定 → AI メディア＆検索でそ
 れぞれ別のキーを設定します。

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -47,7 +47,7 @@ GenOffice는 macOS, Windows, Linux에서 사용할 수 있는 무료 오픈소�
   AI 호출만 사용자가 선택한 공급자로 전송됩니다.
 - **API 키가 있어도, 없어도 됩니다.** Genspark로 로그인하면 키 없이 바로
   사용할 수 있고, 원한다면 Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM,
-  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter는 물론 OpenAI
+  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty는 물론 OpenAI
   호환 엔드포인트(로컬 서버 포함)까지 직접 가져올 수 있습니다.
 
 **다운로드:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon 및 Intel) ·
@@ -183,7 +183,7 @@ Genspark 프록시(Claude, GPT, Gemini 계열)를 거치고, 에이전트는 웹
 있습니다.
 
 **직접 키를 가져올 수도 있습니다.** 설정 → AI에는 Claude, OpenAI, Gemini,
-DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter,
+DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty,
 OpenCode Zen/Go가 있으며, 로컬 모델 서버를 포함한 모든 OpenAI 호환
 엔드포인트(기본 URL + 키)를 위한 사용자 지정 슬롯도 제공됩니다. 검색과
 미디어는 **AI 미디어 및 검색**에서 기능별로 별도 공급자를 설정할 수
@@ -345,7 +345,7 @@ GenOffice는 활발히 개발되고 있으며, 여러분의 피드백이 그 방
 
 네. 키가 필요 없는 Genspark 로그인 외에도, GenOffice는 Claude, OpenAI,
 Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-OpenRouter, OpenCode Zen/Go를 위한 직접 키 사용을 지원하며, 로컬 모델
+OpenRouter, Requesty, OpenCode Zen/Go를 위한 직접 키 사용을 지원하며, 로컬 모델
 서버를 포함한 모든 OpenAI 호환 엔드포인트도 사용할 수 있습니다. 검색,
 이미지 생성, 이미지/비디오 분석은 설정 → AI 미디어 및 검색에서 별도의
 키를 설정합니다.

--- a/docs/i18n/README.ms.md
+++ b/docs/i18n/README.ms.md
@@ -50,7 +50,7 @@ kepada anda dengan tepat apa yang disentuhnya.
 - **Kunci anda sendiri atau tiada langsung.** Log masuk dengan Genspark dan
   anda tidak perlu sebarang kunci, atau bawa kunci anda sendiri untuk Claude,
   OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-  OpenRouter, atau mana-mana titik akhir yang serasi dengan OpenAI, termasuk
+  OpenRouter, Requesty, atau mana-mana titik akhir yang serasi dengan OpenAI, termasuk
   pelayan setempat.
 
 **Dapatkan:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon dan Intel) ·
@@ -188,7 +188,7 @@ Gemini) dan agen mendapat carian web serta imej, penjanaan imej, dan analisis
 imej/audio/video.
 
 **Atau bawa kunci anda sendiri.** Settings → AI menyenaraikan Claude, OpenAI,
-Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter
+Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
 dan OpenCode Zen/Go, ditambah slot tersuai untuk mana-mana titik akhir yang
 serasi dengan OpenAI (URL asas + kunci), termasuk pelayan model setempat.
 Carian dan media mempunyai pembekal tersendiri mengikut keupayaan di bawah
@@ -352,7 +352,7 @@ halaman.
 
 Ya. Selain log masuk Genspark tanpa kunci, GenOffice menyokong bawa kunci
 anda sendiri untuk Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao,
-MiniMax, Grok, Mistral, OpenRouter dan OpenCode Zen/Go, ditambah mana-mana
+MiniMax, Grok, Mistral, OpenRouter, Requesty dan OpenCode Zen/Go, ditambah mana-mana
 titik akhir serasi OpenAI — termasuk pelayan model setempat. Carian,
 penjanaan imej dan analisis imej/video memerlukan kunci tersendiri di bawah
 Settings → AI Media & Search.

--- a/docs/i18n/README.nl.md
+++ b/docs/i18n/README.nl.md
@@ -48,7 +48,7 @@ aangepast.
   verlaten de machine, naar de provider die jij kiest.
 - **Jouw eigen keys, of geen enkele.** Log in met Genspark en je hoeft niets te
   regelen, of gebruik je eigen key voor Claude, OpenAI, Gemini, DeepSeek,
-  Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, of elk
+  Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty, of elk
   OpenAI-compatibel endpoint, inclusief lokale servers.
 
 **Haal het hier:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon en Intel) ·
@@ -186,7 +186,7 @@ krijgen toegang tot web- en beeldzoeken, beeldgeneratie en analyse van beeld,
 audio en video.
 
 **Of gebruik je eigen key.** Onder Settings → AI vind je Claude, OpenAI,
-Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter
+Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
 en OpenCode Zen/Go, plus een aangepast slot voor elk OpenAI-compatibel
 endpoint (base URL + key), inclusief lokale modelservers. Zoeken en media
 hebben elk hun eigen providers per capability onder **AI Media & Search**:
@@ -351,7 +351,7 @@ pagina-afbeelding.
 
 Ja. Naast de keyless Genspark-login ondersteunt GenOffice je eigen key voor
 Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-Mistral, OpenRouter en OpenCode Zen/Go, plus elk OpenAI-compatibel endpoint —
+Mistral, OpenRouter, Requesty en OpenCode Zen/Go, plus elk OpenAI-compatibel endpoint —
 inclusief lokale modelservers. Search, beeldgeneratie en analyse van beeld en
 video gebruiken hun eigen keys onder Settings → AI Media & Search.
 

--- a/docs/i18n/README.pl.md
+++ b/docs/i18n/README.pl.md
@@ -48,7 +48,7 @@ i pokazuje precyzyjnie, czego dotknął.
   wybierzesz.
 - **Twoje klucze albo żadne.** Zaloguj się przez Genspark i pomiń klucze, albo
   użyj własnego klucza dla Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen,
-  Doubao, MiniMax, Grok, Mistral, OpenRouter lub dowolnego endpointu
+  Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty lub dowolnego endpointu
   zgodnego z OpenAI, w tym lokalnych serwerów.
 
 **Pobierz:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon i Intel) ·
@@ -188,7 +188,7 @@ analizę obrazu, audio i wideo.
 
 **Albo użyj własnego klucza.** Ustawienia → AI zawierają Claude, OpenAI,
 Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-OpenRouter oraz OpenCode Zen/Go, a także dowolny slot dla endpointu zgodnego
+OpenRouter, Requesty oraz OpenCode Zen/Go, a także dowolny slot dla endpointu zgodnego
 z OpenAI (adres bazowy + klucz), w tym lokalnych serwerów modeli.
 Wyszukiwanie i media mają własnych dostawców przypisanych do konkretnej
 funkcji w sekcji **AI Media & Search**: Serper lub Tavily do wyszukiwania w
@@ -355,7 +355,7 @@ tekstu, a nie obrazu strony.
 
 Tak. Oprócz bezkluczowego logowania przez Genspark, GenOffice wspiera
 użycie własnego klucza dla Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM,
-Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter i OpenCode Zen/Go, a także
+Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty i OpenCode Zen/Go, a także
 dowolnego endpointu zgodnego z OpenAI — w tym lokalnych serwerów modeli.
 Wyszukiwanie, generowanie obrazów oraz analiza obrazu i wideo mają własne
 klucze w Ustawienia → AI Media & Search.

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -47,7 +47,7 @@ lê o arquivo, faz a alteração e mostra exatamente o que foi tocado.
   máquina, para o provedor que você escolher.
 - **Suas chaves, ou nenhuma.** Faça login com o Genspark e pule as chaves, ou
   use sua própria chave para Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM,
-  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, ou qualquer endpoint
+  Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty, ou qualquer endpoint
   compatível com OpenAI, incluindo servidores locais.
 
 **Baixe:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon e Intel) ·
@@ -187,7 +187,7 @@ agentes ganham busca na web e de imagens, geração de imagens e análise de
 imagem/áudio/vídeo.
 
 **Ou traga sua própria chave.** Configurações → IA lista Claude, OpenAI,
-Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter
+Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty
 e OpenCode Zen/Go, além de um slot personalizado para qualquer endpoint
 compatível com OpenAI (URL base + chave), incluindo servidores de modelo
 locais. Busca e mídia têm seus próprios provedores por capacidade em **IA de
@@ -352,7 +352,7 @@ imagem da página.
 
 Sim. Além do login sem chave pelo Genspark, o GenOffice permite trazer sua
 própria chave para Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen,
-Doubao, MiniMax, Grok, Mistral, OpenRouter e OpenCode Zen/Go, além de
+Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty e OpenCode Zen/Go, além de
 qualquer endpoint compatível com OpenAI — incluindo servidores de modelo
 locais. Busca, geração de imagens e análise de imagem/vídeo usam suas
 próprias chaves em Configurações → IA de Mídia e Busca.

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -49,7 +49,7 @@ AI-агента рядом с каждым документом — не чат-
   выбранному вами провайдеру.
 - **Свои ключи или никаких.** Войдите через Genspark и обойдитесь без ключей
   вообще, либо используйте собственный ключ для Claude, OpenAI, Gemini,
-  DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter или
+  DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty или
   любого совместимого с OpenAI эндпоинта, включая локальные серверы.
 
 **Скачать:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon и Intel) ·
@@ -189,7 +189,7 @@ AI-агента рядом с каждым документом — не чат-
 
 **Либо используйте собственный ключ.** В разделе Settings → AI перечислены
 Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok,
-Mistral, OpenRouter и OpenCode Zen/Go, а также отдельный слот для любого
+Mistral, OpenRouter, Requesty и OpenCode Zen/Go, а также отдельный слот для любого
 совместимого с OpenAI эндпоинта (базовый URL + ключ), включая локальные
 серверы моделей. Поиск и работа с медиа настраиваются через отдельных
 провайдеров по каждой возможности в разделе **AI Media & Search**: Serper
@@ -356,7 +356,7 @@ Windows их читает системный OCR, поэтому они конв
 
 Да. Помимо входа через Genspark без ключей, GenOffice поддерживает
 собственный ключ для Claude, OpenAI, Gemini, DeepSeek, Kimi, GLM, Qwen,
-Doubao, MiniMax, Grok, Mistral, OpenRouter и OpenCode Zen/Go, а также любой
+Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty и OpenCode Zen/Go, а также любой
 совместимый с OpenAI эндпоинт — включая локальные серверы моделей. Поиск,
 генерация изображений и анализ изображений/видео используют собственные
 ключи в разделе Settings → AI Media & Search.

--- a/docs/i18n/README.th.md
+++ b/docs/i18n/README.th.md
@@ -47,7 +47,7 @@ Windows และ Linux เปิดและบันทึกไฟล์ `.do
 - **ใช้คีย์ของคุณเองหรือไม่ต้องใช้เลยก็ได้** ลงชื่อเข้าใช้ด้วย Genspark
   แล้วข้ามการตั้งค่าคีย์ไปได้เลย หรือใช้คีย์ของคุณเองกับ Claude, OpenAI,
   Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-  OpenRouter หรือ endpoint ที่รองรับ OpenAI-compatible ใดๆ
+  OpenRouter, Requesty หรือ endpoint ที่รองรับ OpenAI-compatible ใดๆ
   รวมถึงเซิร์ฟเวอร์โมเดลภายในเครื่องด้วย
 
 **ดาวน์โหลด:** [macOS](https://github.com/genspark-ai/genoffice/releases/latest) (Apple Silicon และ Intel) ·
@@ -181,7 +181,7 @@ Windows และ Linux เปิดและบันทึกไฟล์ `.do
 
 **หรือใช้คีย์ของคุณเอง** เมนู Settings → AI มีให้เลือก Claude, OpenAI,
 Gemini, DeepSeek, Kimi, GLM, Qwen, Doubao, MiniMax, Grok, Mistral,
-OpenRouter และ OpenCode Zen/Go พร้อมช่องสำหรับ endpoint ที่รองรับ
+OpenRouter, Requesty และ OpenCode Zen/Go พร้อมช่องสำหรับ endpoint ที่รองรับ
 OpenAI-compatible แบบกำหนดเอง (base URL + คีย์) รวมถึงเซิร์ฟเวอร์โมเดล
 ในเครื่องด้วย การค้นหาและมีเดียมีผู้ให้บริการแยกตามความสามารถของตัวเอง
 ภายใต้ **AI Media & Search**: Serper หรือ Tavily สำหรับการค้นหาเว็บ
@@ -340,7 +340,7 @@ GenOffice อยู่ในระหว่างการพัฒนาอย�
 
 ได้ นอกจากการลงชื่อเข้าใช้ด้วย Genspark ที่ไม่ต้องใช้คีย์แล้ว GenOffice
 ยังรองรับการใช้คีย์ของคุณเองกับ Claude, OpenAI, Gemini, DeepSeek, Kimi,
-GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter และ OpenCode Zen/Go
+GLM, Qwen, Doubao, MiniMax, Grok, Mistral, OpenRouter, Requesty และ OpenCode Zen/Go
 พร้อม endpoint ที่รองรับ OpenAI-compatible ใดๆ — รวมถึงเซิร์ฟเวอร์โมเดล
 ในเครื่องด้วย การค้นหา การสร้างภาพ และการวิเคราะห์ภาพ/วิดีโอ ใช้คีย์
 แยกของตัวเองภายใต้ Settings → AI Media & Search

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -43,7 +43,7 @@ PDF、Markdown 和 HTML，并在每份文档旁边配备一个 AI 智能体 —�
   只有 AI 调用会发送到你选择的服务商。
 - **用自己的密钥，或者不用密钥。** 登录 Genspark 即可免配置使用；也可以自带
   Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、
-  Mistral、OpenRouter 的密钥，或任何 OpenAI 兼容端点，包括本地模型服务。
+  Mistral、OpenRouter、Requesty 的密钥，或任何 OpenAI 兼容端点，包括本地模型服务。
 
 **获取：** [macOS](https://github.com/genspark-ai/genoffice/releases/latest)（Apple Silicon 和 Intel）·
 [Windows](https://github.com/genspark-ai/genoffice/releases/latest)（x64 和 Arm）·
@@ -173,7 +173,7 @@ PDF、Markdown 和 HTML，并在每份文档旁边配备一个 AI 智能体 —�
 解析能力。
 
 **或者自带密钥。** 设置 → AI 中列出了 Claude、OpenAI、Gemini、DeepSeek、Kimi、
-GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter 和 OpenCode Zen/Go，另有
+GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty 和 OpenCode Zen/Go，另有
 一个自定义槽位可接入任何 OpenAI 兼容端点（Base URL + 密钥），包括本地模型服务。
 搜索和媒体能力在 **AI 媒体与搜索** 下按能力分别配置服务商：网页搜索可选 Serper
 或 Tavily；图片生成和图片/视频解析可选 OpenAI、Gemini、Doubao/Seedream、GLM、
@@ -321,7 +321,7 @@ GenOffice 正在积极开发中，你的反馈决定它的走向。
 <summary><b>我可以使用自己的 AI 模型或 API 密钥吗？</b></summary>
 
 可以。除了免密钥的 Genspark 登录，GenOffice 还支持自带 Claude、OpenAI、Gemini、
-DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter 和
+DeepSeek、Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty 和
 OpenCode Zen/Go 的密钥，以及任何 OpenAI 兼容端点 —— 包括本地模型服务。搜索、
 图片生成和图片/视频解析在 设置 → AI 媒体与搜索 下使用各自的密钥。
 

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -44,7 +44,7 @@ Windows 與 Linux。它能開啟並儲存原生的 `.docx`、`.xlsx` 與 `.pptx`
   在本機執行。只有 AI 呼叫會離開這台裝置，且僅送往你選擇的服務商。
 - **用你自己的金鑰，或完全不用。** 用 Genspark 登入即可省去金鑰設定，
   或自行帶入 Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、
-  Doubao、MiniMax、Grok、Mistral、OpenRouter，或任何相容 OpenAI 介面
+  Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty，或任何相容 OpenAI 介面
   的服務端點，也支援本機伺服器。
 
 **立即取得：** [macOS](https://github.com/genspark-ai/genoffice/releases/latest)（Apple Silicon 與 Intel）·
@@ -205,7 +205,7 @@ GenOffice 會規劃敘事脈絡、研究相關數據，並把每一頁直接生�
 圖片生成，以及圖片／音訊／影片分析。
 
 **或自帶金鑰。**「設定 → AI」列出了 Claude、OpenAI、Gemini、DeepSeek、
-Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter 與
+Kimi、GLM、Qwen、Doubao、MiniMax、Grok、Mistral、OpenRouter、Requesty 與
 OpenCode Zen/Go，另外還有一個自訂欄位可填入任何相容 OpenAI 的服務端點
 （base URL + 金鑰），也包括本機模型伺服器。搜尋與媒體功能則各自在
 **AI 媒體與搜尋**下設定獨立的服務商：網頁搜尋可選 Serper 或 Tavily，
@@ -360,7 +360,7 @@ Office 中依然能正常使用。
 
 可以。除了免金鑰的 Genspark 登入之外，GenOffice 也支援自帶金鑰，
 涵蓋 Claude、OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen、Doubao、
-MiniMax、Grok、Mistral、OpenRouter 與 OpenCode Zen/Go，以及任何相容
+MiniMax、Grok、Mistral、OpenRouter、Requesty 與 OpenCode Zen/Go，以及任何相容
 OpenAI 的服務端點——包括本機模型伺服器。搜尋、圖片生成與圖片／影片
 分析則在「設定 → AI 媒體與搜尋」下使用各自獨立的金鑰。
 

--- a/packages/ai-provider/src/providers.ts
+++ b/packages/ai-provider/src/providers.ts
@@ -174,6 +174,26 @@ export const AI_PROVIDERS: AiProviderMeta[] = [
     keyPlaceholder: 'sk-or-...',
   },
   {
+    id: 'requesty',
+    label: 'Requesty',
+    // Managed policy ids exactly as GET router.requesty.ai/v1/models/managed
+    // lists them (2026-09-11): short stable names Requesty routes across
+    // providers, used as-is in the model field. The full vendor-prefixed
+    // catalog (GET /v1/models, e.g. openai/gpt-4o-mini) works too when typed
+    // in. Ids ending "@eu" route through EU providers only.
+    models: [
+      'claude-sonnet-5',
+      'claude-opus-4-8',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gemini-3.7-flash',
+      'deepseek-v4-pro',
+      'kimi-k3',
+    ],
+    defaultModel: 'claude-sonnet-5',
+    keyPlaceholder: 'sk-...',
+  },
+  {
     id: 'opencode-zen',
     label: 'OpenCode Zen',
     // Pay-as-you-go gateway (opencode.ai/docs/zen); ids exactly as GET

--- a/packages/ai-provider/src/registry.ts
+++ b/packages/ai-provider/src/registry.ts
@@ -228,6 +228,12 @@ export const AI_PROVIDER_ADAPTERS: Record<AiProviderId, ProviderAdapter> = {
     capabilities: { auth: 'api-key', vision: true },
     resolveEndpoint: fixedEndpoint('openai-compatible', 'https://openrouter.ai/api/v1'),
   },
+  requesty: {
+    meta: metaOf('requesty'),
+    capabilities: { auth: 'api-key', vision: true },
+    // a stored base URL selects a regional router (https://router.eu.requesty.ai/v1 for the EU)
+    resolveEndpoint: fixedEndpoint('openai-compatible', 'https://router.requesty.ai/v1'),
+  },
   'opencode-zen': {
     meta: metaOf('opencode-zen'),
     capabilities: { auth: 'api-key', vision: true },

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -15,6 +15,7 @@ export type AiProviderId =
   | 'xai'
   | 'mistral'
   | 'openrouter'
+  | 'requesty'
   | 'opencode-zen'
   | 'opencode-go'
   | 'custom'

--- a/packages/ai-provider/tests/providers.test.ts
+++ b/packages/ai-provider/tests/providers.test.ts
@@ -54,6 +54,15 @@ describe('provider model catalog', () => {
       }
     }
   })
+
+  it('seeds Requesty with managed policy ids (short names, no vendor prefix)', () => {
+    const requesty = AI_PROVIDERS.find((provider) => provider.id === 'requesty')!
+    expect(requesty.models).toContain(requesty.defaultModel)
+    expect(requesty.needsBaseUrl).toBeUndefined()
+    for (const model of requesty.models) {
+      expect(model).not.toContain('/')
+    }
+  })
 })
 
 describe('resolveAiSettings', () => {

--- a/packages/ai-provider/tests/registry.test.ts
+++ b/packages/ai-provider/tests/registry.test.ts
@@ -99,6 +99,7 @@ describe('provider registry', () => {
       ['xai', 'grok-4.6', 'https://api.x.ai/v1'],
       ['mistral', 'mistral-large-latest', 'https://api.mistral.ai/v1'],
       ['openrouter', 'openrouter/auto', 'https://openrouter.ai/api/v1'],
+      ['requesty', 'claude-sonnet-5', 'https://router.requesty.ai/v1'],
     ]
     for (const [id, model, baseUrl] of cases) {
       expect(AI_PROVIDER_ADAPTERS[id].resolveEndpoint(config(model))).toEqual({
@@ -271,6 +272,28 @@ describe('fixed-sampling models on indirect routes', () => {
       protocol: 'openai-compatible',
       baseUrl: 'https://mirror/v1',
       omitTemperature: true,
+    })
+  })
+
+  it('omits temperature for fixed-sampling managed policies via Requesty', () => {
+    const resolve = (model: string, baseUrl?: string) =>
+      AI_PROVIDER_ADAPTERS.requesty.resolveEndpoint(config(model, baseUrl))
+    for (const model of ['kimi-k3', 'gpt-5.6-sol', 'gemini-3.7-flash', 'openai/gpt-5.4']) {
+      expect(resolve(model)).toEqual({
+        protocol: 'openai-compatible',
+        baseUrl: 'https://router.requesty.ai/v1',
+        omitTemperature: true,
+      })
+    }
+    // the full-catalog vendor-prefixed ids work as-is on the same endpoint
+    expect(resolve('openai/gpt-4o-mini')).toEqual({
+      protocol: 'openai-compatible',
+      baseUrl: 'https://router.requesty.ai/v1',
+    })
+    // a stored base URL picks the EU router
+    expect(resolve('claude-sonnet-5', 'https://router.eu.requesty.ai/v1')).toEqual({
+      protocol: 'openai-compatible',
+      baseUrl: 'https://router.eu.requesty.ai/v1',
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds Requesty (router.requesty.ai) to the bring-your-own-key provider picker, wired the same way as OpenRouter: an `openai-compatible` fixed endpoint at `https://router.requesty.ai/v1`. A stored base URL selects a regional router such as `https://router.eu.requesty.ai/v1`.
- One Requesty key reaches 700+ models across OpenAI, Anthropic, Google, DeepSeek, Moonshot and others, plus Requesty's managed routing policies (a Requesty maintained multi provider routing chain per model). Users who already route through Requesty can bring that key here without falling back to the generic custom endpoint.

Changes:
- `packages/ai-provider/src/types.ts`: `requesty` added to `AiProviderId`.
- `packages/ai-provider/src/providers.ts`: `AI_PROVIDERS` entry seeded from the managed policy ids returned by `GET /v1/models/managed` (verified live on 2026-09-11), default `claude-sonnet-5`. Vendor prefixed catalog ids such as `openai/gpt-4o-mini` also work when typed in.
- `packages/ai-provider/src/registry.ts`: adapter with api key auth and vision, mirroring the OpenRouter adapter.
- `apps/shell/src/renderer/src/provider-logos.tsx`: plain monochrome "R" mark using `currentColor` (no trademarked artwork).
- `README.md` and the 19 translated READMEs in `docs/i18n/`: "Requesty" inserted after "OpenRouter" in the provider lists, using each language's own list separator.

## Related issue

Not applicable, no existing issue.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

ai-provider: 212 passed, shell: 239 passed, docs: 1922 passed. New tests in `registry.test.ts` and `providers.test.ts` cover the endpoint row, fixed sampling handling for the seeded ids (`temperature` dropped for gpt-5 / gemini-3 / kimi-k3), vendor prefixed catalog ids, the EU base URL override, and that the seed list contains the default with no `needsBaseUrl`.

Live check through the package's own `chatForProvider('requesty', ...)` path returned a reply for both `openai/gpt-4o-mini` and the managed default `claude-sonnet-5`, and `GET /v1/models/managed` listed all 7 seeded ids.

## Screenshots or recordings

Not applicable (one new row in the existing data driven provider picker, no layout change).

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [ ] File open/save changes include an appropriate round-trip or fidelity test. (Not applicable, no file format changes.)

Disclosure: I work at Requesty. Happy to adjust anything to match project conventions.
