### PR TITLE
fix(i18n): require BCP-47 boundary in normalizeLang prefix match

### DIFF
--- a/apps/sheets/tests/csv-import.test.ts
+++ b/apps/sheets/tests/csv-import.test.ts
@@ -103,7 +103,7 @@ describe('parseCsv', () => {
     // The "" escape keeps the field quoted: all five inner ; must not count,
     // or they outvote the two true commas and the columns mis-split.
     expect(sniffDelimiter('a,"; ""; ""; ""; """,d')).toBe(',')
-    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; ""; ""; ""; ""', 'd']])
+    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; "; "; "; "', 'd']])
   })
 
   it('drops the trailing empty row from a final newline', () => {

--- a/apps/slides/tests/ai-panel-collapse.test.ts
+++ b/apps/slides/tests/ai-panel-collapse.test.ts
@@ -130,7 +130,9 @@ describe('AiPanel collapse (slides)', () => {
         'textarea[data-slides-ai-input]',
       )
       expect(textarea).not.toBeNull()
-      expect(textarea!.spellcheck).toBe(false)
+      // jsdom does not implement the spellcheck IDL attribute (it always reads
+      // back undefined), so assert on the rendered content attribute instead.
+      expect(textarea!.getAttribute('spellcheck')).toBe('false')
       cleanup()
     } finally {
       applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: true })

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -54,7 +54,8 @@ export function normalizeLang(raw: string | null | undefined): Lang {
   // traditional-script Chinese variants must win over the generic 'zh' prefix
   if (/^zh[-_](tw|hk|mo|hant)/.test(value)) return 'zh-TW'
   for (const lang of LANGS) {
-    if (lang !== 'en' && lang !== 'zh-TW' && value.startsWith(lang)) return lang
+    if (lang === 'en' || lang === 'zh-TW') continue
+    if (value === lang || value.startsWith(`${lang}-`) || value.startsWith(`${lang}_`)) return lang
   }
   // 'in' is the legacy ISO code for Indonesian still reported by some systems
   if (/^in\b/.test(value) || /^in[-_]/.test(value)) return 'id'

--- a/packages/i18n/tests/i18n.test.ts
+++ b/packages/i18n/tests/i18n.test.ts
@@ -56,10 +56,23 @@ describe('normalizeLang', () => {
 
   it('maps everything else (and missing) to en', () => {
     expect(normalizeLang('en-US')).toBe('en')
+    expect(normalizeLang('en_US')).toBe('en')
     expect(normalizeLang('sv-SE')).toBe('en')
     expect(normalizeLang('')).toBe('en')
     expect(normalizeLang(undefined)).toBe('en')
     expect(normalizeLang(null)).toBe('en')
+  })
+
+  it('requires a BCP-47 boundary after the language code', () => {
+    expect(normalizeLang('deleted')).toBe('en')
+    expect(normalizeLang('french')).toBe('en')
+    expect(normalizeLang('thread')).toBe('en')
+    expect(normalizeLang('italian')).toBe('en')
+    expect(normalizeLang('hebrew')).toBe('en')
+    expect(normalizeLang('de')).toBe('de')
+    expect(normalizeLang('de-DE')).toBe('de')
+    expect(normalizeLang('de_DE')).toBe('de')
+    expect(normalizeLang('es-419')).toBe('es')
   })
 })
 


### PR DESCRIPTION
## Summary

- What changed? `normalizeLang` in `packages/i18n/src/index.ts` now requires an exact language code or a BCP-47 delimiter (hyphen or underscore) after the code. Boundary regression tests were added in `packages/i18n/tests/i18n.test.ts`.
- Why is this change needed? The old prefix match accepted any string starting with a supported code, so ordinary words such as deleted, french, thread, italian, and hebrew were misdetected as German, French, Thai, Italian, and Hebrew, and the UI could start in the wrong language.

## Related issue

None. Self-identified defect found during review; regression test included.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: the targeted i18n workspace suite was run locally with all tests passing; the full suite runs in CI. This branch also carries the two red-main test corrections from PR 314 because the base revision fails those tests without them; those extra commits will be dropped on rebase once PR 314 lands.

## Screenshots or recordings

Not applicable. No visible changes.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
