### PR TITLE
fix(pdf): validate colors and toggles when decoding text styles

### DIFF
--- a/apps/pdf/src/renderer/color-runs.ts
+++ b/apps/pdf/src/renderer/color-runs.ts
@@ -46,14 +46,16 @@ export function decodeStyle(key: string): CharStyle {
   if (!key) return {}
   const [color = '', font = '', size = '', bold = '', italic = ''] = key.split('|')
   const out: CharStyle = {}
-  if (color) out.color = color
+  if (/^#[0-9a-f]{6}$/i.test(color)) out.color = color
   if (font) out.font = font
   if (size) {
     const n = Number(size)
     if (Number.isFinite(n) && n > 0) out.size = n
   }
-  if (bold) out.bold = bold === '1'
-  if (italic) out.italic = italic === '1'
+  if (bold === '1') out.bold = true
+  else if (bold === '0') out.bold = false
+  if (italic === '1') out.italic = true
+  else if (italic === '0') out.italic = false
   return out
 }
 

--- a/apps/pdf/tests/color-runs.test.ts
+++ b/apps/pdf/tests/color-runs.test.ts
@@ -147,10 +147,23 @@ describe('style keys', () => {
   })
 
   it('ignores non-numeric, non-finite, and non-positive sizes', () => {
-    expect(decodeStyle('x|y|oops||')).toEqual({ color: 'x', font: 'y' })
-    expect(decodeStyle('x|y|Infinity||')).toEqual({ color: 'x', font: 'y' })
-    expect(decodeStyle('x|y|0||')).toEqual({ color: 'x', font: 'y' })
-    expect(decodeStyle('x|y|-3||')).toEqual({ color: 'x', font: 'y' })
-    expect(decodeStyle('x|y|12.5||')).toEqual({ color: 'x', font: 'y', size: 12.5 })
+    expect(decodeStyle('x|y|oops||')).toEqual({ font: 'y' })
+    expect(decodeStyle('x|y|Infinity||')).toEqual({ font: 'y' })
+    expect(decodeStyle('x|y|0||')).toEqual({ font: 'y' })
+    expect(decodeStyle('x|y|-3||')).toEqual({ font: 'y' })
+    expect(decodeStyle('x|y|12.5||')).toEqual({ font: 'y', size: 12.5 })
+  })
+
+  it('ignores non-hex colors and non-0/1 toggles', () => {
+    expect(decodeStyle('#d32f2f|arial|12|1|0')).toEqual({
+      color: '#d32f2f',
+      font: 'arial',
+      size: 12,
+      bold: true,
+      italic: false,
+    })
+    expect(decodeStyle('red|arial|12||')).toEqual({ font: 'arial', size: 12 })
+    expect(decodeStyle('x|a|b|2|x')).toEqual({ font: 'a' })
+    expect(decodeStyle('#d32f2f|a|b|||extra|more')).toEqual({ color: '#d32f2f', font: 'a' })
   })
 })


### PR DESCRIPTION
## Summary

- What changed? `decodeStyle` in `apps/pdf/src/renderer/color-runs.ts` now only accepts hex colors and explicit on or off toggles, leaving anything else to inherit. The size cases from the earlier fix were updated for the stricter color rule and new color and toggle cases were added in `apps/pdf/tests/color-runs.test.ts`.
- Why is this change needed? Any non-empty color text became a style, so corrupt keys decoded to colors that convert to Not-a-Number channels downstream, and any toggle text other than the on value silently became off instead of inheriting the draft value.

## Related issue

None. Self-identified defect found during review; regression tests included.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

List any checks not run and explain why: the targeted color-runs suite was run locally with all tests passing, and the affected cases were verified to fail without the fix; the full suite runs in CI.

## Screenshots or recordings

Not applicable. No visible changes.

## Contributor checklist

- [x] The change is focused and does not include unrelated reformatting or refactoring.
- [x] User-facing strings use the existing i18n resources.
- [x] File open/save changes include an appropriate round-trip or fidelity test.
