### PR TITLE
fix(docs,slides): accept spaces around dashes in print ranges

### DIFF
--- a/apps/docs/src/renderer/print-range.ts
+++ b/apps/docs/src/renderer/print-range.ts
@@ -5,8 +5,10 @@
  */
 export function parsePrintRange(text: string, max: number): number[] | null {
   const out = new Set<number>()
-  const parts = text.split(/[,，、;；\s]+/).filter(Boolean)
+  const tokenRe = /\d+\s*[-–]\s*\d+|\d+/g
+  const parts = text.match(tokenRe) ?? []
   if (parts.length === 0) return null
+  if (text.replace(tokenRe, '').replace(/[,，、;；\s]/g, '') !== '') return null
   for (const part of parts) {
     const m = /^(\d+)\s*[-–]\s*(\d+)$|^(\d+)$/.exec(part)
     if (!m) return null

--- a/apps/docs/tests/print-range.test.ts
+++ b/apps/docs/tests/print-range.test.ts
@@ -14,6 +14,11 @@ describe('parsePrintRange', () => {
     expect(parsePrintRange('1，3、5–6', 6)).toEqual([0, 2, 4, 5])
   })
 
+  it('accepts spaces around dashes', () => {
+    expect(parsePrintRange('1 - 3', 5)).toEqual([0, 1, 2])
+    expect(parsePrintRange('1 – 3, 5', 5)).toEqual([0, 1, 2, 4])
+  })
+
   it('rejects empty, malformed, reversed, and out-of-bounds input', () => {
     expect(parsePrintRange('', 5)).toBeNull()
     expect(parsePrintRange('a-b', 5)).toBeNull()

--- a/apps/sheets/tests/csv-import.test.ts
+++ b/apps/sheets/tests/csv-import.test.ts
@@ -103,7 +103,7 @@ describe('parseCsv', () => {
     // The "" escape keeps the field quoted: all five inner ; must not count,
     // or they outvote the two true commas and the columns mis-split.
     expect(sniffDelimiter('a,"; ""; ""; ""; """,d')).toBe(',')
-    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; ""; ""; ""; ""', 'd']])
+    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; "; "; "; "', 'd']])
   })
 
   it('drops the trailing empty row from a final newline', () => {

--- a/apps/slides/src/shared/print-html.ts
+++ b/apps/slides/src/shared/print-html.ts
@@ -26,8 +26,10 @@ export interface PrintDocOptions {
 /** "1,3,5-8" → 0-based slide indices (1-based input over the whole deck); null = invalid */
 export function parsePrintRange(text: string, max: number): number[] | null {
   const out = new Set<number>()
-  const parts = text.split(/[,，、;；\s]+/).filter(Boolean)
+  const tokenRe = /\d+\s*[-–]\s*\d+|\d+/g
+  const parts = text.match(tokenRe) ?? []
   if (parts.length === 0) return null
+  if (text.replace(tokenRe, '').replace(/[,，、;；\s]/g, '') !== '') return null
   for (const part of parts) {
     const m = /^(\d+)\s*[-–]\s*(\d+)$|^(\d+)$/.exec(part)
     if (!m) return null

--- a/apps/slides/tests/ai-panel-collapse.test.ts
+++ b/apps/slides/tests/ai-panel-collapse.test.ts
@@ -130,7 +130,9 @@ describe('AiPanel collapse (slides)', () => {
         'textarea[data-slides-ai-input]',
       )
       expect(textarea).not.toBeNull()
-      expect(textarea!.spellcheck).toBe(false)
+      // jsdom does not implement the spellcheck IDL attribute (it always reads
+      // back undefined), so assert on the rendered content attribute instead.
+      expect(textarea!.getAttribute('spellcheck')).toBe('false')
       cleanup()
     } finally {
       applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: true })

--- a/apps/slides/tests/print-html.test.ts
+++ b/apps/slides/tests/print-html.test.ts
@@ -17,6 +17,11 @@ describe('parsePrintRange', () => {
     expect(parsePrintRange('4-2', 5)).toBeNull()
     expect(parsePrintRange('6', 5)).toBeNull()
   })
+
+  it('accepts spaces around dashes', () => {
+    expect(parsePrintRange('1 - 3', 5)).toEqual([0, 1, 2])
+    expect(parsePrintRange('1 – 3, 5', 5)).toEqual([0, 1, 2, 4])
+  })
 })
 
 describe('printPageCount', () => {


### PR DESCRIPTION
## Summary

- What changed? The print-range parsers in `apps/docs/src/renderer/print-range.ts` and `apps/slides/src/shared/print-html.ts` now tokenize range-or-single inputs with a pattern match instead of splitting on whitespace, rejecting any leftover characters outside the known separators. Spaced hyphen and en-dash cases were added to both test files.
- Why is this change needed? Both parsers split on whitespace before matching, so an input like 1 - 3 became three fragments and the lone dash failed validation, rejecting the whole range. The range pattern already allowed whitespace around the dash, but the pre-split destroyed it. Space-separated pages keep working as before.

## Related issue

None. Self-identified defect found during review; regression tests included.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: the targeted docs and slides suites were run locally with all tests passing; the full suite runs in CI. This branch also carries the two red-main test corrections from PR 314 because the base revision fails those tests without them; those extra commits will be dropped on rebase once PR 314 lands.

## Screenshots or recordings

Not applicable. No visible changes.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
