### PR TITLE
fix(ai-provider): match JSON Content-Type case-insensitively

### DIFF
--- a/apps/sheets/tests/csv-import.test.ts
+++ b/apps/sheets/tests/csv-import.test.ts
@@ -103,7 +103,7 @@ describe('parseCsv', () => {
     // The "" escape keeps the field quoted: all five inner ; must not count,
     // or they outvote the two true commas and the columns mis-split.
     expect(sniffDelimiter('a,"; ""; ""; ""; """,d')).toBe(',')
-    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; ""; ""; ""; ""', 'd']])
+    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; "; "; "; "', 'd']])
   })
 
   it('drops the trailing empty row from a final newline', () => {

--- a/apps/slides/tests/ai-panel-collapse.test.ts
+++ b/apps/slides/tests/ai-panel-collapse.test.ts
@@ -130,7 +130,9 @@ describe('AiPanel collapse (slides)', () => {
         'textarea[data-slides-ai-input]',
       )
       expect(textarea).not.toBeNull()
-      expect(textarea!.spellcheck).toBe(false)
+      // jsdom does not implement the spellcheck IDL attribute (it always reads
+      // back undefined), so assert on the rendered content attribute instead.
+      expect(textarea!.getAttribute('spellcheck')).toBe('false')
       cleanup()
     } finally {
       applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: true })

--- a/packages/ai-provider/src/protocols/shared.ts
+++ b/packages/ai-provider/src/protocols/shared.ts
@@ -109,7 +109,7 @@ export function sseErrorText(error: unknown, fallback: string): string {
  */
 export async function jsonBodyInsteadOfSse(response: Response): Promise<string | null> {
   const contentType = response.headers.get('content-type') ?? ''
-  return contentType.includes('application/json') ? await response.text() : null
+  return contentType.toLowerCase().includes('application/json') ? await response.text() : null
 }
 
 /**

--- a/packages/ai-provider/tests/stream.test.ts
+++ b/packages/ai-provider/tests/stream.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentToolCall } from '@genoffice/agent-core'
 import { AiCreditsError, sseLines, streamForProvider } from '../src/stream'
+import { jsonBodyInsteadOfSse } from '../src/protocols/shared'
 import { jsonResponse, okResponse, sseStream } from './test-utils'
 
 afterEach(() => {
@@ -1144,5 +1145,25 @@ describe('streamForProvider: a connection dropped mid tool arguments is not an e
       cb,
     )
     expect(toolCalls.map((c) => [c.name, c.input])).toEqual([['ping', { a: 1 }]])
+  })
+})
+
+describe('jsonBodyInsteadOfSse', () => {
+  it('detects JSON bodies regardless of Content-Type casing', async () => {
+    const payload = JSON.stringify({ choices: [] })
+    for (const contentType of [
+      'application/json',
+      'Application/JSON',
+      'APPLICATION/JSON; charset=utf-8',
+      'Application/Json; charset=utf-8',
+    ]) {
+      const res = new Response(payload, { status: 200, headers: { 'content-type': contentType } })
+      await expect(jsonBodyInsteadOfSse(res)).resolves.toBe(payload)
+    }
+    const sse = new Response('data: hi\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })
+    await expect(jsonBodyInsteadOfSse(sse)).resolves.toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- What changed? `jsonBodyInsteadOfSse` in `packages/ai-provider/src/protocols/shared.ts` lowercases the Content-Type header value before checking for a JSON body. A casing regression test was added in `packages/ai-provider/tests/stream.test.ts`.
- Why is this change needed? Gateways and proxies may answer with a capitalized Content-Type such as Application JSON. The case-sensitive check missed those bodies, so all three streaming paths fell through to the SSE parser, found no data lines, and reported an empty stream instead of emitting the complete JSON reply or detecting the credits-exhausted notice.

## Related issue

None. Self-identified defect found during review; regression test included.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: the full ai-provider workspace suite was run locally with all tests passing; the full suite runs in CI. This branch also carries the two red-main test corrections from PR 314 because the base revision fails those tests without them; those extra commits will be dropped on rebase once PR 314 lands.

## Screenshots or recordings

Not applicable. No visible changes.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
