### PR TITLE
fix(docs): count Greek, Cyrillic, Hebrew, and Arabic words

### DIFF
--- a/apps/docs/src/renderer/word-count.ts
+++ b/apps/docs/src/renderer/word-count.ts
@@ -13,7 +13,10 @@
 const ASIAN_RE =
   /[ᄀ-ᇿ⺀-⿟、-〿぀-ヿ㄀-ㄯ㄰-㆏㇀-ㇿ㐀-䶿一-鿿가-힯豈-﫿！-｠￠-￦]|[\uD840-\uD87F][\uDC00-\uDFFF]/g
 
-const NON_ASIAN_WORD_RE = /[A-Za-z0-9À-ɏ]+(?:['-][A-Za-z0-9À-ɏ]+)*/g
+// Latin Extended Additional (Vietnamese, …) plus the space-delimited
+// non-Latin scripts Word counts as words: Greek, Cyrillic, Hebrew, Arabic.
+// Deliberately excludes the ASIAN_RE ranges above (counted char-by-char).
+const NON_ASIAN_WORD_RE = /[A-Za-z0-9À-ɏͰ-ϿЀ-ӿ֐-׿؀-ۿḀ-ỿ]+(?:['-][A-Za-z0-9À-ɏͰ-ϿЀ-ӿ֐-׿؀-ۿḀ-ỿ]+)*/g
 
 export function asianCharCount(text: string): number {
   return (text.match(ASIAN_RE) ?? []).length

--- a/apps/docs/tests/word-count.test.ts
+++ b/apps/docs/tests/word-count.test.ts
@@ -29,4 +29,13 @@ describe('word count CJK rule', () => {
     expect(countWords('第1章：GenOffice 使用指南')).toBe(9)
     // 7 asian chars (incl. the fullwidth colon) + "1" and "GenOffice" as 2 words
   })
+
+  it('counts space-delimited non-Latin scripts as words', () => {
+    expect(nonAsianWordCount('Привет мир')).toBe(2)
+    expect(nonAsianWordCount('Γεια σου')).toBe(2)
+    expect(nonAsianWordCount('שלום עולם')).toBe(2)
+    expect(nonAsianWordCount('مرحبا بالعالم')).toBe(2)
+    expect(countWords('Привет мир')).toBe(2)
+    expect(countWords('Hello Привет')).toBe(2)
+  })
 })

--- a/apps/sheets/tests/csv-import.test.ts
+++ b/apps/sheets/tests/csv-import.test.ts
@@ -103,7 +103,7 @@ describe('parseCsv', () => {
     // The "" escape keeps the field quoted: all five inner ; must not count,
     // or they outvote the two true commas and the columns mis-split.
     expect(sniffDelimiter('a,"; ""; ""; ""; """,d')).toBe(',')
-    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; ""; ""; ""; ""', 'd']])
+    expect(parseCsv('a,"; ""; ""; ""; """,d')).toEqual([['a', '; "; "; "; "', 'd']])
   })
 
   it('drops the trailing empty row from a final newline', () => {

--- a/apps/slides/tests/ai-panel-collapse.test.ts
+++ b/apps/slides/tests/ai-panel-collapse.test.ts
@@ -130,7 +130,9 @@ describe('AiPanel collapse (slides)', () => {
         'textarea[data-slides-ai-input]',
       )
       expect(textarea).not.toBeNull()
-      expect(textarea!.spellcheck).toBe(false)
+      // jsdom does not implement the spellcheck IDL attribute (it always reads
+      // back undefined), so assert on the rendered content attribute instead.
+      expect(textarea!.getAttribute('spellcheck')).toBe('false')
       cleanup()
     } finally {
       applyAiPanelPrefs({ fontSize: 'default', customFontSize: 14, spellcheck: true })


### PR DESCRIPTION
## Summary

- What changed? The non-Asian word pattern in `apps/docs/src/renderer/word-count.ts` was extended with Greek, Cyrillic, Hebrew, Arabic, and Latin Extended Additional ranges, staying clear of the Asian ranges that are counted character by character. Regression cases were added in `apps/docs/tests/word-count.test.ts`.
- Why is this change needed? The pattern only covered Latin, so Russian, Greek, Hebrew, and Arabic words never matched and the word count severely undercounted documents in those languages. Word counts space-delimited scripts as words.

## Related issue

None. Self-identified defect found during review; regression test included.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: the targeted word-count suite was run locally with all tests passing; the full suite runs in CI. This branch also carries the two red-main test corrections from PR 314 because the base revision fails those tests without them; those extra commits will be dropped on rebase once PR 314 lands.

## Screenshots or recordings

Not applicable. No visible changes.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
